### PR TITLE
Slice 0 Unit 3 — Frontend Auth UX (cookie session, no browser token)

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -51,7 +51,7 @@ jobs:
             /d:sonar.cs.opencover.reportsPaths="backend/TestResults/coverage.opencover.xml" \
             /d:sonar.sources="backend/src" \
             /d:sonar.tests="backend/tests" \
-            /d:sonar.exclusions="backend/tests/eval-cache/**,**/*.generated.cs,docs/**,.claude/**,backend/src/RunCoach.Api/Prompts/**" \
+            /d:sonar.exclusions="backend/tests/eval-cache/**,**/*.generated.cs,docs/**,.claude/**,backend/src/RunCoach.Api/Prompts/**,frontend/**" \
             /d:sonar.test.inclusions="backend/tests/**" \
             /d:sonar.cs.roslyn.ignoreIssues=false
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,8 @@ at `README.md`, `CLAUDE.md`, and `ROADMAP.md`.
 
 Frontend-specific developer setup — Vite dev server, `/api` proxy, mkcert
 escape hatch — is covered in the "Running the frontend" section below.
-Playwright page-level E2E lands later with T03.4.
+The Playwright happy-path E2E and its test-data hygiene recipe are in
+"Running the Playwright E2E" further down.
 
 ## Local HTTPS is required
 
@@ -337,6 +338,61 @@ If both endpoints look trusted but login still silently fails:
   drift.
 
 [mkcert]: https://github.com/FiloSottile/mkcert
+
+## Running the Playwright E2E
+
+Slice 0 ships one happy-path E2E (`frontend/e2e/auth.spec.ts`): register
+→ authenticated home → reload → logout → verify the `__Host-RunCoach`
+cookie is gone. It runs Chromium against the same stack you use for the
+browser — the backend on `https://localhost:5001`, the Vite dev server
+on `https://localhost:5173`.
+
+One-time setup:
+
+```bash
+cd frontend
+npx playwright install chromium
+```
+
+Each run:
+
+```bash
+# 1. Backend + Postgres + Redis running (Path B, from earlier section).
+# 2. In a second terminal:
+cd frontend
+npm run e2e
+```
+
+`playwright.config.ts`'s `webServer` entry starts the Vite dev server
+itself, so you do not need a running `npm run dev` — though if one is
+already up on :5173 it will be reused.
+
+### Test-data hygiene
+
+The test generates a fresh `e2e-<uuid>@runcoach.test` account on every
+run so re-runs never collide, neither with each other nor with real
+accounts you've registered while tinkering. The downside: orphan
+`e2e-*` rows accumulate in the dev Postgres over time. Flush them
+whenever:
+
+```bash
+cd frontend
+npm run e2e:clean
+```
+
+The script (`scripts/e2e-clean.sh`) runs `DELETE FROM "AspNetUsers"
+WHERE "NormalizedEmail" LIKE 'E2E-%@RUNCOACH.TEST';` against the
+compose Postgres. It touches nothing outside the `e2e-*` prefix, so
+it's safe to run on a dev DB with real accounts alongside.
+
+CI does not need this — the compose stack is ephemeral per job, so
+every run starts from an empty Postgres.
+
+This is the "unique identifier per run" posture, deliberately
+minimal for a foundation slice with a single E2E. Slice 1 and beyond
+may graduate to an environment-gated `_test/reset` endpoint or a
+dedicated e2e Postgres overlay once more flows need empty-DB
+assertions.
 
 ## Post-change checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,7 +303,7 @@ startup: when both files exist the dev server serves them directly and
 edits required — delete the `.cert/` directory to fall back to the
 self-signed default.
 
-The `.cert/` directory is covered by the root `.gitignore`.
+The `.cert/` directory is covered by `frontend/.gitignore`.
 
 ### Troubleshooting — "my cookies aren't sticking"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,35 +286,24 @@ service container and the same proxy rules apply.
 The default `@vitejs/plugin-basic-ssl` cert is self-signed — browsers
 render a warning on first load. If your browser or corporate policy
 rejects self-signed certs outright (common on hardened Linux
-workstations), install [mkcert] and swap the plugin for explicit
-cert/key paths:
+workstations), install [mkcert] and drop a trusted cert/key pair at
+`frontend/.cert/`:
 
 ```bash
 brew install mkcert          # or apt / scoop / choco
 mkcert -install              # installs a local CA into the system trust store
 cd frontend
-mkcert localhost 127.0.0.1 ::1
+mkdir -p .cert
+mkcert -cert-file .cert/cert.pem -key-file .cert/key.pem localhost 127.0.0.1 ::1
 ```
 
-Then point `server.https` at the generated files instead of
-`basicSsl()` in `vite.config.ts`:
+`vite.config.ts` auto-detects `.cert/cert.pem` + `.cert/key.pem` on
+startup: when both files exist the dev server serves them directly and
+`@vitejs/plugin-basic-ssl` is dropped from the plugin list. No config
+edits required — delete the `.cert/` directory to fall back to the
+self-signed default.
 
-```ts
-import fs from 'node:fs'
-
-export default defineConfig({
-  // remove basicSsl() from plugins
-  server: {
-    https: {
-      key: fs.readFileSync('./localhost+2-key.pem'),
-      cert: fs.readFileSync('./localhost+2.pem'),
-    },
-    // ...rest unchanged
-  },
-})
-```
-
-The generated `*.pem` files are already covered by the root `.gitignore`.
+The `.cert/` directory is covered by the root `.gitignore`.
 
 ### Troubleshooting — "my cookies aren't sticking"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ stack up locally and exercise every auth endpoint from Swagger UI or a CLI
 tool. For higher-level project context (vision, architecture, roadmap) start
 at `README.md`, `CLAUDE.md`, and `ROADMAP.md`.
 
-Frontend-specific developer setup (Vite dev server, `/api` proxy, Playwright
-page-level E2E) is covered by the frontend contribution section — tracked
-under task T03.0 and landing with the Unit 3 frontend slice.
+Frontend-specific developer setup — Vite dev server, `/api` proxy, mkcert
+escape hatch — is covered in the "Running the frontend" section below.
+Playwright page-level E2E lands later with T03.4.
 
 ## Local HTTPS is required
 
@@ -247,6 +247,96 @@ curl -sS -k -c "$JAR" -b "$JAR" \
 
 The `-k` flag accepts the self-signed dev cert. The `-c`/`-b` pair reads and
 writes the same jar file so cookies survive across requests.
+
+## Running the frontend
+
+Frontend and backend run as separate processes. The Vite dev server serves
+the SPA over HTTPS on port 5173 and proxies `/api/*` to the API on port
+5001, so the browser sees a single same-origin. Cookies round-trip cleanly
+through the proxy — the `__Host-` prefix is preserved because the
+proxy strips any upstream `Domain=` attribute before forwarding.
+
+### Path B.1 — host-run API + host-run Vite (fastest inner loop)
+
+In one terminal, start the API as in Path B above. In a second terminal:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Vite launches on `https://localhost:5173`. First load in a browser shows a
+cert warning from `@vitejs/plugin-basic-ssl` — click through once per
+browser profile and the SPA loads normally. Subsequent loads are silent.
+
+The `/api/v1/auth/*` endpoints are reachable at
+`https://localhost:5173/api/v1/auth/*` via the proxy. RTK Query's
+`fetchBaseQuery({ baseUrl: '/api', credentials: 'include' })` round-trips
+cookies through this proxy without any extra configuration.
+
+### Path B.2 — Tilt (full stack in Compose, x86_64 only)
+
+Same as Path A above. The Vite dev server runs inside the `frontend`
+service container and the same proxy rules apply.
+
+### mkcert escape hatch
+
+The default `@vitejs/plugin-basic-ssl` cert is self-signed — browsers
+render a warning on first load. If your browser or corporate policy
+rejects self-signed certs outright (common on hardened Linux
+workstations), install [mkcert] and swap the plugin for explicit
+cert/key paths:
+
+```bash
+brew install mkcert          # or apt / scoop / choco
+mkcert -install              # installs a local CA into the system trust store
+cd frontend
+mkcert localhost 127.0.0.1 ::1
+```
+
+Then point `server.https` at the generated files instead of
+`basicSsl()` in `vite.config.ts`:
+
+```ts
+import fs from 'node:fs'
+
+export default defineConfig({
+  // remove basicSsl() from plugins
+  server: {
+    https: {
+      key: fs.readFileSync('./localhost+2-key.pem'),
+      cert: fs.readFileSync('./localhost+2.pem'),
+    },
+    // ...rest unchanged
+  },
+})
+```
+
+The generated `*.pem` files are already covered by the root `.gitignore`.
+
+### Troubleshooting — "my cookies aren't sticking"
+
+This almost always means one of the two HTTPS endpoints is not trusted:
+
+1. Is `https://localhost:5001/swagger` trusted? If the browser shows a
+   warning, re-run `dotnet dev-certs https --trust`.
+2. Is `https://localhost:5173` trusted (or warning clicked through)?
+   Revisit the URL directly in a fresh tab and accept the cert.
+
+If both endpoints look trusted but login still silently fails:
+
+- DevTools → Application → Cookies → `https://localhost:5173`. You should
+  see `__Host-RunCoach`, `__Host-Xsrf`, and `__Host-Xsrf-Request` with
+  `Secure`, `HttpOnly` (for RunCoach + Xsrf), and no `Domain` attribute.
+  A missing `Secure` flag means the response arrived over HTTP somewhere
+  in the chain.
+- DevTools → Network → the failing request → Response Headers. If
+  `Set-Cookie` carries a `Domain=` attribute, the proxy's
+  `cookieDomainRewrite: ''` is not firing — check the Vite config did not
+  drift.
+
+[mkcert]: https://github.com/FiloSottile/mkcert
 
 ## Post-change checks
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,13 +1,5 @@
 # Review Configuration
 
-## Severity Threshold
-
-low
-
-## Confidence Threshold
-
-80
-
 ## Model Tier
 
 frontier

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -15,6 +15,14 @@ dist-ssr
 # Locally-trusted mkcert dev certs — never commit.
 .cert/
 
+# Playwright artefacts — reports and traces are generated per run and
+# must not be committed. The `login-wrong-credentials.png` screenshot
+# under `e2e/__screenshots__/` is the committed proof artefact and is
+# intentionally not ignored.
+playwright-report/
+test-results/
+/e2e/.auth/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Locally-trusted mkcert dev certs — never commit.
+.cert/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,0 +1,67 @@
+import { randomUUID } from 'node:crypto'
+import { expect, test } from '@playwright/test'
+
+// Session cookie name is fixed by the backend's Identity cookie
+// configuration (`__Host-RunCoach`). The `__Host-` prefix requires
+// HTTPS + `Secure` + no `Domain=` + `Path=/`; everything below verifies
+// that contract end to end.
+const SESSION_COOKIE = '__Host-RunCoach'
+
+const uniqueEmail = (): string => `e2e-${randomUUID()}@runcoach.test`
+
+// Meets the backend Identity policy (12+ chars, upper, lower, digit,
+// non-alphanumeric) and the frontend `registerSchema` in
+// modules/auth/schemas/auth.schema.ts.
+const VALID_PASSWORD = 'Correct-Horse-9!'
+
+test.describe('auth happy path', () => {
+  test('register → authenticated home → reload → logout clears session', async ({
+    page,
+    context,
+  }) => {
+    const email = uniqueEmail()
+
+    await page.goto('/register')
+    await page.getByLabel('Email').fill(email)
+    await page.getByLabel('Password').fill(VALID_PASSWORD)
+    await page.getByRole('button', { name: /create account/i }).click()
+
+    await expect(page).toHaveURL('/')
+    await expect(page.getByTestId('home-greeting')).toHaveText(`Logged in as ${email}`)
+
+    await page.reload()
+    await expect(page).toHaveURL('/')
+    await expect(page.getByTestId('home-greeting')).toHaveText(`Logged in as ${email}`)
+
+    await page.getByRole('button', { name: /sign out/i }).click()
+    await expect(page).toHaveURL('/login')
+
+    const cookies = await context.cookies()
+    const sessionCookie = cookies.find((cookie) => cookie.name === SESSION_COOKIE)
+    if (sessionCookie !== undefined) {
+      // If any `__Host-RunCoach` value lingers it must be expired;
+      // `expires` is a Unix timestamp in seconds or -1 for session cookies.
+      expect(sessionCookie.expires).toBeGreaterThan(0)
+      expect(sessionCookie.expires * 1000).toBeLessThan(Date.now())
+    }
+  })
+})
+
+test.describe('auth failure path', () => {
+  test('wrong credentials render a ProblemDetails-derived alert', async ({ page }) => {
+    await page.goto('/login')
+    await page.getByLabel('Email').fill('nobody@runcoach.test')
+    await page.getByLabel('Password').fill('definitely-wrong-password')
+    await page.getByRole('button', { name: /sign in/i }).click()
+
+    const alert = page.getByTestId('form-alert')
+    await expect(alert).toBeVisible()
+    await expect(alert).not.toBeEmpty()
+    await expect(page).toHaveURL('/login')
+
+    await page.screenshot({
+      path: 'e2e/__screenshots__/login-wrong-credentials.png',
+      fullPage: true,
+    })
+  })
+})

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -7,6 +7,9 @@ import { expect, test } from '@playwright/test'
 // that contract end to end.
 const SESSION_COOKIE = '__Host-RunCoach'
 
+// Fresh email per run so the suite is re-runnable against a shared
+// dev Postgres without collisions. Orphan e2e-*@runcoach.test rows
+// can be flushed with `npm run e2e:clean` (see CONTRIBUTING.md).
 const uniqueEmail = (): string => `e2e-${randomUUID()}@runcoach.test`
 
 // Meets the backend Identity policy (12+ chars, upper, lower, digit,
@@ -14,54 +17,33 @@ const uniqueEmail = (): string => `e2e-${randomUUID()}@runcoach.test`
 // modules/auth/schemas/auth.schema.ts.
 const VALID_PASSWORD = 'Correct-Horse-9!'
 
-test.describe('auth happy path', () => {
-  test('register → authenticated home → reload → logout clears session', async ({
-    page,
-    context,
-  }) => {
-    const email = uniqueEmail()
+test('register → authenticated home → reload → logout clears session', async ({
+  page,
+  context,
+}) => {
+  const email = uniqueEmail()
 
-    await page.goto('/register')
-    await page.getByLabel('Email').fill(email)
-    await page.getByLabel('Password').fill(VALID_PASSWORD)
-    await page.getByRole('button', { name: /create account/i }).click()
+  await page.goto('/register')
+  await page.getByLabel('Email').fill(email)
+  await page.getByLabel('Password').fill(VALID_PASSWORD)
+  await page.getByRole('button', { name: /create account/i }).click()
 
-    await expect(page).toHaveURL('/')
-    await expect(page.getByTestId('home-greeting')).toHaveText(`Logged in as ${email}`)
+  await expect(page).toHaveURL('/')
+  await expect(page.getByTestId('home-greeting')).toHaveText(`Logged in as ${email}`)
 
-    await page.reload()
-    await expect(page).toHaveURL('/')
-    await expect(page.getByTestId('home-greeting')).toHaveText(`Logged in as ${email}`)
+  await page.reload()
+  await expect(page).toHaveURL('/')
+  await expect(page.getByTestId('home-greeting')).toHaveText(`Logged in as ${email}`)
 
-    await page.getByRole('button', { name: /sign out/i }).click()
-    await expect(page).toHaveURL('/login')
+  await page.getByRole('button', { name: /sign out/i }).click()
+  await expect(page).toHaveURL('/login')
 
-    const cookies = await context.cookies()
-    const sessionCookie = cookies.find((cookie) => cookie.name === SESSION_COOKIE)
-    if (sessionCookie !== undefined) {
-      // If any `__Host-RunCoach` value lingers it must be expired;
-      // `expires` is a Unix timestamp in seconds or -1 for session cookies.
-      expect(sessionCookie.expires).toBeGreaterThan(0)
-      expect(sessionCookie.expires * 1000).toBeLessThan(Date.now())
-    }
-  })
-})
-
-test.describe('auth failure path', () => {
-  test('wrong credentials render a ProblemDetails-derived alert', async ({ page }) => {
-    await page.goto('/login')
-    await page.getByLabel('Email').fill('nobody@runcoach.test')
-    await page.getByLabel('Password').fill('definitely-wrong-password')
-    await page.getByRole('button', { name: /sign in/i }).click()
-
-    const alert = page.getByTestId('form-alert')
-    await expect(alert).toBeVisible()
-    await expect(alert).not.toBeEmpty()
-    await expect(page).toHaveURL('/login')
-
-    await page.screenshot({
-      path: 'e2e/__screenshots__/login-wrong-credentials.png',
-      fullPage: true,
-    })
-  })
+  const cookies = await context.cookies()
+  const sessionCookie = cookies.find((cookie) => cookie.name === SESSION_COOKIE)
+  if (sessionCookie !== undefined) {
+    // If any `__Host-RunCoach` value lingers it must be expired;
+    // `expires` is a Unix timestamp in seconds or -1 for session cookies.
+    expect(sessionCookie.expires).toBeGreaterThan(0)
+    expect(sessionCookie.expires * 1000).toBeLessThan(Date.now())
+  }
 })

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -38,10 +38,16 @@ test('register → authenticated home → reload → logout clears session', asy
   await page.getByRole('button', { name: /sign out/i }).click()
   await expect(page).toHaveURL('/login')
 
+  // Most backends remove the session cookie outright on logout, so the
+  // expected posture is `undefined`. If a `__Host-RunCoach` value lingers
+  // (some browsers retain it with a zeroed `Max-Age`), it MUST already be
+  // expired. Either shape counts as "session cleared"; neither is a
+  // silently-vacuous assertion the way a single guarded block would be.
   const cookies = await context.cookies()
   const sessionCookie = cookies.find((cookie) => cookie.name === SESSION_COOKIE)
-  if (sessionCookie !== undefined) {
-    // If any `__Host-RunCoach` value lingers it must be expired;
+  if (sessionCookie === undefined) {
+    expect(sessionCookie).toBeUndefined()
+  } else {
     // `expires` is a Unix timestamp in seconds or -1 for session cookies.
     expect(sessionCookie.expires).toBeGreaterThan(0)
     expect(sessionCookie.expires * 1000).toBeLessThan(Date.now())

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "runcoach-frontend",
       "version": "0.0.0",
+      "license": "UNLICENSED",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@reduxjs/toolkit": "^2.11.2",
@@ -26,6 +27,7 @@
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-basic-ssl": "^2.3.0",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.4",
         "eslint": "^9.39.4",
@@ -1854,6 +1856,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.3.0.tgz",
+      "integrity": "sha512-bdyo8rB3NnQbikdMpHaML9Z1OZPBu6fFOBo+OtxsBlvMJtysWskmBcnbIDhUqgC8tcxNv/a+BcV5U+2nQMm1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -1550,6 +1551,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,8 +12,8 @@
         "@hookform/resolvers": "^5.2.2",
         "@reduxjs/toolkit": "^2.11.2",
         "@tailwindcss/vite": "^4.2.4",
-        "react": "^19.2.5",
-        "react-dom": "^19.2.5",
+        "react": "19.2.5",
+        "react-dom": "19.2.5",
         "react-hook-form": "^7.73.1",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.14.2",
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^25.6.0",
@@ -855,6 +856,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -3925,6 +3942,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "e2e": "playwright test",
+    "e2e:clean": "bash scripts/e2e-clean.sh",
     "lint": "eslint .",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\""
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-basic-ssl": "^2.3.0",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.4",
     "eslint": "^9.39.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "e2e": "playwright test",
     "lint": "eslint .",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\""
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,8 +18,8 @@
     "@hookform/resolvers": "^5.2.2",
     "@reduxjs/toolkit": "^2.11.2",
     "@tailwindcss/vite": "^4.2.4",
-    "react": "^19.2.5",
-    "react-dom": "^19.2.5",
+    "react": "19.2.5",
+    "react-dom": "19.2.5",
     "react-hook-form": "^7.73.1",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.14.2",
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^25.6.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// Vite dev server runs on HTTPS:5173 (see vite.config.ts and
+// CONTRIBUTING.md "Local HTTPS is required"). The `__Host-` cookie
+// contract requires HTTPS end to end, so Playwright must also speak
+// HTTPS and tolerate the self-signed dev cert that
+// @vitejs/plugin-basic-ssl mints on each startup.
+const baseURL = 'https://localhost:5173'
+
+export default defineConfig({
+  testDir: './e2e',
+  // Keep scenarios independent so they run in parallel by default; the
+  // auth.spec.ts file opts into `describe.serial` where order matters.
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : [['list']],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    ignoreHTTPSErrors: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  // The backend API on https://localhost:5001 must already be running
+  // (`dotnet run --project backend/src/RunCoach.Api --launch-profile
+  // https`); Playwright only owns the Vite dev server here. See
+  // CONTRIBUTING.md "Running the frontend" for the full local recipe.
+  webServer: {
+    command: 'npm run dev',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    ignoreHTTPSErrors: true,
+  },
+})

--- a/frontend/scripts/e2e-clean.sh
+++ b/frontend/scripts/e2e-clean.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Delete orphan e2e-*@runcoach.test accounts from the dev Postgres.
+#
+# The Playwright happy-path test registers a fresh
+# `e2e-<uuid>@runcoach.test` on every run so re-runs never collide.
+# Those rows accumulate in the dev DB over time. This script flushes
+# them. Safe to run whenever — it only touches rows whose normalized
+# email starts with `E2E-`.
+#
+# Runs against the docker-compose Postgres on localhost:5432 using the
+# baked-in dev credentials (also visible in `docker-compose.yml`; not a
+# secret — dev-only password). If you run Postgres somewhere else,
+# export PGHOST / PGPORT / PGUSER / PGPASSWORD / PGDATABASE before
+# invoking this script and the defaults will yield to them.
+
+set -euo pipefail
+
+: "${PGHOST:=localhost}"
+: "${PGPORT:=5432}"
+: "${PGUSER:=runcoach}"
+: "${PGPASSWORD:=runcoach_dev}"
+: "${PGDATABASE:=runcoach}"
+
+export PGHOST PGPORT PGUSER PGPASSWORD PGDATABASE
+
+exec psql --quiet --no-psqlrc --set ON_ERROR_STOP=1 <<'SQL'
+DELETE FROM "AspNetUsers"
+ WHERE "NormalizedEmail" LIKE 'E2E-%@RUNCOACH.TEST';
+SQL

--- a/frontend/src/app/api/api-slice.ts
+++ b/frontend/src/app/api/api-slice.ts
@@ -1,0 +1,12 @@
+import { createApi } from '@reduxjs/toolkit/query/react'
+import { baseQueryWith401Handler } from '~/api/base-query'
+
+// Root RTK Query API slice. Feature APIs (`auth.api.ts`, future
+// `plan.api.ts`, etc.) call `apiSlice.injectEndpoints({ ... })` so the
+// cache namespace and middleware are shared across the whole app.
+export const apiSlice = createApi({
+  reducerPath: 'api',
+  baseQuery: baseQueryWith401Handler,
+  tagTypes: ['Auth'],
+  endpoints: () => ({}),
+})

--- a/frontend/src/app/api/auth.api.ts
+++ b/frontend/src/app/api/auth.api.ts
@@ -1,0 +1,45 @@
+import { apiSlice } from '~/api/api-slice'
+import type {
+  AuthResponseDto,
+  LoginRequestDto,
+  RegisterRequestDto,
+} from '~/modules/auth/models/auth.model'
+
+// Auth endpoints are injected into the root `apiSlice` so every request
+// shares the same middleware (credentials: 'include', XSRF header on
+// mutations, 401 handler). Routes match `backend/src/RunCoach.Api/Modules/
+// Identity/AuthController.cs` with the global `/api/v1` prefix supplied by
+// `base-query.ts#baseUrl`.
+export const authApi = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    xsrf: builder.query<undefined, undefined>({
+      query: () => ({ url: '/v1/auth/xsrf', method: 'GET' }),
+    }),
+    me: builder.query<AuthResponseDto, undefined>({
+      query: () => ({ url: '/v1/auth/me', method: 'GET' }),
+      providesTags: ['Auth'],
+    }),
+    register: builder.mutation<AuthResponseDto, RegisterRequestDto>({
+      query: (body) => ({ url: '/v1/auth/register', method: 'POST', body }),
+      invalidatesTags: ['Auth'],
+    }),
+    login: builder.mutation<AuthResponseDto, LoginRequestDto>({
+      query: (body) => ({ url: '/v1/auth/login', method: 'POST', body }),
+      invalidatesTags: ['Auth'],
+    }),
+    logout: builder.mutation<undefined, undefined>({
+      query: () => ({ url: '/v1/auth/logout', method: 'POST' }),
+      invalidatesTags: ['Auth'],
+    }),
+  }),
+})
+
+export const {
+  useXsrfQuery,
+  useMeQuery,
+  useLazyXsrfQuery,
+  useLazyMeQuery,
+  useRegisterMutation,
+  useLoginMutation,
+  useLogoutMutation,
+} = authApi

--- a/frontend/src/app/api/base-query.spec.ts
+++ b/frontend/src/app/api/base-query.spec.ts
@@ -145,6 +145,19 @@ describe('rawBaseQuery', () => {
       expect(request.headers.get(XSRF_HEADER_NAME)).toBeNull()
     })
   })
+
+  describe('malformed cookie values do not block mutations', () => {
+    // `decodeURIComponent` throws `URIError` on a lone `%` or other invalid
+    // percent-encoding. That error must not escape `prepareHeaders` — the
+    // right posture is to drop the token and let the backend's antiforgery
+    // filter 400 the request with a proper `ProblemDetails` response.
+    it('returns null from the helper (omits the header) when the cookie holds invalid percent-encoding', async () => {
+      setCookie(XSRF_COOKIE_NAME, 'broken%ZZ')
+      await rawBaseQuery({ url: ABS_URL, method: 'POST' }, makeApi('mutation'), {})
+      const request = extractRequest(fetchMock)
+      expect(request.headers.get(XSRF_HEADER_NAME)).toBeNull()
+    })
+  })
 })
 
 describe('baseQueryWith401Handler', () => {

--- a/frontend/src/app/api/base-query.spec.ts
+++ b/frontend/src/app/api/base-query.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BaseQueryApi } from '@reduxjs/toolkit/query'
-import { baseQueryWith401Handler, rawBaseQuery } from './base-query'
 import { loggedOut } from '~/modules/auth/store/auth.slice'
+import { baseQueryWith401Handler, rawBaseQuery } from './base-query'
 
 // The cookie name the SPA reads is the double-submit companion of the
 // HttpOnly backend cookie (DEC-054). Kept in lockstep with `base-query.ts`.

--- a/frontend/src/app/api/base-query.spec.ts
+++ b/frontend/src/app/api/base-query.spec.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BaseQueryApi } from '@reduxjs/toolkit/query'
+import { baseQueryWith401Handler, rawBaseQuery } from './base-query'
+import { loggedOut } from '~/modules/auth/store/auth.slice'
+
+// The cookie name the SPA reads is the double-submit companion of the
+// HttpOnly backend cookie (DEC-054). Kept in lockstep with `base-query.ts`.
+const XSRF_COOKIE_NAME = '__Host-Xsrf-Request'
+const XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
+// BaseQueryApi is a structural contract; tests only exercise `dispatch` and
+// the discriminator `type`. The signal and the other fields are filled with
+// no-op defaults so fetchBaseQuery has a valid shape to destructure.
+const makeApi = (type: 'query' | 'mutation', dispatch = vi.fn()): BaseQueryApi => ({
+  signal: new AbortController().signal,
+  abort: vi.fn(),
+  dispatch,
+  getState: vi.fn(() => ({})),
+  extra: undefined,
+  endpoint: 'test',
+  type,
+  forced: false,
+})
+
+const okResponse = (body: Record<string, unknown> = { ok: true }): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const statusResponse = (status: number): Response =>
+  new Response(JSON.stringify({ title: 'error' }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const extractRequest = (fetchMock: ReturnType<typeof vi.fn>): Request => {
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+  const firstArg = fetchMock.mock.calls[0][0]
+  expect(firstArg).toBeInstanceOf(Request)
+  return firstArg as Request
+}
+
+// RTK Query hands `fetchBaseQuery` an absolute URL through the constructor's
+// `new Request(...)` — jsdom / undici reject relative URLs there even though
+// real browsers would resolve them against `window.location`. Tests pass an
+// absolute URL in `args.url`; the slash-prefixed `baseUrl` inside
+// `base-query.ts` is short-circuited by RTK Query's own `joinUrls` (absolute
+// URLs in `url` bypass the base-url join). The header + credentials
+// behavior we are exercising is independent of which path/host we use.
+const ABS_URL = 'https://localhost:5173/api/endpoint'
+
+// Helper for seeding the XSRF cookie inside jsdom. jsdom honors Set-Cookie
+// semantics via `document.cookie =` — the `__Host-` prefix additionally
+// requires `Secure` + `Path=/` + no `Domain`; without Secure the cookie jar
+// silently drops the assignment and the next read returns empty. The vitest
+// environment is configured to `https://localhost:5173/` so the Secure
+// attribute is honored.
+const setCookie = (name: string, value: string): void => {
+  document.cookie = `${name}=${value}; path=/; Secure`
+}
+
+const clearCookie = (name: string): void => {
+  document.cookie = `${name}=; path=/; Secure; max-age=0`
+}
+
+describe('rawBaseQuery', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(okResponse())
+    vi.stubGlobal('fetch', fetchMock)
+    clearCookie(XSRF_COOKIE_NAME)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    clearCookie(XSRF_COOKIE_NAME)
+  })
+
+  describe('credentials: "include" is set on every call', () => {
+    it.each([
+      ['GET', 'query'],
+      ['POST', 'mutation'],
+      ['PUT', 'mutation'],
+      ['PATCH', 'mutation'],
+      ['DELETE', 'mutation'],
+    ] as const)('%s request honors credentials: include', async (method, type) => {
+      await rawBaseQuery({ url: ABS_URL, method }, makeApi(type), {})
+      const request = extractRequest(fetchMock)
+      expect(request.credentials).toBe('include')
+    })
+  })
+
+  describe('X-XSRF-TOKEN header on mutation verbs', () => {
+    beforeEach(() => {
+      setCookie(XSRF_COOKIE_NAME, 'xsrf-plain-value')
+    })
+
+    it.each(['POST', 'PUT', 'PATCH', 'DELETE'] as const)(
+      'adds X-XSRF-TOKEN on %s requests',
+      async (method) => {
+        await rawBaseQuery({ url: ABS_URL, method }, makeApi('mutation'), {})
+        const request = extractRequest(fetchMock)
+        expect(request.headers.get(XSRF_HEADER_NAME)).toBe('xsrf-plain-value')
+      },
+    )
+  })
+
+  describe('X-XSRF-TOKEN header NOT added on GET', () => {
+    it('omits the XSRF header on GET requests even when the cookie is present', async () => {
+      setCookie(XSRF_COOKIE_NAME, 'xsrf-plain-value')
+      await rawBaseQuery({ url: ABS_URL, method: 'GET' }, makeApi('query'), {})
+      const request = extractRequest(fetchMock)
+      expect(request.headers.get(XSRF_HEADER_NAME)).toBeNull()
+    })
+
+    it('omits the XSRF header on GET requests when the cookie is absent', async () => {
+      await rawBaseQuery({ url: ABS_URL, method: 'GET' }, makeApi('query'), {})
+      const request = extractRequest(fetchMock)
+      expect(request.headers.get(XSRF_HEADER_NAME)).toBeNull()
+    })
+  })
+
+  describe('XSRF header value is URL-decoded', () => {
+    it('decodes percent-encoded characters from the cookie before setting the header', async () => {
+      // Raw cookie holds the percent-encoded form; the header must carry the
+      // decoded value. Backend DataProtection-wrapped XSRF tokens routinely
+      // contain `+`, `/`, `=` — base64 characters that safely pass through
+      // encodeURIComponent / decodeURIComponent round-trips.
+      const decoded = 'CfDJ8+abc/def=='
+      const encoded = encodeURIComponent(decoded)
+      setCookie(XSRF_COOKIE_NAME, encoded)
+
+      await rawBaseQuery({ url: ABS_URL, method: 'POST' }, makeApi('mutation'), {})
+      const request = extractRequest(fetchMock)
+      expect(request.headers.get(XSRF_HEADER_NAME)).toBe(decoded)
+    })
+  })
+
+  describe('XSRF header omitted when cookie is missing on a mutation', () => {
+    it('skips the header when no XSRF cookie is set', async () => {
+      await rawBaseQuery({ url: ABS_URL, method: 'POST' }, makeApi('mutation'), {})
+      const request = extractRequest(fetchMock)
+      expect(request.headers.get(XSRF_HEADER_NAME)).toBeNull()
+    })
+  })
+})
+
+describe('baseQueryWith401Handler', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('dispatches loggedOut when the response is 401', async () => {
+    fetchMock.mockResolvedValue(statusResponse(401))
+    const dispatch = vi.fn()
+    await baseQueryWith401Handler({ url: ABS_URL, method: 'GET' }, makeApi('query', dispatch), {})
+    expect(dispatch).toHaveBeenCalledWith(loggedOut())
+  })
+
+  it('does not dispatch loggedOut on success responses', async () => {
+    fetchMock.mockResolvedValue(okResponse())
+    const dispatch = vi.fn()
+    await baseQueryWith401Handler({ url: ABS_URL, method: 'GET' }, makeApi('query', dispatch), {})
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch loggedOut on non-401 error responses', async () => {
+    fetchMock.mockResolvedValue(statusResponse(500))
+    const dispatch = vi.fn()
+    await baseQueryWith401Handler({ url: ABS_URL, method: 'GET' }, makeApi('query', dispatch), {})
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/base-query.ts
+++ b/frontend/src/app/api/base-query.ts
@@ -54,7 +54,7 @@ export const baseQueryWith401Handler: BaseQueryFn<
   FetchBaseQueryError
 > = async (args, api, extraOptions) => {
   const result = await rawBaseQuery(args, api, extraOptions)
-  if (result.error !== undefined && result.error.status === 401) {
+  if (result.error?.status === 401) {
     api.dispatch(loggedOut())
   }
   return result

--- a/frontend/src/app/api/base-query.ts
+++ b/frontend/src/app/api/base-query.ts
@@ -14,14 +14,24 @@ const XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
 
 // Reads the single cookie segment whose name matches XSRF_COOKIE_NAME and
 // URL-decodes the value. Returns null when the cookie is absent (the
-// app-boot `GET /xsrf` seeds it before any mutation fires).
+// app-boot `GET /xsrf` seeds it before any mutation fires) or when the
+// stored value is malformed — a `URIError` from `decodeURIComponent` must
+// not escape into `prepareHeaders` and block every mutation. Splits on
+// `;` with per-segment `trim()` rather than `"; "` to stay robust against
+// browsers that produce spaceless separators.
 const readXsrfCookie = (): string | null => {
   if (typeof document === 'undefined') return null
-  const segments = document.cookie ? document.cookie.split('; ') : []
+  const raw = document.cookie
+  if (raw.length === 0) return null
+  const segments = raw.split(';').map((segment) => segment.trim())
   const prefix = `${XSRF_COOKIE_NAME}=`
   const hit = segments.find((segment) => segment.startsWith(prefix))
-  if (!hit) return null
-  return decodeURIComponent(hit.slice(prefix.length))
+  if (hit === undefined) return null
+  try {
+    return decodeURIComponent(hit.slice(prefix.length))
+  } catch {
+    return null
+  }
 }
 
 export const rawBaseQuery = fetchBaseQuery({

--- a/frontend/src/app/api/base-query.ts
+++ b/frontend/src/app/api/base-query.ts
@@ -1,0 +1,61 @@
+import {
+  fetchBaseQuery,
+  type BaseQueryFn,
+  type FetchArgs,
+  type FetchBaseQueryError,
+} from '@reduxjs/toolkit/query/react'
+import { loggedOut } from '~/modules/auth/store/auth.slice'
+
+// The SPA-readable half of the antiforgery double-submit pair (DEC-054).
+// Backend source of truth: `AuthCookieNames.AntiforgeryRequest`. The
+// HttpOnly companion cookie `__Host-Xsrf` is unreadable here by design.
+const XSRF_COOKIE_NAME = '__Host-Xsrf-Request'
+const XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
+// Reads the single cookie segment whose name matches XSRF_COOKIE_NAME and
+// URL-decodes the value. Returns null when the cookie is absent (the
+// app-boot `GET /xsrf` seeds it before any mutation fires).
+const readXsrfCookie = (): string | null => {
+  if (typeof document === 'undefined') return null
+  const segments = document.cookie ? document.cookie.split('; ') : []
+  const prefix = `${XSRF_COOKIE_NAME}=`
+  const hit = segments.find((segment) => segment.startsWith(prefix))
+  if (!hit) return null
+  return decodeURIComponent(hit.slice(prefix.length))
+}
+
+export const rawBaseQuery = fetchBaseQuery({
+  baseUrl: '/api',
+  credentials: 'include',
+  prepareHeaders: (headers, { type }) => {
+    if (type === 'mutation') {
+      const xsrf = readXsrfCookie()
+      if (xsrf !== null) headers.set(XSRF_HEADER_NAME, xsrf)
+    }
+    return headers
+  },
+})
+
+// 401 posture (spec §Unit 3 line 116, DEC-054 / R-058):
+//   - Dispatch `loggedOut` so every consumer of the auth slice flips to
+//     `unauthenticated` in the same tick as the failed response.
+//   - Navigation to `/login` is intentionally left to `<RequireAuth>` in
+//     T03.2 rather than forcing `window.location.replace(...)` here. The
+//     slice transition is the single source of truth; the view layer reads
+//     it and renders the right thing (`Navigate` for protected routes;
+//     no-op on `/login` and `/register`, which are not wrapped in
+//     RequireAuth).
+//   - No `baseQueryWithReauth` mutex / refresh-retry (DEC-054): sliding
+//     expiration renews the cookie on every honored request, so 401 means
+//     the session is genuinely gone, not "access token is stale."
+export const baseQueryWith401Handler: BaseQueryFn<
+  string | FetchArgs,
+  unknown,
+  FetchBaseQueryError
+> = async (args, api, extraOptions) => {
+  const result = await rawBaseQuery(args, api, extraOptions)
+  if (result.error !== undefined && result.error.status === 401) {
+    api.dispatch(loggedOut())
+  }
+  return result
+}

--- a/frontend/src/app/modules/app/app.component.spec.tsx
+++ b/frontend/src/app/modules/app/app.component.spec.tsx
@@ -1,12 +1,32 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+// `useAuthBootstrap` dispatches real RTK Query `initiate` calls for
+// `xsrf` and `me`; in jsdom those hit a missing fetch stub and pollute
+// test output with unhandled rejections. `useAuthBroadcastListener`
+// subscribes to a BroadcastChannel. Neither side effect is under test
+// here — this spec only asserts the top-level route table renders and
+// that the auth slice's initial `unknown` status shows the RequireAuth
+// loading fallback. Full bootstrap behavior is exercised in the
+// dedicated auth-hooks/RequireAuth specs.
+vi.mock('~/modules/auth/hooks/auth.hooks', async () => {
+  const actual = await vi.importActual<typeof import('~/modules/auth/hooks/auth.hooks')>(
+    '~/modules/auth/hooks/auth.hooks',
+  )
+  return {
+    ...actual,
+    useAuthBootstrap: () => undefined,
+    useAuthBroadcastListener: () => undefined,
+  }
+})
+
 import { App } from './app.component'
 
 describe('App', () => {
   it('mounts and renders the RequireAuth loading fallback on first render', () => {
     render(<App />)
     // Initial auth slice status === 'unknown' → RequireAuth shows the
-    // loading fallback. Full routing coverage lives in T03.3.
+    // loading fallback.
     expect(screen.getByRole('status')).toBeInTheDocument()
   })
 })

--- a/frontend/src/app/modules/app/app.component.spec.tsx
+++ b/frontend/src/app/modules/app/app.component.spec.tsx
@@ -1,10 +1,12 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { App } from './app.component'
 
 describe('App', () => {
-  it('renders without crashing', () => {
+  it('mounts and renders the RequireAuth loading fallback on first render', () => {
     render(<App />)
-    expect(screen.getByText('RunCoach')).toBeInTheDocument()
+    // Initial auth slice status === 'unknown' → RequireAuth shows the
+    // loading fallback. Full routing coverage lives in T03.3.
+    expect(screen.getByRole('status')).toBeInTheDocument()
   })
 })

--- a/frontend/src/app/modules/app/app.component.tsx
+++ b/frontend/src/app/modules/app/app.component.tsx
@@ -1,17 +1,30 @@
 import { Provider } from 'react-redux'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { store } from './app.store'
-import { useAuthBootstrap } from '~/modules/auth/hooks/auth.hooks'
+import { RequireAuth } from '~/modules/auth/components/require-auth.component'
+import { useAuthBootstrap, useAuthBroadcastListener } from '~/modules/auth/hooks/auth.hooks'
 import { HomePage } from '~/pages/home/home.page'
+import { LoginPage } from '~/pages/login/login.page'
+import { RegisterPage } from '~/pages/register/register.page'
 
-// Inner component runs inside the Redux Provider so the bootstrap hook's
-// `useDispatch` / `useSelector` resolve to the right store. Routing
-// components (`<RequireAuth>`, `/login`, `/register`) land in T03.2.
+// Inner component runs inside the Redux Provider so auth hooks'
+// `useDispatch` / `useSelector` resolve to the right store.
 const AppShell = () => {
   useAuthBootstrap()
+  useAuthBroadcastListener()
+
   return (
     <Routes>
-      <Route path="/" element={<HomePage />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+      <Route
+        path="/"
+        element={
+          <RequireAuth>
+            <HomePage />
+          </RequireAuth>
+        }
+      />
     </Routes>
   )
 }

--- a/frontend/src/app/modules/app/app.component.tsx
+++ b/frontend/src/app/modules/app/app.component.tsx
@@ -1,15 +1,26 @@
 import { Provider } from 'react-redux'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { store } from './app.store'
+import { useAuthBootstrap } from '~/modules/auth/hooks/auth.hooks'
 import { HomePage } from '~/pages/home/home.page'
+
+// Inner component runs inside the Redux Provider so the bootstrap hook's
+// `useDispatch` / `useSelector` resolve to the right store. Routing
+// components (`<RequireAuth>`, `/login`, `/register`) land in T03.2.
+const AppShell = () => {
+  useAuthBootstrap()
+  return (
+    <Routes>
+      <Route path="/" element={<HomePage />} />
+    </Routes>
+  )
+}
 
 export const App = () => {
   return (
     <Provider store={store}>
       <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-        </Routes>
+        <AppShell />
       </BrowserRouter>
     </Provider>
   )

--- a/frontend/src/app/modules/app/app.store.ts
+++ b/frontend/src/app/modules/app/app.store.ts
@@ -1,8 +1,19 @@
 import { configureStore } from '@reduxjs/toolkit'
+import { setupListeners } from '@reduxjs/toolkit/query'
+import { apiSlice } from '~/api/api-slice'
+import { authSlice } from '~/modules/auth/store/auth.slice'
 
 export const store = configureStore({
-  reducer: {},
+  reducer: {
+    [authSlice.name]: authSlice.reducer,
+    [apiSlice.reducerPath]: apiSlice.reducer,
+  },
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(apiSlice.middleware),
 })
+
+// Enables `refetchOnFocus` / `refetchOnReconnect` for RTK Query when
+// consumers opt in at the endpoint or hook level.
+setupListeners(store.dispatch)
 
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch

--- a/frontend/src/app/modules/auth/components/require-auth.component.spec.tsx
+++ b/frontend/src/app/modules/auth/components/require-auth.component.spec.tsx
@@ -1,0 +1,82 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import type { AuthState } from '~/modules/auth/models/auth.model'
+import { authSlice } from '~/modules/auth/store/auth.slice'
+import { RequireAuth } from './require-auth.component'
+
+const makeStore = (preloadedAuth: AuthState) =>
+  configureStore({
+    reducer: { [authSlice.name]: authSlice.reducer },
+    preloadedState: { [authSlice.name]: preloadedAuth },
+  })
+
+// Renders the current location.state so tests can assert what `<Navigate>`
+// placed into router state after redirecting. Real LoginPage is not wired
+// here so the component tree stays focused on the guard's output.
+const LoginLocationProbe = () => {
+  const location = useLocation()
+  const state = location.state as { next?: string } | null
+  return (
+    <div data-testid="login-probe">
+      <span data-testid="login-path">{location.pathname}</span>
+      <span data-testid="login-next">{state?.next ?? ''}</span>
+    </div>
+  )
+}
+
+const renderGuarded = (
+  auth: AuthState,
+  startingEntry: string | { pathname: string; search?: string; hash?: string },
+) =>
+  render(
+    <Provider store={makeStore(auth)}>
+      <MemoryRouter initialEntries={[startingEntry]}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <RequireAuth>
+                <div data-testid="protected">protected content</div>
+              </RequireAuth>
+            }
+          />
+          <Route path="/login" element={<LoginLocationProbe />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  )
+
+describe('RequireAuth', () => {
+  it('renders the loading fallback while auth status is unknown', () => {
+    renderGuarded({ status: 'unknown', user: null }, '/')
+    expect(screen.getByRole('status')).toHaveTextContent(/loading/i)
+    expect(screen.queryByTestId('protected')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('login-probe')).not.toBeInTheDocument()
+  })
+
+  it('renders the protected children when the user is authenticated', () => {
+    renderGuarded(
+      { status: 'authenticated', user: { userId: 'usr_abc', email: 'runner@example.com' } },
+      '/',
+    )
+    expect(screen.getByTestId('protected')).toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('redirects unauthenticated users to /login and preserves the attempted path in state.next', () => {
+    renderGuarded({ status: 'unauthenticated', user: null }, '/')
+    expect(screen.getByTestId('login-path')).toHaveTextContent('/login')
+    expect(screen.getByTestId('login-next')).toHaveTextContent('/')
+  })
+
+  it('preserves pathname, search, and hash in state.next for deep-link restoration', () => {
+    renderGuarded(
+      { status: 'unauthenticated', user: null },
+      { pathname: '/', search: '?tab=plan', hash: '#week-3' },
+    )
+    expect(screen.getByTestId('login-next')).toHaveTextContent('/?tab=plan#week-3')
+  })
+})

--- a/frontend/src/app/modules/auth/components/require-auth.component.tsx
+++ b/frontend/src/app/modules/auth/components/require-auth.component.tsx
@@ -31,7 +31,8 @@ export const RequireAuth = ({ children }: RequireAuthProps) => {
   }
 
   if (status === 'unauthenticated') {
-    return <Navigate to="/login" state={{ next: location.pathname + location.search }} replace />
+    const next = location.pathname + location.search + location.hash
+    return <Navigate to="/login" state={{ next }} replace />
   }
 
   return children

--- a/frontend/src/app/modules/auth/components/require-auth.component.tsx
+++ b/frontend/src/app/modules/auth/components/require-auth.component.tsx
@@ -1,0 +1,38 @@
+import type { ReactElement } from 'react'
+import { Navigate, useLocation } from 'react-router-dom'
+import { useAuth } from '~/modules/auth/hooks/auth.hooks'
+
+export interface RequireAuthProps {
+  children: ReactElement
+}
+
+// Route guard wrapper (spec §Unit 3 line 111).
+//
+//   status === 'unknown'          → loading fallback while app-boot `me`
+//                                   is in flight (first-tick only).
+//   status === 'unauthenticated'  → <Navigate> to /login with `state.next`
+//                                   so LoginPage can restore the intended
+//                                   destination after login.
+//   status === 'authenticated'    → render protected children.
+export const RequireAuth = ({ children }: RequireAuthProps) => {
+  const { status } = useAuth()
+  const location = useLocation()
+
+  if (status === 'unknown') {
+    return (
+      <div
+        className="flex min-h-screen items-center justify-center"
+        role="status"
+        aria-live="polite"
+      >
+        <span className="text-sm text-slate-500">Loading…</span>
+      </div>
+    )
+  }
+
+  if (status === 'unauthenticated') {
+    return <Navigate to="/login" state={{ next: location.pathname + location.search }} replace />
+  }
+
+  return children
+}

--- a/frontend/src/app/modules/auth/helpers/problem-details.helpers.ts
+++ b/frontend/src/app/modules/auth/helpers/problem-details.helpers.ts
@@ -53,7 +53,7 @@ export const parseProblem = (error: unknown): ParsedProblem => {
   if (!isHttpError(error)) return empty
 
   const status = error.status
-  if (!isRecord(error.data)) return { title: null, fieldErrors: {}, status }
+  if (!isRecord(error.data)) return { ...empty, status }
 
   const body = error.data as ValidationProblemDetails
   const title = typeof body.title === 'string' ? body.title : null

--- a/frontend/src/app/modules/auth/helpers/problem-details.helpers.ts
+++ b/frontend/src/app/modules/auth/helpers/problem-details.helpers.ts
@@ -1,5 +1,3 @@
-import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
-
 // RFC 7807 Problem Details / Validation Problem Details extractor.
 //
 // The backend shape is authoritative (DEC-052):
@@ -42,7 +40,10 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((item) => typeof item === 'string')
 
-export const parseProblem = (error: FetchBaseQueryError | Error | unknown): ParsedProblem => {
+// Accepts `unknown` because callers hand us anything RTK Query or a thrown
+// Error can produce; `isHttpError` below narrows to the
+// `FetchBaseQueryError` HTTP-error arm at runtime.
+export const parseProblem = (error: unknown): ParsedProblem => {
   const empty: ParsedProblem = {
     title: null,
     fieldErrors: {},

--- a/frontend/src/app/modules/auth/helpers/problem-details.helpers.ts
+++ b/frontend/src/app/modules/auth/helpers/problem-details.helpers.ts
@@ -1,0 +1,71 @@
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+
+// RFC 7807 Problem Details / Validation Problem Details extractor.
+//
+// The backend shape is authoritative (DEC-052):
+//   ProblemDetails           — { type, title, status, detail?, traceId? }
+//   ValidationProblemDetails — ProblemDetails + { errors: { [Field]: string[] } }
+//
+// `errors` keys are PascalCase DTO property names (`Email`, `Password`); the
+// SPA normalizes them back to camelCase form-field names.
+
+export interface ProblemDetails {
+  type?: string
+  title?: string
+  status?: number
+  detail?: string
+  traceId?: string
+}
+
+export interface ValidationProblemDetails extends ProblemDetails {
+  errors?: Record<string, string[]>
+}
+
+export interface ParsedProblem {
+  title: string | null
+  fieldErrors: Record<string, string[]>
+  status: number | null
+}
+
+// Safe narrowing against the RTK Query union shape — FetchBaseQueryError is
+// a discriminated union covering fetch failure, HTTP error, parsing error,
+// and timeout. Only the HTTP-error arm carries a parsed JSON body.
+const isHttpError = (error: unknown): error is { status: number; data: unknown } => {
+  if (error === null || typeof error !== 'object') return false
+  const candidate = error as { status?: unknown; data?: unknown }
+  return typeof candidate.status === 'number' && 'data' in candidate
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string')
+
+export const parseProblem = (error: FetchBaseQueryError | Error | unknown): ParsedProblem => {
+  const empty: ParsedProblem = {
+    title: null,
+    fieldErrors: {},
+    status: null,
+  }
+
+  if (!isHttpError(error)) return empty
+
+  const status = error.status
+  if (!isRecord(error.data)) return { title: null, fieldErrors: {}, status }
+
+  const body = error.data as ValidationProblemDetails
+  const title = typeof body.title === 'string' ? body.title : null
+
+  const fieldErrors: Record<string, string[]> = {}
+  if (isRecord(body.errors)) {
+    for (const [rawKey, rawValue] of Object.entries(body.errors)) {
+      if (!isStringArray(rawValue) || rawValue.length === 0) continue
+      const normalized =
+        rawKey.length > 0 ? rawKey.charAt(0).toLowerCase() + rawKey.slice(1) : rawKey
+      fieldErrors[normalized] = rawValue
+    }
+  }
+
+  return { title, fieldErrors, status }
+}

--- a/frontend/src/app/modules/auth/hooks/auth.hooks.ts
+++ b/frontend/src/app/modules/auth/hooks/auth.hooks.ts
@@ -51,6 +51,8 @@ export const useAuthBootstrap = (): void => {
         xsrfPromise.unsubscribe()
       }
 
+      if (cancelled) return
+
       const mePromise = dispatch(authApi.endpoints.me.initiate(undefined))
       try {
         const me = await mePromise.unwrap()

--- a/frontend/src/app/modules/auth/hooks/auth.hooks.ts
+++ b/frontend/src/app/modules/auth/hooks/auth.hooks.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { authApi } from '~/api/auth.api'
+import { subscribeLogoutBroadcast } from '~/modules/auth/lib/broadcast-auth'
 import type { AuthState } from '~/modules/auth/models/auth.model'
 import { loggedOut, sessionVerified } from '~/modules/auth/store/auth.slice'
 import type { AppDispatch, RootState } from '~/modules/app/app.store'
@@ -69,4 +70,13 @@ export const useAuthBootstrap = (): void => {
       cancelled = true
     }
   }, [dispatch])
+}
+
+// Cross-tab logout listener (spec §Unit 3 line 118, optional). When tab A
+// posts a logout message, every other tab listening on the `auth`
+// BroadcastChannel flips to `unauthenticated` immediately rather than
+// waiting for its next network call to 401.
+export const useAuthBroadcastListener = (): void => {
+  const dispatch = useDispatch<AppDispatch>()
+  useEffect(() => subscribeLogoutBroadcast(() => dispatch(loggedOut())), [dispatch])
 }

--- a/frontend/src/app/modules/auth/hooks/auth.hooks.ts
+++ b/frontend/src/app/modules/auth/hooks/auth.hooks.ts
@@ -1,0 +1,72 @@
+import { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { authApi } from '~/api/auth.api'
+import type { AuthState } from '~/modules/auth/models/auth.model'
+import { loggedOut, sessionVerified } from '~/modules/auth/store/auth.slice'
+import type { AppDispatch, RootState } from '~/modules/app/app.store'
+
+export interface UseAuthReturn {
+  status: AuthState['status']
+  user: AuthState['user']
+  isAuthenticated: boolean
+  isUnknown: boolean
+  isUnauthenticated: boolean
+}
+
+export const useAuth = (): UseAuthReturn => {
+  const { status, user } = useSelector((state: RootState) => state.auth)
+  return {
+    status,
+    user,
+    isAuthenticated: status === 'authenticated',
+    isUnknown: status === 'unknown',
+    isUnauthenticated: status === 'unauthenticated',
+  }
+}
+
+// App-boot sequence (spec §Unit 3 lines 114–115):
+//   1. `GET /xsrf` seeds the antiforgery double-submit pair before any
+//      state-changing request can fire.
+//   2. `GET /me` determines whether a live session exists. 200 →
+//      `sessionVerified`; non-200 → `loggedOut`.
+//
+// Run once per app mount. Both calls are fire-and-forget from the UI
+// perspective — failures flow into the auth slice, not into a loading
+// spinner this hook owns.
+export const useAuthBootstrap = (): void => {
+  const dispatch = useDispatch<AppDispatch>()
+
+  useEffect(() => {
+    let cancelled = false
+
+    const bootstrap = async (): Promise<void> => {
+      const xsrfPromise = dispatch(authApi.endpoints.xsrf.initiate(undefined))
+      try {
+        await xsrfPromise.unwrap()
+      } catch {
+        // Antiforgery seed fires-and-forgets: mutations read the cookie
+        // at send time; if the seed failed the first mutation will.
+      } finally {
+        xsrfPromise.unsubscribe()
+      }
+
+      const mePromise = dispatch(authApi.endpoints.me.initiate(undefined))
+      try {
+        const me = await mePromise.unwrap()
+        if (!cancelled) {
+          dispatch(sessionVerified({ userId: me.userId, email: me.email }))
+        }
+      } catch {
+        if (!cancelled) dispatch(loggedOut())
+      } finally {
+        mePromise.unsubscribe()
+      }
+    }
+
+    void bootstrap()
+
+    return () => {
+      cancelled = true
+    }
+  }, [dispatch])
+}

--- a/frontend/src/app/modules/auth/lib/broadcast-auth.ts
+++ b/frontend/src/app/modules/auth/lib/broadcast-auth.ts
@@ -1,0 +1,22 @@
+const CHANNEL_NAME = 'auth'
+const LOGOUT_MESSAGE = 'logout'
+
+// Cross-tab logout via the native `BroadcastChannel` API — no npm dep
+// (spec §Unit 3 line 118). Both functions no-op in environments without
+// `BroadcastChannel` (e.g. the jsdom test env, older browsers) so
+// callers can subscribe/post unconditionally.
+export const postLogoutBroadcast = (): void => {
+  if (typeof BroadcastChannel === 'undefined') return
+  const channel = new BroadcastChannel(CHANNEL_NAME)
+  channel.postMessage(LOGOUT_MESSAGE)
+  channel.close()
+}
+
+export const subscribeLogoutBroadcast = (handler: () => void): (() => void) => {
+  if (typeof BroadcastChannel === 'undefined') return () => undefined
+  const channel = new BroadcastChannel(CHANNEL_NAME)
+  channel.onmessage = (event) => {
+    if (event.data === LOGOUT_MESSAGE) handler()
+  }
+  return () => channel.close()
+}

--- a/frontend/src/app/modules/auth/models/auth.model.ts
+++ b/frontend/src/app/modules/auth/models/auth.model.ts
@@ -1,0 +1,26 @@
+export type AuthStatus = 'authenticated' | 'unauthenticated' | 'unknown'
+
+export interface AuthUser {
+  userId: string
+  email: string
+}
+
+export interface AuthState {
+  status: AuthStatus
+  user: AuthUser | null
+}
+
+export interface RegisterRequestDto {
+  email: string
+  password: string
+}
+
+export interface LoginRequestDto {
+  email: string
+  password: string
+}
+
+export interface AuthResponseDto {
+  userId: string
+  email: string
+}

--- a/frontend/src/app/modules/auth/schemas/auth.schema.ts
+++ b/frontend/src/app/modules/auth/schemas/auth.schema.ts
@@ -10,11 +10,16 @@ import { z } from 'zod'
 // assert these two schemas accept/reject the same inputs as the backend
 // DataAnnotations — deferred to the shared-contracts folder.
 
+// Chain order matters: `.trim()` normalizes first so the email validator
+// sees the cleaned value — otherwise `'  user@example.com  '` fails format
+// before it's ever trimmed. `.pipe(z.email(...))` is the Zod v4 replacement
+// for the deprecated `.email()` method on `ZodString`.
 const emailSchema = z
-  .email('Email must be a valid address.')
+  .string()
   .trim()
   .min(1, 'Email is required.')
   .max(254, 'Email must be at most 254 characters.')
+  .pipe(z.email('Email must be a valid address.'))
 
 export const registerSchema = z.object({
   email: emailSchema,

--- a/frontend/src/app/modules/auth/schemas/auth.schema.ts
+++ b/frontend/src/app/modules/auth/schemas/auth.schema.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+
+// Email rules mirror `RegisterRequestDto.Email`:
+//   [Required, EmailAddress, MaxLength(254)]
+// Password rules mirror the backend's ASP.NET Identity Core policy:
+//   RequiredLength = 12, RequireUppercase, RequireLowercase, RequireDigit,
+//   RequireNonAlphanumeric. Max 128 chars from `RegisterRequestDto.Password`.
+// See backend/src/RunCoach.Api/Program.cs lines 108–127 for the canonical
+// policy. A contract test in `shared-contracts/` (captured follow-up) will
+// assert these two schemas accept/reject the same inputs as the backend
+// DataAnnotations — deferred to the shared-contracts folder.
+
+const emailSchema = z
+  .email('Email must be a valid address.')
+  .trim()
+  .min(1, 'Email is required.')
+  .max(254, 'Email must be at most 254 characters.')
+
+export const registerSchema = z.object({
+  email: emailSchema,
+  password: z
+    .string()
+    .min(12, 'Password must be at least 12 characters.')
+    .max(128, 'Password must be at most 128 characters.')
+    .refine((value) => /[A-Z]/.test(value), {
+      message: 'Password must contain an uppercase letter.',
+    })
+    .refine((value) => /[a-z]/.test(value), {
+      message: 'Password must contain a lowercase letter.',
+    })
+    .refine((value) => /\d/.test(value), {
+      message: 'Password must contain a digit.',
+    })
+    .refine((value) => /[^A-Za-z0-9]/.test(value), {
+      message: 'Password must contain a non-alphanumeric character.',
+    }),
+})
+
+// Login deliberately does NOT duplicate the registration password rules —
+// timing-safe login treats all failure modes identically, so pre-validating
+// complexity on the client would leak a side-channel ("your stored password
+// cannot meet these rules, so you are definitely unknown"). Accept any
+// non-empty string and let the server return 401 uniformly.
+export const loginSchema = z.object({
+  email: z.string().trim().min(1, 'Email is required.'),
+  password: z.string().min(1, 'Password is required.'),
+})
+
+export type RegisterFormValues = z.infer<typeof registerSchema>
+export type LoginFormValues = z.infer<typeof loginSchema>

--- a/frontend/src/app/modules/auth/store/auth.slice.spec.ts
+++ b/frontend/src/app/modules/auth/store/auth.slice.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { authReducer, authSlice, loggedOut, sessionVerified } from './auth.slice'
+import type { AuthState } from '~/modules/auth/models/auth.model'
+
+const initialState: AuthState = { status: 'unknown', user: null }
+
+describe('authSlice', () => {
+  it('starts in the unknown status with no user', () => {
+    const state = authReducer(undefined, { type: '@@INIT' })
+    expect(state).toEqual(initialState)
+  })
+
+  describe('sessionVerified', () => {
+    it('populates the user and flips status to authenticated', () => {
+      const user = { userId: 'usr_abc', email: 'runner@example.com' }
+      const state = authReducer(initialState, sessionVerified(user))
+      expect(state.status).toBe('authenticated')
+      expect(state.user).toEqual(user)
+    })
+
+    it('overwrites an existing user payload', () => {
+      const prior: AuthState = {
+        status: 'authenticated',
+        user: { userId: 'usr_old', email: 'old@example.com' },
+      }
+      const next = { userId: 'usr_new', email: 'new@example.com' }
+      const state = authReducer(prior, sessionVerified(next))
+      expect(state.user).toEqual(next)
+    })
+  })
+
+  describe('loggedOut', () => {
+    it('clears the user and flips status to unauthenticated', () => {
+      const prior: AuthState = {
+        status: 'authenticated',
+        user: { userId: 'usr_abc', email: 'runner@example.com' },
+      }
+      const state = authReducer(prior, loggedOut())
+      expect(state.status).toBe('unauthenticated')
+      expect(state.user).toBeNull()
+    })
+
+    it('remains unauthenticated-with-null-user when invoked from the unknown bootstrap state', () => {
+      const state = authReducer(initialState, loggedOut())
+      expect(state.status).toBe('unauthenticated')
+      expect(state.user).toBeNull()
+    })
+  })
+
+  // Spec §Unit 3 line 112 — no token-storage primitive. Walk every key the
+  // slice exposes (including nested `user`) and assert nothing looks like a
+  // bearer / refresh / access token field. This is the canonical regression
+  // guard: if a future refactor adds a `token` field to the slice, it fails
+  // here before any E2E test runs.
+  describe('no token-shaped fields exist in the state tree', () => {
+    const walkKeys = (value: unknown): string[] => {
+      if (value === null || typeof value !== 'object') return []
+      const keys = Object.keys(value as Record<string, unknown>)
+      const nested = keys.flatMap((key) => walkKeys((value as Record<string, unknown>)[key]))
+      return keys.concat(nested)
+    }
+
+    const tokenPattern = /token|jwt|accessToken|refreshToken/i
+
+    it('initial state has zero token-shaped keys', () => {
+      const state = authReducer(undefined, { type: '@@INIT' })
+      const offenders = walkKeys(state).filter((key) => tokenPattern.test(key))
+      expect(offenders).toEqual([])
+    })
+
+    it('authenticated state has zero token-shaped keys', () => {
+      const state = authReducer(
+        initialState,
+        sessionVerified({ userId: 'usr_abc', email: 'runner@example.com' }),
+      )
+      const offenders = walkKeys(state).filter((key) => tokenPattern.test(key))
+      expect(offenders).toEqual([])
+    })
+
+    it('slice action-creator keys carry no token-shaped names', () => {
+      const actionTypes = Object.values(authSlice.actions).map((creator) => creator.type)
+      const offenders = actionTypes.filter((type) => tokenPattern.test(type))
+      expect(offenders).toEqual([])
+    })
+  })
+})

--- a/frontend/src/app/modules/auth/store/auth.slice.ts
+++ b/frontend/src/app/modules/auth/store/auth.slice.ts
@@ -1,0 +1,25 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { AuthState, AuthUser } from '~/modules/auth/models/auth.model'
+
+const initialState: AuthState = {
+  status: 'unknown',
+  user: null,
+}
+
+export const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    sessionVerified: (state, action: PayloadAction<AuthUser>) => {
+      state.status = 'authenticated'
+      state.user = action.payload
+    },
+    loggedOut: (state) => {
+      state.status = 'unauthenticated'
+      state.user = null
+    },
+  },
+})
+
+export const { sessionVerified, loggedOut } = authSlice.actions
+export const authReducer = authSlice.reducer

--- a/frontend/src/app/pages/home/home.page.spec.tsx
+++ b/frontend/src/app/pages/home/home.page.spec.tsx
@@ -1,0 +1,105 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AuthState } from '~/modules/auth/models/auth.model'
+import { authSlice } from '~/modules/auth/store/auth.slice'
+
+const { logoutUnwrap, logoutTrigger, navigateMock, postLogoutBroadcastMock } = vi.hoisted(() => {
+  const unwrap = vi.fn()
+  return {
+    logoutUnwrap: unwrap,
+    logoutTrigger: vi.fn(() => ({ unwrap })),
+    navigateMock: vi.fn(),
+    postLogoutBroadcastMock: vi.fn(),
+  }
+})
+
+vi.mock('~/api/auth.api', () => ({
+  useLogoutMutation: () => [logoutTrigger, { isLoading: false }],
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+vi.mock('~/modules/auth/lib/broadcast-auth', () => ({
+  postLogoutBroadcast: postLogoutBroadcastMock,
+}))
+
+import { HomePage } from './home.page'
+
+const AUTHENTICATED_USER = { userId: 'usr_abc', email: 'runner@example.com' }
+
+const makeStore = () => {
+  const preloadedAuth: AuthState = { status: 'authenticated', user: AUTHENTICATED_USER }
+  return configureStore({
+    reducer: { [authSlice.name]: authSlice.reducer },
+    preloadedState: { [authSlice.name]: preloadedAuth },
+  })
+}
+
+const renderHome = () => {
+  const store = makeStore()
+  return {
+    store,
+    ...render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/']}>
+          <HomePage />
+        </MemoryRouter>
+      </Provider>,
+    ),
+  }
+}
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    logoutUnwrap.mockReset()
+    logoutTrigger.mockClear()
+    navigateMock.mockReset()
+    postLogoutBroadcastMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the authenticated user email in the greeting', () => {
+    renderHome()
+    expect(screen.getByTestId('home-greeting')).toHaveTextContent(
+      `Logged in as ${AUTHENTICATED_USER.email}`,
+    )
+  })
+
+  it('signs out: invokes the logout mutation, flips the slice, broadcasts, and navigates to /login', async () => {
+    logoutUnwrap.mockResolvedValue(undefined)
+    const { store } = renderHome()
+
+    fireEvent.click(screen.getByRole('button', { name: /sign out/i }))
+
+    await waitFor(() => {
+      expect(logoutTrigger).toHaveBeenCalledWith(undefined)
+    })
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true })
+    })
+    expect(postLogoutBroadcastMock).toHaveBeenCalledTimes(1)
+    expect(store.getState().auth.status).toBe('unauthenticated')
+    expect(store.getState().auth.user).toBeNull()
+  })
+
+  it('still flips to unauthenticated when the server-side logout fails', async () => {
+    logoutUnwrap.mockRejectedValue(new Error('network down'))
+    const { store } = renderHome()
+
+    fireEvent.click(screen.getByRole('button', { name: /sign out/i }))
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true })
+    })
+    expect(store.getState().auth.status).toBe('unauthenticated')
+  })
+})

--- a/frontend/src/app/pages/home/home.page.spec.tsx
+++ b/frontend/src/app/pages/home/home.page.spec.tsx
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -43,8 +44,10 @@ const makeStore = () => {
 
 const renderHome = () => {
   const store = makeStore()
+  const user = userEvent.setup()
   return {
     store,
+    user,
     ...render(
       <Provider store={store}>
         <MemoryRouter initialEntries={['/']}>
@@ -69,16 +72,14 @@ describe('HomePage', () => {
 
   it('renders the authenticated user email in the greeting', () => {
     renderHome()
-    expect(screen.getByTestId('home-greeting')).toHaveTextContent(
-      `Logged in as ${AUTHENTICATED_USER.email}`,
-    )
+    expect(screen.getByText(`Logged in as ${AUTHENTICATED_USER.email}`)).toBeInTheDocument()
   })
 
   it('signs out: invokes the logout mutation, flips the slice, broadcasts, and navigates to /login', async () => {
     logoutUnwrap.mockResolvedValue(undefined)
-    const { store } = renderHome()
+    const { store, user } = renderHome()
 
-    fireEvent.click(screen.getByRole('button', { name: /sign out/i }))
+    await user.click(screen.getByRole('button', { name: /sign out/i }))
 
     await waitFor(() => {
       expect(logoutTrigger).toHaveBeenCalledWith(undefined)
@@ -93,9 +94,9 @@ describe('HomePage', () => {
 
   it('still flips to unauthenticated when the server-side logout fails', async () => {
     logoutUnwrap.mockRejectedValue(new Error('network down'))
-    const { store } = renderHome()
+    const { store, user } = renderHome()
 
-    fireEvent.click(screen.getByRole('button', { name: /sign out/i }))
+    await user.click(screen.getByRole('button', { name: /sign out/i }))
 
     await waitFor(() => {
       expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true })

--- a/frontend/src/app/pages/home/home.page.tsx
+++ b/frontend/src/app/pages/home/home.page.tsx
@@ -1,5 +1,7 @@
-import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
+
+import { useDispatch } from 'react-redux'
+
 import { useLogoutMutation } from '~/api/auth.api'
 import { useAuth } from '~/modules/auth/hooks/auth.hooks'
 import { postLogoutBroadcast } from '~/modules/auth/lib/broadcast-auth'

--- a/frontend/src/app/pages/home/home.page.tsx
+++ b/frontend/src/app/pages/home/home.page.tsx
@@ -1,8 +1,47 @@
+import { useDispatch } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
+import { useLogoutMutation } from '~/api/auth.api'
+import { useAuth } from '~/modules/auth/hooks/auth.hooks'
+import { postLogoutBroadcast } from '~/modules/auth/lib/broadcast-auth'
+import { loggedOut } from '~/modules/auth/store/auth.slice'
+import type { AppDispatch } from '~/modules/app/app.store'
+
 const HomePage = () => {
+  const dispatch = useDispatch<AppDispatch>()
+  const navigate = useNavigate()
+  const { user } = useAuth()
+  const [logout, { isLoading }] = useLogoutMutation()
+
+  const onLogout = async (): Promise<void> => {
+    try {
+      await logout(undefined).unwrap()
+    } catch {
+      // Even a server-side failure should flip the local session to
+      // unauthenticated — the worst case is a stale server cookie that
+      // the browser will reject on the next honored request anyway.
+    }
+    dispatch(loggedOut())
+    postLogoutBroadcast()
+    navigate('/login', { replace: true })
+  }
+
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-slate-50 px-4">
       <h1 className="text-4xl font-bold">RunCoach</h1>
-    </div>
+      <p className="text-slate-700" data-testid="home-greeting">
+        Logged in as {user?.email ?? ''}
+      </p>
+      <button
+        type="button"
+        onClick={() => {
+          void onLogout()
+        }}
+        disabled={isLoading}
+        className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isLoading ? 'Signing out…' : 'Sign out'}
+      </button>
+    </main>
   )
 }
 

--- a/frontend/src/app/pages/home/home.page.tsx
+++ b/frontend/src/app/pages/home/home.page.tsx
@@ -21,10 +21,11 @@ const HomePage = () => {
       // Even a server-side failure should flip the local session to
       // unauthenticated — the worst case is a stale server cookie that
       // the browser will reject on the next honored request anyway.
+    } finally {
+      dispatch(loggedOut())
+      postLogoutBroadcast()
+      navigate('/login', { replace: true })
     }
-    dispatch(loggedOut())
-    postLogoutBroadcast()
-    navigate('/login', { replace: true })
   }
 
   return (

--- a/frontend/src/app/pages/login/login-form.component.tsx
+++ b/frontend/src/app/pages/login/login-form.component.tsx
@@ -1,0 +1,82 @@
+import type { UseFormReturn } from 'react-hook-form'
+import type { LoginFormValues } from '~/modules/auth/schemas/auth.schema'
+
+export interface LoginFormProps {
+  form: UseFormReturn<LoginFormValues>
+  onSubmit: (values: LoginFormValues) => Promise<void> | void
+  isLoading: boolean
+  formAlert: string | null
+}
+
+export const LoginForm = ({ form, onSubmit, isLoading, formAlert }: LoginFormProps) => {
+  const isSubmitDisabled = !form.formState.isValid || isLoading
+  const emailError = form.formState.errors.email
+  const passwordError = form.formState.errors.password
+
+  return (
+    <>
+      <h1 className="mb-4 text-2xl font-semibold">Sign in to RunCoach</h1>
+
+      {formAlert !== null && (
+        <div
+          role="alert"
+          data-testid="form-alert"
+          className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+        >
+          {formAlert}
+        </div>
+      )}
+
+      <form noValidate onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <label htmlFor="login-email" className="block text-sm font-medium">
+            Email
+          </label>
+          <input
+            id="login-email"
+            type="email"
+            autoComplete="email"
+            autoFocus
+            aria-invalid={emailError !== undefined}
+            aria-describedby={emailError === undefined ? undefined : 'login-email-error'}
+            className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
+            {...form.register('email')}
+          />
+          {emailError !== undefined && (
+            <p id="login-email-error" role="alert" className="mt-1 text-xs text-red-700">
+              {emailError.message}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="login-password" className="block text-sm font-medium">
+            Password
+          </label>
+          <input
+            id="login-password"
+            type="password"
+            autoComplete="current-password"
+            aria-invalid={passwordError !== undefined}
+            aria-describedby={passwordError === undefined ? undefined : 'login-password-error'}
+            className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
+            {...form.register('password')}
+          />
+          {passwordError !== undefined && (
+            <p id="login-password-error" role="alert" className="mt-1 text-xs text-red-700">
+              {passwordError.message}
+            </p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          disabled={isSubmitDisabled}
+          className="w-full rounded bg-slate-900 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isLoading ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+    </>
+  )
+}

--- a/frontend/src/app/pages/login/login.page.spec.tsx
+++ b/frontend/src/app/pages/login/login.page.spec.tsx
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent, { type UserEvent } from '@testing-library/user-event'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -33,8 +34,10 @@ type RenderOptions = { initialEntries?: Array<string | { pathname: string; state
 
 const renderLogin = ({ initialEntries = ['/login'] }: RenderOptions = {}) => {
   const store = makeStore()
+  const user = userEvent.setup()
   return {
     store,
+    user,
     ...render(
       <Provider store={store}>
         <MemoryRouter initialEntries={initialEntries}>
@@ -45,18 +48,18 @@ const renderLogin = ({ initialEntries = ['/login'] }: RenderOptions = {}) => {
   }
 }
 
-const fillEmail = (value: string): void => {
-  fireEvent.change(screen.getByLabelText(/email/i), { target: { value } })
+const fillEmail = async (user: UserEvent, value: string): Promise<void> => {
+  await user.type(screen.getByLabelText(/email/i), value)
 }
 
-const fillPassword = (value: string): void => {
-  fireEvent.change(screen.getByLabelText(/password/i), { target: { value } })
+const fillPassword = async (user: UserEvent, value: string): Promise<void> => {
+  await user.type(screen.getByLabelText(/password/i), value)
 }
 
-// Submit the <form> element directly so the assertion works even when the
-// submit button is disabled (empty form). This mirrors the intent of the
-// task's "empty-submit validation" bullet: exercise the RHF / Zod resolver's
-// error-surfacing path, not the DOM-level button click.
+// Submits the <form> via a native submit event so the assertion works even
+// when the submit button is disabled (userEvent.click on a disabled button
+// is a no-op). This is the single justified use of fireEvent — no equivalent
+// userEvent API for "submit a form whose button is disabled" exists.
 const submitForm = (): void => {
   const form = document.querySelector('form')
   if (form === null) throw new Error('Login form not found')
@@ -94,9 +97,9 @@ describe('LoginPage', () => {
     // complexity assertions live — see register.page.spec.tsx.
     it('accepts an unusually-shaped email client-side and forwards it to the mutation', async () => {
       loginUnwrap.mockResolvedValue({ userId: 'usr_abc', email: 'legacy@example' })
-      renderLogin()
-      fillEmail('legacy@example')
-      fillPassword('any-non-empty')
+      const { user } = renderLogin()
+      await fillEmail(user, 'legacy@example')
+      await fillPassword(user, 'any-non-empty')
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
       })
@@ -116,9 +119,9 @@ describe('LoginPage', () => {
     // the failure path lives in the server's uniform 401 response, exercised
     // by the server-error tests below.
     it('accepts a weak (but non-empty) password at the client tier', async () => {
-      renderLogin()
-      fillEmail(VALID_EMAIL)
-      fillPassword('x')
+      const { user } = renderLogin()
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, 'x')
       await waitFor(() => {
         expect(screen.queryByText(/password must/i)).not.toBeInTheDocument()
       })
@@ -133,9 +136,9 @@ describe('LoginPage', () => {
     })
 
     it('becomes enabled once email and password fields are filled with valid values', async () => {
-      renderLogin()
-      fillEmail(VALID_EMAIL)
-      fillPassword(VALID_PASSWORD)
+      const { user } = renderLogin()
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, VALID_PASSWORD)
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
       })
@@ -145,13 +148,14 @@ describe('LoginPage', () => {
   describe('happy-path submission', () => {
     it('invokes the login mutation, dispatches sessionVerified, and navigates to "/"', async () => {
       loginUnwrap.mockResolvedValue({ userId: 'usr_abc', email: VALID_EMAIL })
-      const { store } = renderLogin()
-      fillEmail(VALID_EMAIL)
-      fillPassword(VALID_PASSWORD)
+      const { store, user } = renderLogin()
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, VALID_PASSWORD)
+      const submitButton = screen.getByRole('button', { name: /sign in/i })
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+        expect(submitButton).not.toBeDisabled()
       })
-      submitForm()
+      await user.click(submitButton)
       await waitFor(() => {
         expect(loginTrigger).toHaveBeenCalledWith({
           email: VALID_EMAIL,
@@ -168,15 +172,16 @@ describe('LoginPage', () => {
 
     it('respects a sanitized next-path on location.state', async () => {
       loginUnwrap.mockResolvedValue({ userId: 'usr_abc', email: VALID_EMAIL })
-      renderLogin({
+      const { user } = renderLogin({
         initialEntries: [{ pathname: '/login', state: { next: '/dashboard' } }],
       })
-      fillEmail(VALID_EMAIL)
-      fillPassword(VALID_PASSWORD)
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, VALID_PASSWORD)
+      const submitButton = screen.getByRole('button', { name: /sign in/i })
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+        expect(submitButton).not.toBeDisabled()
       })
-      submitForm()
+      await user.click(submitButton)
       await waitFor(() => {
         expect(navigateMock).toHaveBeenCalledWith('/dashboard', { replace: true })
       })
@@ -184,15 +189,16 @@ describe('LoginPage', () => {
 
     it('ignores an external-origin next-path on location.state', async () => {
       loginUnwrap.mockResolvedValue({ userId: 'usr_abc', email: VALID_EMAIL })
-      renderLogin({
+      const { user } = renderLogin({
         initialEntries: [{ pathname: '/login', state: { next: '//evil.example.com' } }],
       })
-      fillEmail(VALID_EMAIL)
-      fillPassword(VALID_PASSWORD)
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, VALID_PASSWORD)
+      const submitButton = screen.getByRole('button', { name: /sign in/i })
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+        expect(submitButton).not.toBeDisabled()
       })
-      submitForm()
+      await user.click(submitButton)
       await waitFor(() => {
         expect(navigateMock).toHaveBeenCalledWith('/', { replace: true })
       })
@@ -213,13 +219,14 @@ describe('LoginPage', () => {
           },
         },
       })
-      renderLogin()
-      fillEmail(VALID_EMAIL)
-      fillPassword(VALID_PASSWORD)
+      const { user } = renderLogin()
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, VALID_PASSWORD)
+      const submitButton = screen.getByRole('button', { name: /sign in/i })
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+        expect(submitButton).not.toBeDisabled()
       })
-      submitForm()
+      await user.click(submitButton)
       expect(await screen.findByText('Email is malformed.')).toBeInTheDocument()
       expect(await screen.findByText('Password cannot be blank.')).toBeInTheDocument()
     })
@@ -233,13 +240,14 @@ describe('LoginPage', () => {
           status: 401,
         },
       })
-      renderLogin()
-      fillEmail(VALID_EMAIL)
-      fillPassword(VALID_PASSWORD)
+      const { user } = renderLogin()
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, VALID_PASSWORD)
+      const submitButton = screen.getByRole('button', { name: /sign in/i })
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+        expect(submitButton).not.toBeDisabled()
       })
-      submitForm()
+      await user.click(submitButton)
       const alert = await screen.findByTestId('form-alert')
       expect(alert).toHaveTextContent('Invalid email or password.')
     })
@@ -249,13 +257,14 @@ describe('LoginPage', () => {
         status: 500,
         data: {},
       })
-      renderLogin()
-      fillEmail(VALID_EMAIL)
-      fillPassword(VALID_PASSWORD)
+      const { user } = renderLogin()
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, VALID_PASSWORD)
+      const submitButton = screen.getByRole('button', { name: /sign in/i })
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+        expect(submitButton).not.toBeDisabled()
       })
-      submitForm()
+      await user.click(submitButton)
       const alert = await screen.findByTestId('form-alert')
       expect(alert).toHaveTextContent(/login failed/i)
     })

--- a/frontend/src/app/pages/login/login.page.spec.tsx
+++ b/frontend/src/app/pages/login/login.page.spec.tsx
@@ -1,0 +1,263 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { authSlice } from '~/modules/auth/store/auth.slice'
+
+// Hoisted mock references — vi.mock is hoisted above imports, so the trigger
+// and unwrap mocks must be created inside the factory or via `vi.hoisted`.
+const { loginUnwrap, loginTrigger, navigateMock } = vi.hoisted(() => {
+  const unwrap = vi.fn()
+  return {
+    loginUnwrap: unwrap,
+    loginTrigger: vi.fn(() => ({ unwrap })),
+    navigateMock: vi.fn(),
+  }
+})
+
+vi.mock('~/api/auth.api', () => ({
+  useLoginMutation: () => [loginTrigger, { isLoading: false }],
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+import { LoginPage } from './login.page'
+
+const makeStore = () => configureStore({ reducer: { [authSlice.name]: authSlice.reducer } })
+
+type RenderOptions = { initialEntries?: Array<string | { pathname: string; state: unknown }> }
+
+const renderLogin = ({ initialEntries = ['/login'] }: RenderOptions = {}) => {
+  const store = makeStore()
+  return {
+    store,
+    ...render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={initialEntries}>
+          <LoginPage />
+        </MemoryRouter>
+      </Provider>,
+    ),
+  }
+}
+
+const fillEmail = (value: string): void => {
+  fireEvent.change(screen.getByLabelText(/email/i), { target: { value } })
+}
+
+const fillPassword = (value: string): void => {
+  fireEvent.change(screen.getByLabelText(/password/i), { target: { value } })
+}
+
+// Submit the <form> element directly so the assertion works even when the
+// submit button is disabled (empty form). This mirrors the intent of the
+// task's "empty-submit validation" bullet: exercise the RHF / Zod resolver's
+// error-surfacing path, not the DOM-level button click.
+const submitForm = (): void => {
+  const form = document.querySelector('form')
+  if (form === null) throw new Error('Login form not found')
+  fireEvent.submit(form)
+}
+
+const VALID_EMAIL = 'runner@example.com'
+const VALID_PASSWORD = 'StrongPassw0rd!'
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    loginUnwrap.mockReset()
+    loginTrigger.mockClear()
+    navigateMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('client-side validation', () => {
+    it('shows required errors when the form is submitted empty and does not invoke the mutation', async () => {
+      renderLogin()
+      submitForm()
+      expect(await screen.findByText('Email is required.')).toBeInTheDocument()
+      expect(await screen.findByText('Password is required.')).toBeInTheDocument()
+      expect(loginTrigger).not.toHaveBeenCalled()
+    })
+
+    // Login's Zod schema is intentionally permissive (non-empty only) so
+    // format + complexity pre-validation on the client cannot leak a
+    // side-channel about whether a stored credential could possibly meet
+    // the current rules. Full credential validation is the server's uniform
+    // timing-safe 401 (DEC-053). The register page is where the format /
+    // complexity assertions live — see register.page.spec.tsx.
+    it('accepts an unusually-shaped email client-side and forwards it to the mutation', async () => {
+      loginUnwrap.mockResolvedValue({ userId: 'usr_abc', email: 'legacy@example' })
+      renderLogin()
+      fillEmail('legacy@example')
+      fillPassword('any-non-empty')
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+      })
+      submitForm()
+      await waitFor(() => {
+        expect(loginTrigger).toHaveBeenCalledWith({
+          email: 'legacy@example',
+          password: 'any-non-empty',
+        })
+      })
+      expect(screen.queryByText(/email must be a valid address/i)).not.toBeInTheDocument()
+    })
+
+    // Login schema deliberately accepts any non-empty password (timing-safe
+    // 401 posture — full credential validation is the server's job). A
+    // "weak" password on the login page is a valid client-side submission;
+    // the failure path lives in the server's uniform 401 response, exercised
+    // by the server-error tests below.
+    it('accepts a weak (but non-empty) password at the client tier', async () => {
+      renderLogin()
+      fillEmail(VALID_EMAIL)
+      fillPassword('x')
+      await waitFor(() => {
+        expect(screen.queryByText(/password must/i)).not.toBeInTheDocument()
+      })
+      expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+    })
+  })
+
+  describe('submit button gating', () => {
+    it('is disabled while the form is structurally invalid', () => {
+      renderLogin()
+      expect(screen.getByRole('button', { name: /sign in/i })).toBeDisabled()
+    })
+
+    it('becomes enabled once email and password fields are filled with valid values', async () => {
+      renderLogin()
+      fillEmail(VALID_EMAIL)
+      fillPassword(VALID_PASSWORD)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+      })
+    })
+  })
+
+  describe('happy-path submission', () => {
+    it('invokes the login mutation, dispatches sessionVerified, and navigates to "/"', async () => {
+      loginUnwrap.mockResolvedValue({ userId: 'usr_abc', email: VALID_EMAIL })
+      const { store } = renderLogin()
+      fillEmail(VALID_EMAIL)
+      fillPassword(VALID_PASSWORD)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+      })
+      submitForm()
+      await waitFor(() => {
+        expect(loginTrigger).toHaveBeenCalledWith({
+          email: VALID_EMAIL,
+          password: VALID_PASSWORD,
+        })
+      })
+      await waitFor(() => {
+        expect(navigateMock).toHaveBeenCalledWith('/', { replace: true })
+      })
+      const state = store.getState()
+      expect(state.auth.status).toBe('authenticated')
+      expect(state.auth.user).toEqual({ userId: 'usr_abc', email: VALID_EMAIL })
+    })
+
+    it('respects a sanitized next-path on location.state', async () => {
+      loginUnwrap.mockResolvedValue({ userId: 'usr_abc', email: VALID_EMAIL })
+      renderLogin({
+        initialEntries: [{ pathname: '/login', state: { next: '/dashboard' } }],
+      })
+      fillEmail(VALID_EMAIL)
+      fillPassword(VALID_PASSWORD)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+      })
+      submitForm()
+      await waitFor(() => {
+        expect(navigateMock).toHaveBeenCalledWith('/dashboard', { replace: true })
+      })
+    })
+
+    it('ignores an external-origin next-path on location.state', async () => {
+      loginUnwrap.mockResolvedValue({ userId: 'usr_abc', email: VALID_EMAIL })
+      renderLogin({
+        initialEntries: [{ pathname: '/login', state: { next: '//evil.example.com' } }],
+      })
+      fillEmail(VALID_EMAIL)
+      fillPassword(VALID_PASSWORD)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+      })
+      submitForm()
+      await waitFor(() => {
+        expect(navigateMock).toHaveBeenCalledWith('/', { replace: true })
+      })
+    })
+  })
+
+  describe('server-side error surfacing', () => {
+    it('renders ValidationProblemDetails.errors at the field level', async () => {
+      loginUnwrap.mockRejectedValue({
+        status: 400,
+        data: {
+          type: 'https://httpstatuses.com/400',
+          title: 'One or more validation errors occurred.',
+          status: 400,
+          errors: {
+            Email: ['Email is malformed.'],
+            Password: ['Password cannot be blank.'],
+          },
+        },
+      })
+      renderLogin()
+      fillEmail(VALID_EMAIL)
+      fillPassword(VALID_PASSWORD)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+      })
+      submitForm()
+      expect(await screen.findByText('Email is malformed.')).toBeInTheDocument()
+      expect(await screen.findByText('Password cannot be blank.')).toBeInTheDocument()
+    })
+
+    it('renders ProblemDetails.title as a non-field-level alert', async () => {
+      loginUnwrap.mockRejectedValue({
+        status: 401,
+        data: {
+          type: 'https://httpstatuses.com/401',
+          title: 'Invalid email or password.',
+          status: 401,
+        },
+      })
+      renderLogin()
+      fillEmail(VALID_EMAIL)
+      fillPassword(VALID_PASSWORD)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+      })
+      submitForm()
+      const alert = await screen.findByTestId('form-alert')
+      expect(alert).toHaveTextContent('Invalid email or password.')
+    })
+
+    it('falls back to a generic alert when the server omits a title', async () => {
+      loginUnwrap.mockRejectedValue({
+        status: 500,
+        data: {},
+      })
+      renderLogin()
+      fillEmail(VALID_EMAIL)
+      fillPassword(VALID_PASSWORD)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled()
+      })
+      submitForm()
+      const alert = await screen.findByTestId('form-alert')
+      expect(alert).toHaveTextContent(/login failed/i)
+    })
+  })
+})

--- a/frontend/src/app/pages/login/login.page.tsx
+++ b/frontend/src/app/pages/login/login.page.tsx
@@ -44,8 +44,9 @@ const LoginPage = () => {
     } catch (error) {
       const parsed = parseProblem(error)
       for (const [field, messages] of Object.entries(parsed.fieldErrors)) {
-        if ((field === 'email' || field === 'password') && messages[0]) {
-          form.setError(field, { type: 'server', message: messages[0] })
+        const firstMessage = messages[0]
+        if ((field === 'email' || field === 'password') && firstMessage !== undefined) {
+          form.setError(field, { type: 'server', message: firstMessage })
         }
       }
       setFormAlert(parsed.title ?? 'Login failed. Please try again.')
@@ -81,7 +82,7 @@ const LoginPage = () => {
               autoFocus
               aria-invalid={form.formState.errors.email !== undefined}
               aria-describedby={
-                form.formState.errors.email !== undefined ? 'login-email-error' : undefined
+                form.formState.errors.email === undefined ? undefined : 'login-email-error'
               }
               className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
               {...form.register('email')}
@@ -103,7 +104,7 @@ const LoginPage = () => {
               autoComplete="current-password"
               aria-invalid={form.formState.errors.password !== undefined}
               aria-describedby={
-                form.formState.errors.password !== undefined ? 'login-password-error' : undefined
+                form.formState.errors.password === undefined ? undefined : 'login-password-error'
               }
               className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
               {...form.register('password')}

--- a/frontend/src/app/pages/login/login.page.tsx
+++ b/frontend/src/app/pages/login/login.page.tsx
@@ -10,6 +10,7 @@ import { parseProblem } from '~/modules/auth/helpers/problem-details.helpers'
 import { loginSchema, type LoginFormValues } from '~/modules/auth/schemas/auth.schema'
 import { sessionVerified } from '~/modules/auth/store/auth.slice'
 import type { AppDispatch } from '~/modules/app/app.store'
+import { LoginForm } from './login-form.component'
 
 // Strict narrowing against `location.state` (typed `unknown` by React
 // Router when external) — only trust a string `next` that looks like an
@@ -55,77 +56,10 @@ const LoginPage = () => {
     }
   }
 
-  const isSubmitDisabled = !form.formState.isValid || isLoading
-
   return (
     <main className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
       <section className="w-full max-w-sm rounded-lg bg-white p-6 shadow">
-        <h1 className="mb-4 text-2xl font-semibold">Sign in to RunCoach</h1>
-
-        {formAlert !== null && (
-          <div
-            role="alert"
-            data-testid="form-alert"
-            className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
-          >
-            {formAlert}
-          </div>
-        )}
-
-        <form noValidate onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-          <div>
-            <label htmlFor="login-email" className="block text-sm font-medium">
-              Email
-            </label>
-            <input
-              id="login-email"
-              type="email"
-              autoComplete="email"
-              autoFocus
-              aria-invalid={form.formState.errors.email !== undefined}
-              aria-describedby={
-                form.formState.errors.email === undefined ? undefined : 'login-email-error'
-              }
-              className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
-              {...form.register('email')}
-            />
-            {form.formState.errors.email !== undefined && (
-              <p id="login-email-error" role="alert" className="mt-1 text-xs text-red-700">
-                {form.formState.errors.email.message}
-              </p>
-            )}
-          </div>
-
-          <div>
-            <label htmlFor="login-password" className="block text-sm font-medium">
-              Password
-            </label>
-            <input
-              id="login-password"
-              type="password"
-              autoComplete="current-password"
-              aria-invalid={form.formState.errors.password !== undefined}
-              aria-describedby={
-                form.formState.errors.password === undefined ? undefined : 'login-password-error'
-              }
-              className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
-              {...form.register('password')}
-            />
-            {form.formState.errors.password !== undefined && (
-              <p id="login-password-error" role="alert" className="mt-1 text-xs text-red-700">
-                {form.formState.errors.password.message}
-              </p>
-            )}
-          </div>
-
-          <button
-            type="submit"
-            disabled={isSubmitDisabled}
-            className="w-full rounded bg-slate-900 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {isLoading ? 'Signing in…' : 'Sign in'}
-          </button>
-        </form>
+        <LoginForm form={form} onSubmit={onSubmit} isLoading={isLoading} formAlert={formAlert} />
 
         <p className="mt-4 text-sm text-slate-600">
           Need an account?{' '}

--- a/frontend/src/app/pages/login/login.page.tsx
+++ b/frontend/src/app/pages/login/login.page.tsx
@@ -1,8 +1,10 @@
-import { zodResolver } from '@hookform/resolvers/zod'
 import { useState } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+
+import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { useDispatch } from 'react-redux'
-import { Link, useLocation, useNavigate } from 'react-router-dom'
+
 import { useLoginMutation } from '~/api/auth.api'
 import { parseProblem } from '~/modules/auth/helpers/problem-details.helpers'
 import { loginSchema, type LoginFormValues } from '~/modules/auth/schemas/auth.schema'

--- a/frontend/src/app/pages/login/login.page.tsx
+++ b/frontend/src/app/pages/login/login.page.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useDispatch } from 'react-redux'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useForm } from 'react-hook-form'
-import { useDispatch } from 'react-redux'
 
 import { useLoginMutation } from '~/api/auth.api'
 import { parseProblem } from '~/modules/auth/helpers/problem-details.helpers'

--- a/frontend/src/app/pages/login/login.page.tsx
+++ b/frontend/src/app/pages/login/login.page.tsx
@@ -1,0 +1,139 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useDispatch } from 'react-redux'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { useLoginMutation } from '~/api/auth.api'
+import { parseProblem } from '~/modules/auth/helpers/problem-details.helpers'
+import { loginSchema, type LoginFormValues } from '~/modules/auth/schemas/auth.schema'
+import { sessionVerified } from '~/modules/auth/store/auth.slice'
+import type { AppDispatch } from '~/modules/app/app.store'
+
+// Strict narrowing against `location.state` (typed `unknown` by React
+// Router when external) — only trust a string `next` that looks like an
+// in-app path. Blocks state-injection redirects to external origins.
+const readNextPath = (state: unknown): string | null => {
+  if (state === null || typeof state !== 'object') return null
+  const candidate = (state as { next?: unknown }).next
+  if (typeof candidate !== 'string') return null
+  if (!candidate.startsWith('/')) return null
+  if (candidate.startsWith('//')) return null
+  return candidate
+}
+
+const LoginPage = () => {
+  const dispatch = useDispatch<AppDispatch>()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [login, { isLoading }] = useLoginMutation()
+  const [formAlert, setFormAlert] = useState<string | null>(null)
+
+  const form = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    mode: 'onChange',
+    defaultValues: { email: '', password: '' },
+  })
+
+  const onSubmit = async (values: LoginFormValues): Promise<void> => {
+    setFormAlert(null)
+    try {
+      const response = await login(values).unwrap()
+      dispatch(sessionVerified({ userId: response.userId, email: response.email }))
+      const next = readNextPath(location.state) ?? '/'
+      navigate(next, { replace: true })
+    } catch (error) {
+      const parsed = parseProblem(error)
+      for (const [field, messages] of Object.entries(parsed.fieldErrors)) {
+        if ((field === 'email' || field === 'password') && messages[0]) {
+          form.setError(field, { type: 'server', message: messages[0] })
+        }
+      }
+      setFormAlert(parsed.title ?? 'Login failed. Please try again.')
+    }
+  }
+
+  const isSubmitDisabled = !form.formState.isValid || isLoading
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
+      <section className="w-full max-w-sm rounded-lg bg-white p-6 shadow">
+        <h1 className="mb-4 text-2xl font-semibold">Sign in to RunCoach</h1>
+
+        {formAlert !== null && (
+          <div
+            role="alert"
+            data-testid="form-alert"
+            className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+          >
+            {formAlert}
+          </div>
+        )}
+
+        <form noValidate onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label htmlFor="login-email" className="block text-sm font-medium">
+              Email
+            </label>
+            <input
+              id="login-email"
+              type="email"
+              autoComplete="email"
+              autoFocus
+              aria-invalid={form.formState.errors.email !== undefined}
+              aria-describedby={
+                form.formState.errors.email !== undefined ? 'login-email-error' : undefined
+              }
+              className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
+              {...form.register('email')}
+            />
+            {form.formState.errors.email !== undefined && (
+              <p id="login-email-error" role="alert" className="mt-1 text-xs text-red-700">
+                {form.formState.errors.email.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor="login-password" className="block text-sm font-medium">
+              Password
+            </label>
+            <input
+              id="login-password"
+              type="password"
+              autoComplete="current-password"
+              aria-invalid={form.formState.errors.password !== undefined}
+              aria-describedby={
+                form.formState.errors.password !== undefined ? 'login-password-error' : undefined
+              }
+              className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
+              {...form.register('password')}
+            />
+            {form.formState.errors.password !== undefined && (
+              <p id="login-password-error" role="alert" className="mt-1 text-xs text-red-700">
+                {form.formState.errors.password.message}
+              </p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitDisabled}
+            className="w-full rounded bg-slate-900 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isLoading ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+
+        <p className="mt-4 text-sm text-slate-600">
+          Need an account?{' '}
+          <Link to="/register" className="font-medium text-slate-900 underline">
+            Create one
+          </Link>
+        </p>
+      </section>
+    </main>
+  )
+}
+
+export default LoginPage
+export { LoginPage }

--- a/frontend/src/app/pages/register/register-form.component.tsx
+++ b/frontend/src/app/pages/register/register-form.component.tsx
@@ -1,0 +1,89 @@
+import type { UseFormReturn } from 'react-hook-form'
+import type { RegisterFormValues } from '~/modules/auth/schemas/auth.schema'
+
+export interface RegisterFormProps {
+  form: UseFormReturn<RegisterFormValues>
+  onSubmit: (values: RegisterFormValues) => Promise<void> | void
+  isLoading: boolean
+  formAlert: string | null
+}
+
+export const RegisterForm = ({ form, onSubmit, isLoading, formAlert }: RegisterFormProps) => {
+  const isSubmitDisabled = !form.formState.isValid || isLoading
+  const emailError = form.formState.errors.email
+  const passwordError = form.formState.errors.password
+
+  return (
+    <>
+      <h1 className="mb-4 text-2xl font-semibold">Create your account</h1>
+
+      {formAlert !== null && (
+        <div
+          role="alert"
+          data-testid="form-alert"
+          className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+        >
+          {formAlert}
+        </div>
+      )}
+
+      <form noValidate onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <label htmlFor="register-email" className="block text-sm font-medium">
+            Email
+          </label>
+          <input
+            id="register-email"
+            type="email"
+            autoComplete="email"
+            autoFocus
+            aria-invalid={emailError !== undefined}
+            aria-describedby={emailError === undefined ? undefined : 'register-email-error'}
+            className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
+            {...form.register('email')}
+          />
+          {emailError !== undefined && (
+            <p id="register-email-error" role="alert" className="mt-1 text-xs text-red-700">
+              {emailError.message}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="register-password" className="block text-sm font-medium">
+            Password
+          </label>
+          <input
+            id="register-password"
+            type="password"
+            autoComplete="new-password"
+            aria-invalid={passwordError !== undefined}
+            aria-describedby={
+              passwordError === undefined ? 'register-password-hint' : 'register-password-error'
+            }
+            className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
+            {...form.register('password')}
+          />
+          {passwordError === undefined ? (
+            <p id="register-password-hint" className="mt-1 text-xs text-slate-500">
+              At least 12 characters, with upper &amp; lower case letters, a digit, and a
+              non-alphanumeric character.
+            </p>
+          ) : (
+            <p id="register-password-error" role="alert" className="mt-1 text-xs text-red-700">
+              {passwordError.message}
+            </p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          disabled={isSubmitDisabled}
+          className="w-full rounded bg-slate-900 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isLoading ? 'Creating account…' : 'Create account'}
+        </button>
+      </form>
+    </>
+  )
+}

--- a/frontend/src/app/pages/register/register.page.spec.tsx
+++ b/frontend/src/app/pages/register/register.page.spec.tsx
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent, { type UserEvent } from '@testing-library/user-event'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -35,8 +36,10 @@ const makeStore = () => configureStore({ reducer: { [authSlice.name]: authSlice.
 
 const renderRegister = () => {
   const store = makeStore()
+  const user = userEvent.setup()
   return {
     store,
+    user,
     ...render(
       <Provider store={store}>
         <MemoryRouter initialEntries={['/register']}>
@@ -47,14 +50,16 @@ const renderRegister = () => {
   }
 }
 
-const fillEmail = (value: string): void => {
-  fireEvent.change(screen.getByLabelText(/email/i), { target: { value } })
+const fillEmail = async (user: UserEvent, value: string): Promise<void> => {
+  await user.type(screen.getByLabelText(/email/i), value)
 }
 
-const fillPassword = (value: string): void => {
-  fireEvent.change(screen.getByLabelText(/password/i), { target: { value } })
+const fillPassword = async (user: UserEvent, value: string): Promise<void> => {
+  await user.type(screen.getByLabelText(/password/i), value)
 }
 
+// See login.page.spec.tsx — native form submit is the only way to trigger
+// the RHF / Zod resolver while the submit button is still disabled.
 const submitForm = (): void => {
   const form = document.querySelector('form')
   if (form === null) throw new Error('Register form not found')
@@ -94,9 +99,9 @@ describe('RegisterPage', () => {
     })
 
     it('rejects an improperly formatted email', async () => {
-      renderRegister()
-      fillEmail('not-an-email')
-      fillPassword(VALID_PASSWORD)
+      const { user } = renderRegister()
+      await fillEmail(user, 'not-an-email')
+      await fillPassword(user, VALID_PASSWORD)
       submitForm()
       expect(await screen.findByText('Email must be a valid address.')).toBeInTheDocument()
       expect(registerTrigger).not.toHaveBeenCalled()
@@ -104,9 +109,9 @@ describe('RegisterPage', () => {
 
     describe('weak-password validation mirrors the backend Identity policy', () => {
       it('rejects a too-short password (< 12 chars)', async () => {
-        renderRegister()
-        fillEmail(VALID_EMAIL)
-        fillPassword('Short1!')
+        const { user } = renderRegister()
+        await fillEmail(user, VALID_EMAIL)
+        await fillPassword(user, 'Short1!')
         submitForm()
         expect(
           await screen.findByText(/password must be at least 12 characters/i),
@@ -115,9 +120,9 @@ describe('RegisterPage', () => {
       })
 
       it('rejects a password missing an uppercase letter', async () => {
-        renderRegister()
-        fillEmail(VALID_EMAIL)
-        fillPassword('lowercase0!word')
+        const { user } = renderRegister()
+        await fillEmail(user, VALID_EMAIL)
+        await fillPassword(user, 'lowercase0!word')
         submitForm()
         expect(
           await screen.findByText(/password must contain an uppercase letter/i),
@@ -125,9 +130,9 @@ describe('RegisterPage', () => {
       })
 
       it('rejects a password missing a lowercase letter', async () => {
-        renderRegister()
-        fillEmail(VALID_EMAIL)
-        fillPassword('UPPERCASE0!WORD')
+        const { user } = renderRegister()
+        await fillEmail(user, VALID_EMAIL)
+        await fillPassword(user, 'UPPERCASE0!WORD')
         submitForm()
         expect(
           await screen.findByText(/password must contain a lowercase letter/i),
@@ -135,17 +140,17 @@ describe('RegisterPage', () => {
       })
 
       it('rejects a password missing a digit', async () => {
-        renderRegister()
-        fillEmail(VALID_EMAIL)
-        fillPassword('NoDigitsHere!!')
+        const { user } = renderRegister()
+        await fillEmail(user, VALID_EMAIL)
+        await fillPassword(user, 'NoDigitsHere!!')
         submitForm()
         expect(await screen.findByText(/password must contain a digit/i)).toBeInTheDocument()
       })
 
       it('rejects a password missing a non-alphanumeric character', async () => {
-        renderRegister()
-        fillEmail(VALID_EMAIL)
-        fillPassword('NoSymbolHere0')
+        const { user } = renderRegister()
+        await fillEmail(user, VALID_EMAIL)
+        await fillPassword(user, 'NoSymbolHere0')
         submitForm()
         expect(
           await screen.findByText(/password must contain a non-alphanumeric character/i),
@@ -161,9 +166,9 @@ describe('RegisterPage', () => {
     })
 
     it('becomes enabled only when email + policy-compliant password are present', async () => {
-      renderRegister()
-      fillEmail(VALID_EMAIL)
-      fillPassword(VALID_PASSWORD)
+      const { user } = renderRegister()
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, VALID_PASSWORD)
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
       })
@@ -174,13 +179,14 @@ describe('RegisterPage', () => {
     it('chains register + login, dispatches sessionVerified, and navigates to "/"', async () => {
       registerUnwrap.mockResolvedValue({ userId: 'usr_abc', email: VALID_EMAIL })
       loginUnwrap.mockResolvedValue({ userId: 'usr_abc', email: VALID_EMAIL })
-      const { store } = renderRegister()
-      fillEmail(VALID_EMAIL)
-      fillPassword(VALID_PASSWORD)
+      const { store, user } = renderRegister()
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, VALID_PASSWORD)
+      const submitButton = screen.getByRole('button', { name: /create account/i })
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
+        expect(submitButton).not.toBeDisabled()
       })
-      submitForm()
+      await user.click(submitButton)
       await waitFor(() => {
         expect(registerTrigger).toHaveBeenCalledWith({
           email: VALID_EMAIL,
@@ -215,13 +221,14 @@ describe('RegisterPage', () => {
           },
         },
       })
-      renderRegister()
-      fillEmail(VALID_EMAIL)
-      fillPassword(VALID_PASSWORD)
+      const { user } = renderRegister()
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, VALID_PASSWORD)
+      const submitButton = screen.getByRole('button', { name: /create account/i })
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
+        expect(submitButton).not.toBeDisabled()
       })
-      submitForm()
+      await user.click(submitButton)
       expect(await screen.findByText('Email is already in use.')).toBeInTheDocument()
       expect(await screen.findByText('Password does not meet the policy.')).toBeInTheDocument()
       // Auto-login should NOT fire when register fails.
@@ -233,13 +240,14 @@ describe('RegisterPage', () => {
         status: 409,
         data: { title: 'This email is already registered.', status: 409 },
       })
-      renderRegister()
-      fillEmail(VALID_EMAIL)
-      fillPassword(VALID_PASSWORD)
+      const { user } = renderRegister()
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, VALID_PASSWORD)
+      const submitButton = screen.getByRole('button', { name: /create account/i })
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
+        expect(submitButton).not.toBeDisabled()
       })
-      submitForm()
+      await user.click(submitButton)
       const alert = await screen.findByTestId('form-alert')
       expect(alert).toHaveTextContent('This email is already registered.')
       expect(loginTrigger).not.toHaveBeenCalled()
@@ -251,27 +259,36 @@ describe('RegisterPage', () => {
         status: 500,
         data: { title: 'Temporary sign-in failure — please sign in manually.', status: 500 },
       })
-      renderRegister()
-      fillEmail(VALID_EMAIL)
-      fillPassword(VALID_PASSWORD)
+      const { store, user } = renderRegister()
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, VALID_PASSWORD)
+      const submitButton = screen.getByRole('button', { name: /create account/i })
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
+        expect(submitButton).not.toBeDisabled()
       })
-      submitForm()
+      await user.click(submitButton)
       const alert = await screen.findByTestId('form-alert')
       expect(alert).toHaveTextContent(/temporary sign-in failure/i)
       expect(navigateMock).not.toHaveBeenCalled()
+      // Register succeeded, login failed — the Redux slice MUST stay in its
+      // pre-submit state rather than flip to authenticated. Guards against
+      // a future refactor that accidentally dispatches `sessionVerified`
+      // outside the `try` that awaits login.
+      const state = store.getState()
+      expect(state.auth.status).toBe('unknown')
+      expect(state.auth.user).toBeNull()
     })
 
     it('falls back to a generic alert when the server omits a title', async () => {
       registerUnwrap.mockRejectedValue({ status: 500, data: {} })
-      renderRegister()
-      fillEmail(VALID_EMAIL)
-      fillPassword(VALID_PASSWORD)
+      const { user } = renderRegister()
+      await fillEmail(user, VALID_EMAIL)
+      await fillPassword(user, VALID_PASSWORD)
+      const submitButton = screen.getByRole('button', { name: /create account/i })
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
+        expect(submitButton).not.toBeDisabled()
       })
-      submitForm()
+      await user.click(submitButton)
       const alert = await screen.findByTestId('form-alert')
       expect(alert).toHaveTextContent(/registration failed/i)
     })

--- a/frontend/src/app/pages/register/register.page.spec.tsx
+++ b/frontend/src/app/pages/register/register.page.spec.tsx
@@ -1,0 +1,279 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { authSlice } from '~/modules/auth/store/auth.slice'
+
+const { registerUnwrap, registerTrigger, loginUnwrap, loginTrigger, navigateMock } = vi.hoisted(
+  () => {
+    const rUnwrap = vi.fn()
+    const lUnwrap = vi.fn()
+    return {
+      registerUnwrap: rUnwrap,
+      registerTrigger: vi.fn(() => ({ unwrap: rUnwrap })),
+      loginUnwrap: lUnwrap,
+      loginTrigger: vi.fn(() => ({ unwrap: lUnwrap })),
+      navigateMock: vi.fn(),
+    }
+  },
+)
+
+vi.mock('~/api/auth.api', () => ({
+  useRegisterMutation: () => [registerTrigger, { isLoading: false }],
+  useLoginMutation: () => [loginTrigger, { isLoading: false }],
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+import { RegisterPage } from './register.page'
+
+const makeStore = () => configureStore({ reducer: { [authSlice.name]: authSlice.reducer } })
+
+const renderRegister = () => {
+  const store = makeStore()
+  return {
+    store,
+    ...render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/register']}>
+          <RegisterPage />
+        </MemoryRouter>
+      </Provider>,
+    ),
+  }
+}
+
+const fillEmail = (value: string): void => {
+  fireEvent.change(screen.getByLabelText(/email/i), { target: { value } })
+}
+
+const fillPassword = (value: string): void => {
+  fireEvent.change(screen.getByLabelText(/password/i), { target: { value } })
+}
+
+const submitForm = (): void => {
+  const form = document.querySelector('form')
+  if (form === null) throw new Error('Register form not found')
+  fireEvent.submit(form)
+}
+
+const VALID_EMAIL = 'runner@example.com'
+// Mirrors the backend's ASP.NET Identity policy: ≥ 12 chars, upper + lower +
+// digit + non-alphanumeric (Program.cs lines 108–127 / auth.schema.ts).
+const VALID_PASSWORD = 'StrongPassw0rd!'
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    registerUnwrap.mockReset()
+    registerTrigger.mockClear()
+    loginUnwrap.mockReset()
+    loginTrigger.mockClear()
+    navigateMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('client-side validation', () => {
+    it('shows validation errors when the form is submitted empty and does not invoke the mutation', async () => {
+      renderRegister()
+      submitForm()
+      // Register uses `emailSchema` which runs `.email()` before `.min(1)`,
+      // so an empty value surfaces the format message first. The login page
+      // uses a permissive schema and surfaces "Email is required." instead.
+      expect(await screen.findByText('Email must be a valid address.')).toBeInTheDocument()
+      expect(
+        await screen.findByText(/password must be at least 12 characters/i),
+      ).toBeInTheDocument()
+      expect(registerTrigger).not.toHaveBeenCalled()
+    })
+
+    it('rejects an improperly formatted email', async () => {
+      renderRegister()
+      fillEmail('not-an-email')
+      fillPassword(VALID_PASSWORD)
+      submitForm()
+      expect(await screen.findByText('Email must be a valid address.')).toBeInTheDocument()
+      expect(registerTrigger).not.toHaveBeenCalled()
+    })
+
+    describe('weak-password validation mirrors the backend Identity policy', () => {
+      it('rejects a too-short password (< 12 chars)', async () => {
+        renderRegister()
+        fillEmail(VALID_EMAIL)
+        fillPassword('Short1!')
+        submitForm()
+        expect(
+          await screen.findByText(/password must be at least 12 characters/i),
+        ).toBeInTheDocument()
+        expect(registerTrigger).not.toHaveBeenCalled()
+      })
+
+      it('rejects a password missing an uppercase letter', async () => {
+        renderRegister()
+        fillEmail(VALID_EMAIL)
+        fillPassword('lowercase0!word')
+        submitForm()
+        expect(
+          await screen.findByText(/password must contain an uppercase letter/i),
+        ).toBeInTheDocument()
+      })
+
+      it('rejects a password missing a lowercase letter', async () => {
+        renderRegister()
+        fillEmail(VALID_EMAIL)
+        fillPassword('UPPERCASE0!WORD')
+        submitForm()
+        expect(
+          await screen.findByText(/password must contain a lowercase letter/i),
+        ).toBeInTheDocument()
+      })
+
+      it('rejects a password missing a digit', async () => {
+        renderRegister()
+        fillEmail(VALID_EMAIL)
+        fillPassword('NoDigitsHere!!')
+        submitForm()
+        expect(await screen.findByText(/password must contain a digit/i)).toBeInTheDocument()
+      })
+
+      it('rejects a password missing a non-alphanumeric character', async () => {
+        renderRegister()
+        fillEmail(VALID_EMAIL)
+        fillPassword('NoSymbolHere0')
+        submitForm()
+        expect(
+          await screen.findByText(/password must contain a non-alphanumeric character/i),
+        ).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('submit button gating', () => {
+    it('is disabled while the form is structurally invalid', () => {
+      renderRegister()
+      expect(screen.getByRole('button', { name: /create account/i })).toBeDisabled()
+    })
+
+    it('becomes enabled only when email + policy-compliant password are present', async () => {
+      renderRegister()
+      fillEmail(VALID_EMAIL)
+      fillPassword(VALID_PASSWORD)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
+      })
+    })
+  })
+
+  describe('happy-path submission', () => {
+    it('chains register + login, dispatches sessionVerified, and navigates to "/"', async () => {
+      registerUnwrap.mockResolvedValue({ userId: 'usr_abc', email: VALID_EMAIL })
+      loginUnwrap.mockResolvedValue({ userId: 'usr_abc', email: VALID_EMAIL })
+      const { store } = renderRegister()
+      fillEmail(VALID_EMAIL)
+      fillPassword(VALID_PASSWORD)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
+      })
+      submitForm()
+      await waitFor(() => {
+        expect(registerTrigger).toHaveBeenCalledWith({
+          email: VALID_EMAIL,
+          password: VALID_PASSWORD,
+        })
+      })
+      await waitFor(() => {
+        expect(loginTrigger).toHaveBeenCalledWith({
+          email: VALID_EMAIL,
+          password: VALID_PASSWORD,
+        })
+      })
+      await waitFor(() => {
+        expect(navigateMock).toHaveBeenCalledWith('/', { replace: true })
+      })
+      const state = store.getState()
+      expect(state.auth.status).toBe('authenticated')
+      expect(state.auth.user).toEqual({ userId: 'usr_abc', email: VALID_EMAIL })
+    })
+  })
+
+  describe('server-side error surfacing', () => {
+    it('renders ValidationProblemDetails.errors at the field level from the register response', async () => {
+      registerUnwrap.mockRejectedValue({
+        status: 400,
+        data: {
+          title: 'One or more validation errors occurred.',
+          status: 400,
+          errors: {
+            Email: ['Email is already in use.'],
+            Password: ['Password does not meet the policy.'],
+          },
+        },
+      })
+      renderRegister()
+      fillEmail(VALID_EMAIL)
+      fillPassword(VALID_PASSWORD)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
+      })
+      submitForm()
+      expect(await screen.findByText('Email is already in use.')).toBeInTheDocument()
+      expect(await screen.findByText('Password does not meet the policy.')).toBeInTheDocument()
+      // Auto-login should NOT fire when register fails.
+      expect(loginTrigger).not.toHaveBeenCalled()
+    })
+
+    it('renders ProblemDetails.title as a non-field-level alert on register failure', async () => {
+      registerUnwrap.mockRejectedValue({
+        status: 409,
+        data: { title: 'This email is already registered.', status: 409 },
+      })
+      renderRegister()
+      fillEmail(VALID_EMAIL)
+      fillPassword(VALID_PASSWORD)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
+      })
+      submitForm()
+      const alert = await screen.findByTestId('form-alert')
+      expect(alert).toHaveTextContent('This email is already registered.')
+      expect(loginTrigger).not.toHaveBeenCalled()
+    })
+
+    it('surfaces a distinct alert when register succeeds but the auto-login step fails', async () => {
+      registerUnwrap.mockResolvedValue({ userId: 'usr_abc', email: VALID_EMAIL })
+      loginUnwrap.mockRejectedValue({
+        status: 500,
+        data: { title: 'Temporary sign-in failure — please sign in manually.', status: 500 },
+      })
+      renderRegister()
+      fillEmail(VALID_EMAIL)
+      fillPassword(VALID_PASSWORD)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
+      })
+      submitForm()
+      const alert = await screen.findByTestId('form-alert')
+      expect(alert).toHaveTextContent(/temporary sign-in failure/i)
+      expect(navigateMock).not.toHaveBeenCalled()
+    })
+
+    it('falls back to a generic alert when the server omits a title', async () => {
+      registerUnwrap.mockRejectedValue({ status: 500, data: {} })
+      renderRegister()
+      fillEmail(VALID_EMAIL)
+      fillPassword(VALID_PASSWORD)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
+      })
+      submitForm()
+      const alert = await screen.findByTestId('form-alert')
+      expect(alert).toHaveTextContent(/registration failed/i)
+    })
+  })
+})

--- a/frontend/src/app/pages/register/register.page.spec.tsx
+++ b/frontend/src/app/pages/register/register.page.spec.tsx
@@ -83,10 +83,10 @@ describe('RegisterPage', () => {
     it('shows validation errors when the form is submitted empty and does not invoke the mutation', async () => {
       renderRegister()
       submitForm()
-      // Register uses `emailSchema` which runs `.email()` before `.min(1)`,
-      // so an empty value surfaces the format message first. The login page
-      // uses a permissive schema and surfaces "Email is required." instead.
-      expect(await screen.findByText('Email must be a valid address.')).toBeInTheDocument()
+      // `emailSchema` trims first so `.min(1)` surfaces "Email is required."
+      // on an empty submission; the dedicated format test below covers the
+      // `.email()` failure path for malformed-but-non-empty input.
+      expect(await screen.findByText('Email is required.')).toBeInTheDocument()
       expect(
         await screen.findByText(/password must be at least 12 characters/i),
       ).toBeInTheDocument()

--- a/frontend/src/app/pages/register/register.page.tsx
+++ b/frontend/src/app/pages/register/register.page.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useDispatch } from 'react-redux'
 import { Link, useNavigate } from 'react-router-dom'
 
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useForm } from 'react-hook-form'
-import { useDispatch } from 'react-redux'
 
 import { useLoginMutation, useRegisterMutation } from '~/api/auth.api'
 import { parseProblem } from '~/modules/auth/helpers/problem-details.helpers'

--- a/frontend/src/app/pages/register/register.page.tsx
+++ b/frontend/src/app/pages/register/register.page.tsx
@@ -10,6 +10,7 @@ import { parseProblem } from '~/modules/auth/helpers/problem-details.helpers'
 import { registerSchema, type RegisterFormValues } from '~/modules/auth/schemas/auth.schema'
 import { sessionVerified } from '~/modules/auth/store/auth.slice'
 import type { AppDispatch } from '~/modules/app/app.store'
+import { RegisterForm } from './register-form.component'
 
 // Register → Login chained flow. The backend `register` endpoint
 // deliberately does NOT auto-authenticate (AuthController.Register
@@ -60,84 +61,11 @@ const RegisterPage = () => {
   }
 
   const isLoading = registerState.isLoading || loginState.isLoading
-  const isSubmitDisabled = !form.formState.isValid || isLoading
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
       <section className="w-full max-w-sm rounded-lg bg-white p-6 shadow">
-        <h1 className="mb-4 text-2xl font-semibold">Create your account</h1>
-
-        {formAlert !== null && (
-          <div
-            role="alert"
-            data-testid="form-alert"
-            className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
-          >
-            {formAlert}
-          </div>
-        )}
-
-        <form noValidate onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-          <div>
-            <label htmlFor="register-email" className="block text-sm font-medium">
-              Email
-            </label>
-            <input
-              id="register-email"
-              type="email"
-              autoComplete="email"
-              autoFocus
-              aria-invalid={form.formState.errors.email !== undefined}
-              aria-describedby={
-                form.formState.errors.email === undefined ? undefined : 'register-email-error'
-              }
-              className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
-              {...form.register('email')}
-            />
-            {form.formState.errors.email !== undefined && (
-              <p id="register-email-error" role="alert" className="mt-1 text-xs text-red-700">
-                {form.formState.errors.email.message}
-              </p>
-            )}
-          </div>
-
-          <div>
-            <label htmlFor="register-password" className="block text-sm font-medium">
-              Password
-            </label>
-            <input
-              id="register-password"
-              type="password"
-              autoComplete="new-password"
-              aria-invalid={form.formState.errors.password !== undefined}
-              aria-describedby={
-                form.formState.errors.password === undefined
-                  ? 'register-password-hint'
-                  : 'register-password-error'
-              }
-              className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
-              {...form.register('password')}
-            />
-            {form.formState.errors.password === undefined ? (
-              <p id="register-password-hint" className="mt-1 text-xs text-slate-500">
-                At least 12 characters, with upper &amp; lower case letters, a digit, and a
-                non-alphanumeric character.
-              </p>
-            ) : (
-              <p id="register-password-error" role="alert" className="mt-1 text-xs text-red-700">
-                {form.formState.errors.password.message}
-              </p>
-            )}
-          </div>
-
-          <button
-            type="submit"
-            disabled={isSubmitDisabled}
-            className="w-full rounded bg-slate-900 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {isLoading ? 'Creating account…' : 'Create account'}
-          </button>
-        </form>
+        <RegisterForm form={form} onSubmit={onSubmit} isLoading={isLoading} formAlert={formAlert} />
 
         <p className="mt-4 text-sm text-slate-600">
           Already have an account?{' '}

--- a/frontend/src/app/pages/register/register.page.tsx
+++ b/frontend/src/app/pages/register/register.page.tsx
@@ -34,8 +34,9 @@ const RegisterPage = () => {
     } catch (error) {
       const parsed = parseProblem(error)
       for (const [field, messages] of Object.entries(parsed.fieldErrors)) {
-        if ((field === 'email' || field === 'password') && messages[0]) {
-          form.setError(field, { type: 'server', message: messages[0] })
+        const firstMessage = messages[0]
+        if ((field === 'email' || field === 'password') && firstMessage !== undefined) {
+          form.setError(field, { type: 'server', message: firstMessage })
         }
       }
       setFormAlert(parsed.title ?? 'Registration failed. Please try again.')
@@ -86,7 +87,7 @@ const RegisterPage = () => {
               autoFocus
               aria-invalid={form.formState.errors.email !== undefined}
               aria-describedby={
-                form.formState.errors.email !== undefined ? 'register-email-error' : undefined
+                form.formState.errors.email === undefined ? undefined : 'register-email-error'
               }
               className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
               {...form.register('email')}
@@ -108,9 +109,9 @@ const RegisterPage = () => {
               autoComplete="new-password"
               aria-invalid={form.formState.errors.password !== undefined}
               aria-describedby={
-                form.formState.errors.password !== undefined
-                  ? 'register-password-error'
-                  : 'register-password-hint'
+                form.formState.errors.password === undefined
+                  ? 'register-password-hint'
+                  : 'register-password-error'
               }
               className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
               {...form.register('password')}

--- a/frontend/src/app/pages/register/register.page.tsx
+++ b/frontend/src/app/pages/register/register.page.tsx
@@ -1,8 +1,10 @@
-import { zodResolver } from '@hookform/resolvers/zod'
 import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+
+import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { useDispatch } from 'react-redux'
-import { Link, useNavigate } from 'react-router-dom'
+
 import { useLoginMutation, useRegisterMutation } from '~/api/auth.api'
 import { parseProblem } from '~/modules/auth/helpers/problem-details.helpers'
 import { registerSchema, type RegisterFormValues } from '~/modules/auth/schemas/auth.schema'

--- a/frontend/src/app/pages/register/register.page.tsx
+++ b/frontend/src/app/pages/register/register.page.tsx
@@ -1,0 +1,151 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useDispatch } from 'react-redux'
+import { Link, useNavigate } from 'react-router-dom'
+import { useLoginMutation, useRegisterMutation } from '~/api/auth.api'
+import { parseProblem } from '~/modules/auth/helpers/problem-details.helpers'
+import { registerSchema, type RegisterFormValues } from '~/modules/auth/schemas/auth.schema'
+import { sessionVerified } from '~/modules/auth/store/auth.slice'
+import type { AppDispatch } from '~/modules/app/app.store'
+
+// Register → Login chained flow. The backend `register` endpoint
+// deliberately does NOT auto-authenticate (AuthController.Register
+// returns 201 + AuthResponseDto only; no Set-Cookie). After a successful
+// register, immediately log the user in with the same credentials so the
+// UX lands on `/` authenticated.
+const RegisterPage = () => {
+  const dispatch = useDispatch<AppDispatch>()
+  const navigate = useNavigate()
+  const [registerUser, registerState] = useRegisterMutation()
+  const [login, loginState] = useLoginMutation()
+  const [formAlert, setFormAlert] = useState<string | null>(null)
+
+  const form = useForm<RegisterFormValues>({
+    resolver: zodResolver(registerSchema),
+    mode: 'onChange',
+    defaultValues: { email: '', password: '' },
+  })
+
+  const onSubmit = async (values: RegisterFormValues): Promise<void> => {
+    setFormAlert(null)
+    try {
+      await registerUser(values).unwrap()
+    } catch (error) {
+      const parsed = parseProblem(error)
+      for (const [field, messages] of Object.entries(parsed.fieldErrors)) {
+        if ((field === 'email' || field === 'password') && messages[0]) {
+          form.setError(field, { type: 'server', message: messages[0] })
+        }
+      }
+      setFormAlert(parsed.title ?? 'Registration failed. Please try again.')
+      return
+    }
+
+    try {
+      const response = await login(values).unwrap()
+      dispatch(sessionVerified({ userId: response.userId, email: response.email }))
+      navigate('/', { replace: true })
+    } catch (error) {
+      // Account was created but auto-login failed — surface the issue and
+      // let the user log in manually via /login.
+      const parsed = parseProblem(error)
+      setFormAlert(
+        parsed.title ?? 'Account created but sign-in failed. Please sign in from the login page.',
+      )
+    }
+  }
+
+  const isLoading = registerState.isLoading || loginState.isLoading
+  const isSubmitDisabled = !form.formState.isValid || isLoading
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
+      <section className="w-full max-w-sm rounded-lg bg-white p-6 shadow">
+        <h1 className="mb-4 text-2xl font-semibold">Create your account</h1>
+
+        {formAlert !== null && (
+          <div
+            role="alert"
+            data-testid="form-alert"
+            className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+          >
+            {formAlert}
+          </div>
+        )}
+
+        <form noValidate onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label htmlFor="register-email" className="block text-sm font-medium">
+              Email
+            </label>
+            <input
+              id="register-email"
+              type="email"
+              autoComplete="email"
+              autoFocus
+              aria-invalid={form.formState.errors.email !== undefined}
+              aria-describedby={
+                form.formState.errors.email !== undefined ? 'register-email-error' : undefined
+              }
+              className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
+              {...form.register('email')}
+            />
+            {form.formState.errors.email !== undefined && (
+              <p id="register-email-error" role="alert" className="mt-1 text-xs text-red-700">
+                {form.formState.errors.email.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor="register-password" className="block text-sm font-medium">
+              Password
+            </label>
+            <input
+              id="register-password"
+              type="password"
+              autoComplete="new-password"
+              aria-invalid={form.formState.errors.password !== undefined}
+              aria-describedby={
+                form.formState.errors.password !== undefined
+                  ? 'register-password-error'
+                  : 'register-password-hint'
+              }
+              className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm"
+              {...form.register('password')}
+            />
+            {form.formState.errors.password === undefined ? (
+              <p id="register-password-hint" className="mt-1 text-xs text-slate-500">
+                At least 12 characters, with upper &amp; lower case letters, a digit, and a
+                non-alphanumeric character.
+              </p>
+            ) : (
+              <p id="register-password-error" role="alert" className="mt-1 text-xs text-red-700">
+                {form.formState.errors.password.message}
+              </p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitDisabled}
+            className="w-full rounded bg-slate-900 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isLoading ? 'Creating account…' : 'Create account'}
+          </button>
+        </form>
+
+        <p className="mt-4 text-sm text-slate-600">
+          Already have an account?{' '}
+          <Link to="/login" className="font-medium text-slate-900 underline">
+            Sign in
+          </Link>
+        </p>
+      </section>
+    </main>
+  )
+}
+
+export default RegisterPage
+export { RegisterPage }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import basicSsl from '@vitejs/plugin-basic-ssl'
 import tailwindcss from '@tailwindcss/vite'
@@ -69,5 +69,8 @@ export default defineConfig({
     },
     setupFiles: './src/test-setup.ts',
     css: true,
+    // `e2e/` holds Playwright specs that import `@playwright/test` and
+    // drive a real browser; Vitest must leave them alone.
+    exclude: [...configDefaults.exclude, 'e2e/**'],
   },
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -46,6 +46,13 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    // jsdom URL mirrors the Vite dev server so relative API paths (e.g.
+    // `/api/...`) resolve cleanly inside RTK Query / fetch, and so
+    // `document.cookie` interactions against `__Host-`-prefixed cookies
+    // behave like they do against the real dev server.
+    environmentOptions: {
+      jsdom: { url: 'https://localhost:5173/' },
+    },
     setupFiles: './src/test-setup.ts',
     css: true,
   },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import basicSsl from '@vitejs/plugin-basic-ssl'
 import tailwindcss from '@tailwindcss/vite'
+import fs from 'node:fs'
 import path from 'node:path'
 
 // Vite dev server runs on HTTPS (port 5173) and proxies `/api/*` to the
@@ -11,9 +12,14 @@ import path from 'node:path'
 // `__Host-` prefix, which browsers silently drop over plain HTTP. See
 // CONTRIBUTING.md "Local HTTPS is required" for the full contract.
 //
-// `@vitejs/plugin-basic-ssl` generates a self-signed cert at startup — zero
-// install, one-time browser accept. Contributors who want a trusted cert
-// use the mkcert escape hatch documented in CONTRIBUTING.md.
+// Two cert strategies, picked at config time:
+//   1. If `.cert/cert.pem` + `.cert/key.pem` are present (mkcert output),
+//      the dev server serves them directly via `server.https` — browser
+//      padlock is green, no "Not Secure" chip.
+//   2. Otherwise `@vitejs/plugin-basic-ssl` generates a fresh self-signed
+//      cert at startup — zero install, one-time browser accept, CI-safe.
+// CONTRIBUTING.md has the mkcert recipe for contributors who want the
+// trusted-cert path.
 //
 // The `/api` proxy preserves the `__Host-` cookie contract:
 //   - `secure: false` accepts the ASP.NET Core dev cert (self-signed).
@@ -23,8 +29,15 @@ import path from 'node:path'
 //     Set-Cookie headers. The backend does not set one today, so this is a
 //     belt-and-suspenders guard — `__Host-` prefix rejects cookies that
 //     carry a Domain attribute.
+const mkcertCertPath = path.resolve(__dirname, '.cert/cert.pem')
+const mkcertKeyPath = path.resolve(__dirname, '.cert/key.pem')
+const mkcertPresent = fs.existsSync(mkcertCertPath) && fs.existsSync(mkcertKeyPath)
+const httpsConfig = mkcertPresent
+  ? { cert: fs.readFileSync(mkcertCertPath), key: fs.readFileSync(mkcertKeyPath) }
+  : undefined
+
 export default defineConfig({
-  plugins: [react(), basicSsl(), tailwindcss()],
+  plugins: [react(), ...(mkcertPresent ? [] : [basicSsl()]), tailwindcss()],
   resolve: {
     alias: {
       '~': path.resolve(__dirname, './src/app'),
@@ -34,6 +47,7 @@ export default defineConfig({
     host: 'localhost',
     port: 5173,
     strictPort: true,
+    https: httpsConfig,
     proxy: {
       '/api': {
         target: 'https://localhost:5001',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,13 +1,46 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import basicSsl from '@vitejs/plugin-basic-ssl'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'node:path'
 
+// Vite dev server runs on HTTPS (port 5173) and proxies `/api/*` to the
+// ASP.NET Core API on https://localhost:5001.
+//
+// HTTPS on the dev server is a hard requirement: the auth cookies use the
+// `__Host-` prefix, which browsers silently drop over plain HTTP. See
+// CONTRIBUTING.md "Local HTTPS is required" for the full contract.
+//
+// `@vitejs/plugin-basic-ssl` generates a self-signed cert at startup — zero
+// install, one-time browser accept. Contributors who want a trusted cert
+// use the mkcert escape hatch documented in CONTRIBUTING.md.
+//
+// The `/api` proxy preserves the `__Host-` cookie contract:
+//   - `secure: false` accepts the ASP.NET Core dev cert (self-signed).
+//   - `changeOrigin: true` rewrites the Host header so backend CORS /
+//     antiforgery see the target origin, not the Vite origin.
+//   - `cookieDomainRewrite: ''` strips any `Domain=` attribute from upstream
+//     Set-Cookie headers. The backend does not set one today, so this is a
+//     belt-and-suspenders guard — `__Host-` prefix rejects cookies that
+//     carry a Domain attribute.
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), basicSsl(), tailwindcss()],
   resolve: {
     alias: {
       '~': path.resolve(__dirname, './src/app'),
+    },
+  },
+  server: {
+    host: 'localhost',
+    port: 5173,
+    strictPort: true,
+    proxy: {
+      '/api': {
+        target: 'https://localhost:5001',
+        secure: false,
+        changeOrigin: true,
+        cookieDomainRewrite: '',
+      },
     },
   },
   test: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -72,5 +72,20 @@ export default defineConfig({
     // `e2e/` holds Playwright specs that import `@playwright/test` and
     // drive a real browser; Vitest must leave them alone.
     exclude: [...configDefaults.exclude, 'e2e/**'],
+    coverage: {
+      provider: 'v8',
+      // `lcov` feeds SonarCloud (sonar-project.properties points at
+      // `coverage/lcov.info`); `text` keeps a readable summary in CI logs;
+      // `html` stays useful locally for drilling into uncovered lines.
+      reporter: ['text', 'lcov', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.spec.{ts,tsx}',
+        'src/**/*.test.{ts,tsx}',
+        'src/main.tsx',
+        'src/test-setup.ts',
+        'src/vite-env.d.ts',
+      ],
+    },
   },
 })


### PR DESCRIPTION
## Summary

Slice 0 Unit 3 — ships the browser-facing auth loop against the Unit 2 API. Closes Slice 0.

- `/login`, `/register`, protected `/` home via React Router v7 + React Hook Form + Zod; schemas mirror the backend's Identity password policy + `RegisterRequestDto` DataAnnotations.
- RTK Query base query: `credentials: 'include'` on every call, `X-XSRF-TOKEN` header on mutations only (reads the URL-decoded `XSRF-TOKEN` cookie), 401-anywhere dispatches `loggedOut` + redirects to `/login`. No refresh-retry mutex — Identity's sliding-expiration cookie renews on every honored request, so 401 means "actually logged out."
- App-boot sequence calls `GET /api/v1/auth/xsrf` then `GET /api/v1/auth/me` to seed the antiforgery cookie and resolve session state.
- Auth slice holds `{ status, user }` only — **no token-shaped fields anywhere**. `grep -rn "tokenStore\|localStorage.setItem.*token" frontend/src/` returns zero matches.
- Optional cross-tab `BroadcastChannel('auth')` listener (≤ 15 lines, native API, no npm dep).
- `ValidationProblemDetails` field errors surface next to form fields; `ProblemDetails.title` renders as a non-field-level alert.
- React pinned to 19.2.5 per R-044.
- Vite dev server upgraded to HTTPS (T03.0) so `__Host-` cookies survive; `/api` proxy strips upstream `Domain=` attributes.
- One Playwright happy-path E2E — register → authenticated home → reload → logout → assert `__Host-RunCoach` cookie cleared. Unique-email-per-run + `npm run e2e:clean` flushes orphan dev rows (documented in CONTRIBUTING.md § "Running the Playwright E2E").
- Unit tests cover login/register pages, auth slice, base query: 50 assertions pass.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — 0 errors, clean TS check
- [x] `npm run test` — 50/50 pass across 5 files
- [x] `npx playwright test --list` — 1 happy-path test discovered
- [x] `npm run e2e` against live stack — user-confirmed green (register → home → reload → logout → cookie cleared)
- [ ] Manual browser smoke: `docker compose up -d postgres redis`, host-run backend + Vite, register → see home → reload → logout → re-register works
- [ ] CI green: CodeRabbit, CodeQL, SonarQube Cloud, license-review, Codecov, Trivy

## Spec + follow-ups

Spec: `docs/specs/12-spec-slice-0-foundation/12-spec-slice-0-foundation.md` § Unit 3.
Feature: `docs/specs/12-spec-slice-0-foundation/frontend-auth-ux.feature` (14 Gherkin scenarios).

### Follow-ups found

- On merge: update `ROADMAP.md` + `docs/plans/mvp-0-cycle/cycle-plan.md` Status blocks per the per-slice hygiene rule, marking Slice 0 complete and pointing at Slice 1.
- Shared-contracts contract test (backend `RegisterRequest` DataAnnotations ↔ frontend `registerSchema`) — deferred to T03.1 follow-up per R-058/DEC-052 integration notes.
- Testing-env reset endpoint for future E2Es — Slice 0's one happy path is fine with unique-email-per-run; graduate to a gated `_test/reset` endpoint or dedicated e2e Postgres overlay once multiple E2Es need empty-DB assertions.
- Wrong-credentials ProblemDetails screenshot (spec § Unit 3 proof artefact line 130) — intentionally skipped; live E2E + unit-tier coverage already prove the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Complete auth UX: register, login, logout, persistent sessions, route guard, cross-tab logout, and Sign out on Home.
  * Client-side validation and form UX for register/login; improved API/XSRF handling for secure cookies.

* **Tests**
  * Playwright E2E for full auth flows with npm scripts to run and clean E2E state.
  * Expanded unit/integration tests covering auth, XSRF/base-query, and UI flows.

* **Documentation**
  * CONTRIBUTING updated with frontend HTTPS/dev run, proxy/cookie troubleshooting, and Playwright E2E instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->