### PR TITLE
feat(plan): unit 5 regenerate dialog, intent handler, idempotency, and otel test isolation

### DIFF
--- a/backend/src/RunCoach.Api/Modules/Coaching/Models/RegenerationIntent.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Models/RegenerationIntent.cs
@@ -17,15 +17,39 @@ namespace RunCoach.Api.Modules.Coaching.Models;
 /// does NOT re-sanitize.
 /// </para>
 /// <para>
-/// Capped at <see cref="MaxFreeTextLength"/> characters at construction; the
-/// 500-char cap is a placeholder per the spec's "Open Considerations" — see
-/// Slice 1 spec § Open Considerations for review criteria.
+/// Capped at <see cref="MaxFreeTextLength"/> characters at construction. The
+/// cap is sized to admit the post-sanitization payload: the wire-level raw
+/// input is capped at <see cref="RawMaxFreeTextLength"/> by the controller,
+/// and the layered sanitizer wraps the content with a Spotlighting delimiter
+/// (e.g. <c>&lt;REGENERATION_INTENT id="..."&gt;…&lt;/REGENERATION_INTENT&gt;</c>)
+/// that adds up to <see cref="DelimiterOverhead"/> additional characters.
 /// </para>
 /// </param>
 public sealed record RegenerationIntent
 {
-    /// <summary>Maximum allowed length of <see cref="FreeText"/> in UTF-16 code units.</summary>
-    public const int MaxFreeTextLength = 500;
+    /// <summary>
+    /// Maximum allowed length of the raw, pre-sanitization free-text supplied on
+    /// the wire. Per Slice 1 spec § Unit 5 R05.1 this is the wire contract: the
+    /// controller validates the raw request body against this cap and rejects
+    /// over-length input with HTTP 400 BEFORE invoking the sanitizer.
+    /// </summary>
+    public const int RawMaxFreeTextLength = 500;
+
+    /// <summary>
+    /// Upper bound on the per-call delimiter overhead the layered sanitizer
+    /// appends when wrapping the runner's free-text in a Spotlighting block.
+    /// Sized to admit the longest delimiter label + a 16-hex-character per-turn
+    /// nonce + the closing tag with comfortable headroom for future labels.
+    /// </summary>
+    public const int DelimiterOverhead = 200;
+
+    /// <summary>
+    /// Maximum allowed length of <see cref="FreeText"/> in UTF-16 code units.
+    /// Equal to <see cref="RawMaxFreeTextLength"/> + <see cref="DelimiterOverhead"/>
+    /// so a sanitizer-wrapped at-cap raw input round-trips through this record
+    /// without spurious construction failures.
+    /// </summary>
+    public const int MaxFreeTextLength = RawMaxFreeTextLength + DelimiterOverhead;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RegenerationIntent"/> record.

--- a/backend/src/RunCoach.Api/Modules/Coaching/Models/RegenerationIntent.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Models/RegenerationIntent.cs
@@ -44,12 +44,24 @@ public sealed record RegenerationIntent
     public const int DelimiterOverhead = 200;
 
     /// <summary>
-    /// Maximum allowed length of <see cref="FreeText"/> in UTF-16 code units.
-    /// Equal to <see cref="RawMaxFreeTextLength"/> + <see cref="DelimiterOverhead"/>
-    /// so a sanitizer-wrapped at-cap raw input round-trips through this record
-    /// without spurious construction failures.
+    /// Worst-case multiplier the layered sanitizer's <c>EscapeDelimiterBody</c>
+    /// applies to the raw body. The most aggressive expansion is <c>&amp;</c> → <c>&amp;amp;</c> (1→5).
+    /// Sized as 5 to admit any combination of bracket-escape and homoglyph-rewrite
+    /// without throwing on construction.
     /// </summary>
-    public const int MaxFreeTextLength = RawMaxFreeTextLength + DelimiterOverhead;
+    public const int MaxEscapeExpansionFactor = 5;
+
+    /// <summary>
+    /// Maximum allowed length of <see cref="FreeText"/> in UTF-16 code units.
+    /// Accounts for worst-case adversarial-bracket expansion by
+    /// <c>EscapeDelimiterBody</c> (e.g. a 500-char input of all <c>&amp;</c> characters
+    /// expands to 2500 chars after entity-escaping) plus the Spotlighting
+    /// delimiter overhead. Equal to
+    /// <see cref="RawMaxFreeTextLength"/> × <see cref="MaxEscapeExpansionFactor"/> +
+    /// <see cref="DelimiterOverhead"/> so any at-cap raw input round-trips through
+    /// this record without spurious construction failures.
+    /// </summary>
+    public const int MaxFreeTextLength = (RawMaxFreeTextLength * MaxEscapeExpansionFactor) + DelimiterOverhead;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RegenerationIntent"/> record.

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanRenderingController.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanRenderingController.cs
@@ -57,6 +57,7 @@ public sealed partial class PlanRenderingController(
     private const string MissingUserType = "https://runcoach.app/problems/missing-user-claim";
     private const string OnboardingNotCompleteType = "https://runcoach.app/problems/onboarding-not-complete";
     private const string InvalidIdempotencyKeyType = "https://runcoach.app/problems/invalid-idempotency-key";
+    private const string IntentTooLongType = "https://runcoach.app/problems/regeneration-intent-too-long";
 
     /// <summary>GET /api/v1/plan/current — read the user's active plan projection.</summary>
     /// <remarks>
@@ -216,6 +217,7 @@ public sealed partial class PlanRenderingController(
             if (rawText.Length > RegenerationIntent.RawMaxFreeTextLength)
             {
                 return Problem(
+                    type: IntentTooLongType,
                     title: "Regeneration intent is too long.",
                     detail: $"intent.freeText must be at most {RegenerationIntent.RawMaxFreeTextLength} characters; got {rawText.Length}.",
                     statusCode: StatusCodes.Status400BadRequest);

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanRenderingController.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanRenderingController.cs
@@ -5,7 +5,11 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.JsonWebTokens;
 using RunCoach.Api.Infrastructure;
+using RunCoach.Api.Modules.Coaching.Models;
 using RunCoach.Api.Modules.Training.Plan.Models;
+using Wolverine;
+using IPromptSanitizer = RunCoach.Api.Modules.Coaching.Sanitization.IPromptSanitizer;
+using SanitizationPromptSection = RunCoach.Api.Modules.Coaching.Sanitization.PromptSection;
 
 namespace RunCoach.Api.Modules.Training.Plan;
 
@@ -24,10 +28,20 @@ namespace RunCoach.Api.Modules.Training.Plan;
 /// </summary>
 /// <remarks>
 /// <para>
+/// The <c>POST /regenerate</c> endpoint (Unit 5) ships alongside <c>GET /current</c>:
+/// it sanitizes the optional regeneration intent free-text in-line, dispatches a
+/// <see cref="RegeneratePlanCommand"/> to the Wolverine
+/// <see cref="RegeneratePlanHandler"/>, and surfaces the resulting
+/// <see cref="RegeneratePlanResponse"/> verbatim. The handler runs every
+/// per-call side-effect on a single Marten session under Wolverine's
+/// transactional middleware per DEC-057 / DEC-060.
+/// </para>
+/// <para>
 /// Authorization mirrors <see cref="Modules.Coaching.Onboarding.OnboardingController"/>'s
 /// <see cref="AuthPolicies.CookieOrBearer"/> policy. Reads do not require an
 /// antiforgery token (idempotent GETs are out of scope for ASP.NET Core's
-/// antiforgery middleware).
+/// antiforgery middleware); <c>POST /regenerate</c> requires
+/// <c>[RequireAntiforgeryToken]</c> per the Slice 0 pattern.
 /// </para>
 /// </remarks>
 [ApiController]
@@ -35,10 +49,13 @@ namespace RunCoach.Api.Modules.Training.Plan;
 [Authorize(Policy = AuthPolicies.CookieOrBearer)]
 public sealed partial class PlanRenderingController(
     IDocumentStore store,
+    IMessageBus bus,
+    IPromptSanitizer sanitizer,
     RunCoachDbContext db,
     ILogger<PlanRenderingController> logger) : ControllerBase
 {
     private const string MissingUserType = "https://runcoach.app/problems/missing-user-claim";
+    private const string OnboardingNotCompleteType = "https://runcoach.app/problems/onboarding-not-complete";
 
     /// <summary>GET /api/v1/plan/current — read the user's active plan projection.</summary>
     /// <remarks>
@@ -109,11 +126,127 @@ public sealed partial class PlanRenderingController(
         return Ok(plan);
     }
 
+    /// <summary>POST /api/v1/plan/regenerate — regenerate the runner's plan from their persisted profile.</summary>
+    /// <remarks>
+    /// <para>
+    /// Per Slice 1 § Unit 5 R05.1: validates the runner has finished onboarding
+    /// (<c>UserProfile.OnboardingCompletedAt</c> non-null) else returns 409
+    /// ProblemDetails. Sanitizes the optional intent free-text via
+    /// <see cref="IPromptSanitizer.SanitizeAsync"/> with
+    /// <see cref="SanitizationPromptSection.RegenerationIntentFreeText"/> BEFORE dispatching
+    /// the command — the sanitized + delimiter-wrapped text is what reaches the
+    /// LLM via <c>ContextAssembler.ComposeForPlanGenerationAsync</c>, which
+    /// does NOT re-sanitize.
+    /// </para>
+    /// <para>
+    /// Dispatches a <see cref="RegeneratePlanCommand"/> to the Wolverine
+    /// <see cref="RegeneratePlanHandler"/>; the handler performs idempotency
+    /// check + Plan-stream creation + <c>PlanLinkedToUser</c> append +
+    /// idempotency record on a single Marten session inside one transaction
+    /// (DEC-057 / DEC-060). Failure of any LLM call rolls back the whole
+    /// transaction, leaving <c>UserProfile.CurrentPlanId</c> pointing at the
+    /// prior plan.
+    /// </para>
+    /// </remarks>
+    /// <param name="request">The regenerate request body.</param>
+    /// <param name="ct">Request cancellation token.</param>
+    /// <returns>200 with <see cref="RegeneratePlanResponse"/> on success; 409
+    /// when onboarding is incomplete; 400 when the intent free-text exceeds the
+    /// raw cap.</returns>
+    [HttpPost("regenerate")]
+    [Microsoft.AspNetCore.Antiforgery.RequireAntiforgeryToken]
+    [ProducesResponseType(typeof(RegeneratePlanResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> Regenerate(
+        [FromBody] RegeneratePlanRequestDto request,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryGetUserId(out var userId))
+        {
+            return MissingUserClaim();
+        }
+
+        // Verify the runner finished onboarding before allowing regeneration.
+        // Reading the EF UserProfile row from the controller (outside any
+        // Wolverine handler body) is permitted by DEC-060 — only handler
+        // bodies are forbidden from EF mutation. AsNoTracking keeps this
+        // path out of EF's change tracker.
+        var onboardingCompletedAt = await EntityFrameworkQueryableExtensions
+            .SingleOrDefaultAsync(
+                db.RunnerOnboardingProfiles
+                    .AsNoTracking()
+                    .Where(p => p.UserId == userId)
+                    .Select(p => p.OnboardingCompletedAt),
+                ct)
+            .ConfigureAwait(false);
+
+        if (onboardingCompletedAt is null)
+        {
+            LogRegenerateRejectedOnboardingIncomplete(logger, userId);
+            return Problem(
+                type: OnboardingNotCompleteType,
+                title: "Onboarding has not completed yet.",
+                detail: "Finish onboarding before regenerating a plan.",
+                statusCode: StatusCodes.Status409Conflict);
+        }
+
+        // Validate the raw free-text length against the wire-level cap before
+        // sanitization. Sanitization wraps the input with a Spotlighting
+        // delimiter that adds delimiter-overhead chars, so the
+        // `RegenerationIntent` constructor's larger cap is sized to admit
+        // RawMaxFreeTextLength + DelimiterOverhead (see RegenerationIntent.cs).
+        RegenerationIntent? sanitizedIntent = null;
+        if (request.Intent is not null)
+        {
+            var rawText = request.Intent.FreeText ?? string.Empty;
+            if (rawText.Length > RegenerationIntent.RawMaxFreeTextLength)
+            {
+                return Problem(
+                    title: "Regeneration intent is too long.",
+                    detail: $"intent.freeText must be at most {RegenerationIntent.RawMaxFreeTextLength} characters; got {rawText.Length}.",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            // Sanitize once, in the controller, so the wrapped text is what
+            // both the handler's audit log and the downstream context assembler
+            // observe — ContextAssembler.ComposeForPlanGenerationAsync trusts
+            // the wrapped bytes and does NOT re-sanitize.
+            var sanitized = await sanitizer
+                .SanitizeAsync(rawText, SanitizationPromptSection.RegenerationIntentFreeText, ct)
+                .ConfigureAwait(false);
+
+            sanitizedIntent = new RegenerationIntent(sanitized.Sanitized);
+        }
+
+        // InvokeForTenantAsync sets the user id as Marten's conjoined tenant on
+        // the handler's auto-applied IDocumentSession; without it the handler's
+        // session has no TenantId and Marten operations against the
+        // multi-tenant OnboardingView / IdempotencyMarker fail to resolve.
+        var response = await bus
+            .InvokeForTenantAsync<RegeneratePlanResponse>(
+                userId.ToString(),
+                new RegeneratePlanCommand(userId, sanitizedIntent, request.IdempotencyKey),
+                ct)
+            .ConfigureAwait(false);
+
+        return Ok(response);
+    }
+
     [LoggerMessage(
         EventId = 1,
         Level = LogLevel.Warning,
         Message = "Plan rendering miss: RunnerOnboardingProfile.CurrentPlanId set but PlanProjectionDto absent user={UserId} planId={PlanId}")]
     private static partial void LogProjectionMiss(ILogger logger, Guid userId, Guid planId);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Information,
+        Message = "Plan regeneration rejected: onboarding not complete user={UserId}")]
+    private static partial void LogRegenerateRejectedOnboardingIncomplete(ILogger logger, Guid userId);
 
     private bool TryGetUserId(out Guid userId)
     {

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanRenderingController.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanRenderingController.cs
@@ -56,6 +56,7 @@ public sealed partial class PlanRenderingController(
 {
     private const string MissingUserType = "https://runcoach.app/problems/missing-user-claim";
     private const string OnboardingNotCompleteType = "https://runcoach.app/problems/onboarding-not-complete";
+    private const string InvalidIdempotencyKeyType = "https://runcoach.app/problems/invalid-idempotency-key";
 
     /// <summary>GET /api/v1/plan/current — read the user's active plan projection.</summary>
     /// <remarks>
@@ -170,6 +171,15 @@ public sealed partial class PlanRenderingController(
             return MissingUserClaim();
         }
 
+        if (request.IdempotencyKey == Guid.Empty)
+        {
+            return Problem(
+                type: InvalidIdempotencyKeyType,
+                title: "Invalid idempotency key",
+                detail: "The supplied idempotencyKey must be a non-empty UUID.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
         // Verify the runner finished onboarding before allowing regeneration.
         // Reading the EF UserProfile row from the controller (outside any
         // Wolverine handler body) is permitted by DEC-060 — only handler
@@ -202,7 +212,7 @@ public sealed partial class PlanRenderingController(
         RegenerationIntent? sanitizedIntent = null;
         if (request.Intent is not null)
         {
-            var rawText = request.Intent.FreeText ?? string.Empty;
+            var rawText = request.Intent.FreeText;
             if (rawText.Length > RegenerationIntent.RawMaxFreeTextLength)
             {
                 return Problem(

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/RegeneratePlanCommand.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/RegeneratePlanCommand.cs
@@ -1,0 +1,36 @@
+using RunCoach.Api.Modules.Coaching.Models;
+
+namespace RunCoach.Api.Modules.Training.Plan;
+
+/// <summary>
+/// Wolverine command dispatched by <see cref="PlanRenderingController"/> for every
+/// inbound <c>POST /api/v1/plan/regenerate</c> request. Per Slice 1 § Unit 5 R05.1
+/// / DEC-057 / DEC-060 the matching handler is <see cref="RegeneratePlanHandler"/>
+/// — a plain Wolverine handler (NOT an <c>[AggregateHandler]</c> — there is no
+/// aggregate to fetch since regeneration creates a NEW Plan stream) that performs
+/// every per-call side-effect atomically through the single Marten
+/// <see cref="Marten.IDocumentSession"/> Wolverine's transactional middleware
+/// brackets around the handler body: idempotency check + load onboarding view +
+/// inline plan generation + Plan stream creation + <c>PlanLinkedToUser</c> append +
+/// idempotency record — all on the same session, no <c>RunCoachDbContext</c>
+/// injection, no second Postgres transaction.
+/// </summary>
+/// <param name="UserId">The authenticated runner's id; doubles as the per-user
+/// onboarding stream identity from which the handler reads the prior
+/// <c>CurrentPlanId</c>.</param>
+/// <param name="Intent">
+/// Optional regeneration intent. The free-text payload was sanitized + delimiter-wrapped
+/// by the controller via
+/// <c>IPromptSanitizer.SanitizeAsync(rawFreeText, PromptSection.RegenerationIntentFreeText, ct)</c>
+/// BEFORE the command was dispatched, so the handler and downstream context-assembler
+/// hand the value through unchanged. Null when the runner did not supply an intent.
+/// </param>
+/// <param name="IdempotencyKey">
+/// Client-generated idempotency key — typically <c>crypto.randomUUID()</c> the
+/// frontend re-sends on retry. The handler's first action is to short-circuit
+/// duplicate submissions via <see cref="Coaching.Idempotency.IIdempotencyStore.SeenAsync{TResponse}"/>.
+/// </param>
+public sealed record RegeneratePlanCommand(
+    Guid UserId,
+    RegenerationIntent? Intent,
+    Guid IdempotencyKey);

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/RegeneratePlanCommand.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/RegeneratePlanCommand.cs
@@ -28,7 +28,7 @@ namespace RunCoach.Api.Modules.Training.Plan;
 /// <param name="IdempotencyKey">
 /// Client-generated idempotency key — typically <c>crypto.randomUUID()</c> the
 /// frontend re-sends on retry. The handler's first action is to short-circuit
-/// duplicate submissions via <see cref="Coaching.Idempotency.IIdempotencyStore.SeenAsync{TResponse}"/>.
+/// duplicate submissions via <see cref="Infrastructure.Idempotency.IIdempotencyStore.SeenAsync{TResponse}"/>.
 /// </param>
 public sealed record RegeneratePlanCommand(
     Guid UserId,

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/RegeneratePlanHandler.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/RegeneratePlanHandler.cs
@@ -1,0 +1,173 @@
+using Marten;
+using Microsoft.Extensions.Logging;
+using RunCoach.Api.Infrastructure.Idempotency;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+using RunCoach.Api.Modules.Training.Plan.Models;
+
+namespace RunCoach.Api.Modules.Training.Plan;
+
+/// <summary>
+/// Wolverine command handler for <see cref="RegeneratePlanCommand"/> per Slice 1
+/// § Unit 5 R05.1 / DEC-057 / DEC-060. The handler runs as a regular Wolverine
+/// handler (NOT an <c>[AggregateHandler]</c> — there is no aggregate to fetch
+/// since regeneration creates a NEW Plan stream) and performs every side-effect
+/// atomically through the single Marten <see cref="IDocumentSession"/>
+/// Wolverine's transactional middleware brackets around the handler body —
+/// there is no <c>RunCoachDbContext</c> injection, no <c>IMessageBus.InvokeAsync</c>
+/// call, no second Postgres transaction.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per-call flow:
+/// <list type="number">
+/// <item>Idempotency check via <see cref="IIdempotencyStore.SeenAsync"/>; on hit
+///   return the byte-identical prior response, append nothing.</item>
+/// <item>Load the inline-projected <see cref="OnboardingView"/> directly off the
+///   document session — it carries the prior <c>CurrentPlanId</c> set by the
+///   most recent <see cref="PlanLinkedToUser"/> event during initial generation.</item>
+/// <item>Invoke <see cref="IPlanGenerationService.GeneratePlanAsync"/> with the
+///   prior plan id threaded through as <c>previousPlanId</c> so the new
+///   <see cref="PlanGenerated"/> event carries the audit-link via its
+///   <c>PreviousPlanId</c> slot.</item>
+/// <item>Stage the returned events on a new
+///   <c>session.Events.StartStream&lt;PlanProjectionDto&gt;(planId, ...)</c>.</item>
+/// <item>Append a fresh <see cref="PlanLinkedToUser"/> event to the onboarding
+///   stream — <see cref="UserProfileFromOnboardingProjection"/> consumes it
+///   and updates <c>UserProfile.CurrentPlanId</c> atomically with the Marten
+///   event append per DEC-060 (no direct EF write from the handler).</item>
+/// <item>Record the response on <see cref="IIdempotencyStore.Record{TResponse}"/>.</item>
+/// </list>
+/// </para>
+/// <para>
+/// Failure semantics: any uncaught exception (LLM rejection on any of the six
+/// macro/meso/micro calls, transient infrastructure error) propagates out of
+/// the handler. Wolverine's transactional middleware aborts the Marten
+/// transaction — no new Plan stream, no <c>PlanLinkedToUser</c>, the EF
+/// projection's <c>UserProfile.CurrentPlanId</c> stays at its prior value.
+/// </para>
+/// </remarks>
+public sealed partial class RegeneratePlanHandler
+{
+    // The type is a stateless logical handler container: Wolverine codegen
+    // emits a non-static handler stub that calls the static `Handle` method,
+    // and `ILogger<RegeneratePlanHandler>` needs a non-static type argument.
+    // The private constructor prevents instantiation in test code.
+    private RegeneratePlanHandler()
+    {
+    }
+
+    /// <summary>
+    /// Wolverine command handler. Wolverine's <c>AutoApplyTransactions</c>
+    /// policy brackets every Marten <c>IDocumentSession</c> resolution with a
+    /// single transaction-scoped <c>SaveChangesAsync</c> call after the handler
+    /// returns (DEC-048 / batch 22a research). The handler stages every event +
+    /// idempotency marker on this session; the framework commits them
+    /// atomically. The handler itself never calls <c>SaveChangesAsync</c>.
+    /// </summary>
+    /// <param name="cmd">The regenerate-plan command.</param>
+    /// <param name="session">Marten session bracketed by Wolverine's transactional middleware.</param>
+    /// <param name="planGen">Plan generation orchestrator (six-call macro/meso/micro chain).</param>
+    /// <param name="idempotency">Idempotency store backed by the same <paramref name="session"/>.</param>
+    /// <param name="logger">Logger.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The response DTO surfaced by the controller.</returns>
+    public static async Task<RegeneratePlanResponse> Handle(
+        RegeneratePlanCommand cmd,
+        IDocumentSession session,
+        IPlanGenerationService planGen,
+        IIdempotencyStore idempotency,
+        ILogger<RegeneratePlanHandler> logger,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(cmd);
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(planGen);
+        ArgumentNullException.ThrowIfNull(idempotency);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        // (a) idempotency short-circuit: on hit return the byte-identical prior
+        //     response, append nothing, write nothing.
+        var prior = await idempotency
+            .SeenAsync<RegeneratePlanResponse>(cmd.IdempotencyKey, ct)
+            .ConfigureAwait(false);
+        if (prior is not null)
+        {
+            LogIdempotentReplay(logger, cmd.IdempotencyKey, cmd.UserId);
+            return prior;
+        }
+
+        var onboardingStreamId = cmd.UserId;
+
+        // (b) load the inline-projected onboarding view directly off the
+        //     document session. `OnboardingProjection` is registered with
+        //     `ProjectionLifecycle.Inline` so the document is materialized on
+        //     the same NpgsqlConnection the handler is about to write through.
+        //     The controller already verified the runner has completed
+        //     onboarding (UserProfile.OnboardingCompletedAt non-null), so the
+        //     view is guaranteed to exist and carry a non-null `CurrentPlanId`
+        //     by the time this branch runs.
+        var view = await session
+            .LoadAsync<OnboardingView>(onboardingStreamId, ct)
+            .ConfigureAwait(false);
+
+        if (view is null || view.CurrentPlanId is null)
+        {
+            // Defense-in-depth: the controller's UserProfile.OnboardingCompletedAt
+            // gate should make this unreachable, but if a stale projection
+            // somehow carries a missing view we surface the protocol violation
+            // as an exception so Wolverine aborts the transaction.
+            throw new InvalidOperationException(
+                $"Cannot regenerate plan for user {cmd.UserId}: onboarding view missing or no prior plan linked.");
+        }
+
+        var priorPlanId = view.CurrentPlanId.Value;
+
+        // (c) + (d) generate the new Plan stream events. The plan-generation
+        //     service does NOT touch the session; it returns the event list
+        //     for us to stage. PreviousPlanId is threaded onto the returned
+        //     PlanGenerated event so the projection retains audit linkage to
+        //     the prior plan without a schema bump.
+        var planId = Guid.NewGuid();
+        LogRegenerateStart(logger, cmd.UserId, planId, priorPlanId, cmd.Intent is not null);
+
+        var planEvents = await planGen
+            .GeneratePlanAsync(view, cmd.UserId, planId, cmd.Intent, previousPlanId: priorPlanId, ct)
+            .ConfigureAwait(false);
+
+        // (e) stage the new Plan stream — the inline `PlanProjection`
+        //     materializes the `PlanProjectionDto` document on the same
+        //     transaction so `GET /api/v1/plan/current` is consistent the
+        //     instant the response returns.
+        session.Events.StartStream<PlanProjectionDto>(planId, planEvents.ToEvents().ToArray());
+
+        // (f) append PlanLinkedToUser to the onboarding stream — this is what
+        //     `UserProfileFromOnboardingProjection` consumes to flip
+        //     `UserProfile.CurrentPlanId` to the new plan id atomically with
+        //     the Marten event append per DEC-060 / R-069. NO direct EF write.
+        session.Events.Append(onboardingStreamId, new PlanLinkedToUser(cmd.UserId, planId));
+
+        // (g) + (h) record the idempotency marker LAST so the response we
+        //     recorded matches what the caller is about to receive.
+        var response = new RegeneratePlanResponse(planId, "generated");
+        idempotency.Record(cmd.IdempotencyKey, response);
+
+        return response;
+    }
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Information,
+        Message = "Plan regeneration idempotent replay key={IdempotencyKey} user={UserId}")]
+    private static partial void LogIdempotentReplay(ILogger logger, Guid idempotencyKey, Guid userId);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Information,
+        Message = "Plan regeneration starting user={UserId} newPlanId={NewPlanId} previousPlanId={PreviousPlanId} hasIntent={HasIntent}")]
+    private static partial void LogRegenerateStart(
+        ILogger logger,
+        Guid userId,
+        Guid newPlanId,
+        Guid previousPlanId,
+        bool hasIntent);
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/RegeneratePlanRequestDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/RegeneratePlanRequestDto.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace RunCoach.Api.Modules.Training.Plan;
+
+/// <summary>
+/// Request body for <c>POST /api/v1/plan/regenerate</c> per Slice 1 § Unit 5
+/// R05.1. The wire contract carries the client-generated idempotency key plus
+/// an optional regeneration intent block whose free-text is capped at
+/// <see cref="Coaching.Models.RegenerationIntent.RawMaxFreeTextLength"/>
+/// characters BEFORE sanitization.
+/// </summary>
+/// <param name="IdempotencyKey">
+/// Client-generated idempotency key (typically <c>crypto.randomUUID()</c>).
+/// The handler short-circuits duplicate submissions with the same key.
+/// Marked <see cref="JsonRequiredAttribute"/> so System.Text.Json refuses to
+/// under-post a default <see cref="Guid"/> when the field is omitted.
+/// </param>
+/// <param name="Intent">
+/// Optional regeneration intent supplied by the runner via Settings -> Plan.
+/// Null when the runner did not provide a note.
+/// </param>
+public sealed record RegeneratePlanRequestDto(
+    [property: JsonRequired] Guid IdempotencyKey,
+    RegenerationIntentRequestDto? Intent);

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/RegeneratePlanResponse.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/RegeneratePlanResponse.cs
@@ -1,0 +1,24 @@
+namespace RunCoach.Api.Modules.Training.Plan;
+
+/// <summary>
+/// Response shape returned by <see cref="RegeneratePlanHandler"/> and surfaced
+/// verbatim by the <c>POST /api/v1/plan/regenerate</c> endpoint per Slice 1 §
+/// Unit 5 R05.1. Carries the newly-generated plan id so the frontend can
+/// immediately invalidate the <c>Plan</c> RTK-query tag and refetch the plan
+/// projection without a second round-trip to discover the id.
+/// </summary>
+/// <remarks>
+/// The shape is recorded by <see cref="Coaching.Idempotency.IIdempotencyStore.Record{TResponse}"/>
+/// on the handler's session so a duplicate submission with the same
+/// idempotency key returns the byte-identical payload — including the same
+/// <see cref="PlanId"/> — without producing a second Plan stream.
+/// </remarks>
+/// <param name="PlanId">The id of the newly-generated Plan stream.</param>
+/// <param name="Status">
+/// Always <c>"generated"</c> on the success path per the spec wire contract;
+/// modeled as a string so future slices can introduce richer status values
+/// (e.g. <c>"queued"</c>) without breaking existing clients.
+/// </param>
+public sealed record RegeneratePlanResponse(
+    Guid PlanId,
+    string Status);

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/RegeneratePlanResponse.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/RegeneratePlanResponse.cs
@@ -8,7 +8,7 @@ namespace RunCoach.Api.Modules.Training.Plan;
 /// projection without a second round-trip to discover the id.
 /// </summary>
 /// <remarks>
-/// The shape is recorded by <see cref="Coaching.Idempotency.IIdempotencyStore.Record{TResponse}"/>
+/// The shape is recorded by <see cref="Infrastructure.Idempotency.IIdempotencyStore.Record{TResponse}"/>
 /// on the handler's session so a duplicate submission with the same
 /// idempotency key returns the byte-identical payload — including the same
 /// <see cref="PlanId"/> — without producing a second Plan stream.

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/RegenerationIntentRequestDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/RegenerationIntentRequestDto.cs
@@ -1,0 +1,18 @@
+namespace RunCoach.Api.Modules.Training.Plan;
+
+/// <summary>
+/// Wire shape for the optional <c>intent</c> block on
+/// <see cref="RegeneratePlanRequestDto"/>. Captured as its own DTO so the wire
+/// contract stays decoupled from the internal
+/// <see cref="Coaching.Models.RegenerationIntent"/> domain record (which holds
+/// the post-sanitization, delimiter-wrapped payload — never user-supplied wire
+/// bytes).
+/// </summary>
+/// <param name="FreeText">
+/// Raw free-text supplied by the runner (e.g. "I'm coming back from a calf
+/// strain"). Capped at
+/// <see cref="Coaching.Models.RegenerationIntent.RawMaxFreeTextLength"/>
+/// characters by the controller before sanitization runs.
+/// </param>
+public sealed record RegenerationIntentRequestDto(
+    string FreeText);

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/RegenerationIntentRequestDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/RegenerationIntentRequestDto.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace RunCoach.Api.Modules.Training.Plan;
 
 /// <summary>
@@ -13,6 +15,8 @@ namespace RunCoach.Api.Modules.Training.Plan;
 /// strain"). Capped at
 /// <see cref="Coaching.Models.RegenerationIntent.RawMaxFreeTextLength"/>
 /// characters by the controller before sanitization runs.
+/// Marked <see cref="JsonRequiredAttribute"/> so System.Text.Json rejects
+/// missing or null payloads with a 400 deserialization error.
 /// </param>
 public sealed record RegenerationIntentRequestDto(
-    string FreeText);
+    [property: JsonRequired] string FreeText);

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Sanitization/SanitizationOTelTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Sanitization/SanitizationOTelTests.cs
@@ -46,7 +46,8 @@ public sealed class SanitizationOTelTests : IDisposable
     [Fact]
     public async Task SanitizeAsync_EmitsGuardrailSpanWithDocumentedAttributes()
     {
-        // Arrange
+        // Arrange — see Clear+LastOrDefault rationale in the sibling test.
+        _captured.Clear();
         var sut = new LayeredPromptSanitizer(NullLogger<LayeredPromptSanitizer>.Instance);
         const string secretishLookingPii = "I am John Doe, born 1985-04-12, ssn 123-45-6789";
 
@@ -94,7 +95,13 @@ public sealed class SanitizationOTelTests : IDisposable
     [Fact]
     public async Task SanitizeAsync_FindingsAttribute_IsValidPiiFreeJson()
     {
-        // Arrange
+        // Arrange — clear _captured so we only inspect activities fired by
+        // this test's SanitizeAsync call. Without this, ambient sanitizer
+        // calls from other tests in the suite (the listener filters by
+        // ActivitySource name, not by test-scoped Activity.Id) can land in
+        // _captured before this method runs and cause `.LastOrDefault(...)`
+        // to return a stale span with unrelated findings.
+        _captured.Clear();
         var sut = new LayeredPromptSanitizer(NullLogger<LayeredPromptSanitizer>.Instance);
 
         // Act — exercise a clear hit so `findings` is a non-empty array,

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanRegenerateIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanRegenerateIntegrationTests.cs
@@ -1,0 +1,616 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Marten;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using RunCoach.Api.Infrastructure;
+using RunCoach.Api.Infrastructure.Idempotency;
+using RunCoach.Api.Modules.Coaching.Models;
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+using RunCoach.Api.Modules.Coaching.Onboarding.Entities;
+using RunCoach.Api.Modules.Identity.Contracts;
+using RunCoach.Api.Modules.Identity.Entities;
+using RunCoach.Api.Modules.Training.Plan;
+using RunCoach.Api.Modules.Training.Plan.Models;
+using RunCoach.Api.Tests.Infrastructure;
+
+namespace RunCoach.Api.Tests.Modules.Training.Plan;
+
+/// <summary>
+/// Integration coverage for Slice 1 § Unit 5 R05.1 / DEC-060 — the regenerate
+/// flow's atomic event-sourcing wiring (idempotency check + view load + plan
+/// stream creation + <see cref="PlanLinkedToUser"/> append +
+/// <see cref="UserProfileFromOnboardingProjection"/> EF write) against the
+/// shared Testcontainers Postgres. Covers the four scenarios per task
+/// description:
+/// (a) regenerate with intent produces a second Plan stream linked back to
+///     the prior plan via <see cref="PlanGenerated.PreviousPlanId"/>;
+/// (b) regenerate without intent succeeds with the same shape;
+/// (c) regenerate before onboarding completion returns HTTP 409;
+/// (d) the same idempotency key returns the byte-identical response and
+///     stages no extra writes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The four scenarios split across two surfaces:
+/// </para>
+/// <list type="bullet">
+/// <item>
+///   <description>
+///   Scenario (c) runs through the live HTTP pipeline because the 409 gate
+///   sits on the controller — short-circuited before the Wolverine handler is
+///   dispatched. No Wolverine routing is exercised here.
+///   </description>
+/// </item>
+/// <item>
+///   <description>
+///   Scenarios (a), (b), (d) drive the
+///   <see cref="RegeneratePlanHandler.Handle"/> entry point directly against
+///   a real Marten <see cref="IDocumentSession"/> resolved from the fixture's
+///   DI container. This exercises the full Marten + EF projection stack
+///   (<see cref="OnboardingProjection"/> + <see cref="UserProfileFromOnboardingProjection"/>
+///   + <see cref="PlanProjection"/>) under one transaction commit per call —
+///   the same wiring Wolverine's transactional middleware brackets in
+///   production. Going around <c>IMessageBus.InvokeAsync</c> avoids the test
+///   harness needing to seed Wolverine handler discovery for the WAF-derived
+///   host (a known Slice 1 limitation tracked in <c>InvokeAsyncTransactionScopeTests</c>'s
+///   prose; the Wolverine routing seam itself is exercised by the smoke
+///   curl proof captured at T05.1 commit).
+///   </description>
+/// </item>
+/// </list>
+/// <para>
+/// The stub <see cref="StubPlanGenerationService"/> returns a deterministic
+/// canonical-Slice-1 event sequence
+/// (<c>[PlanGenerated, MesoCycleCreated×4, FirstMicroCycleCreated]</c>) with
+/// the <see cref="PlanGenerated.PreviousPlanId"/> slot threaded through from
+/// the parameter the handler passes. This is the same shape
+/// <c>PlanGenerationService</c> produces in production; the only thing the
+/// stub elides is the six LLM calls.
+/// </para>
+/// </remarks>
+[Trait("Category", "Integration")]
+public class PlanRegenerateIntegrationTests(RunCoachAppFactory factory) : DbBackedIntegrationTestBase(factory)
+{
+    private const string StrongPassword = "Str0ngTestPassw0rd!";
+    private const string AntiforgeryHeaderName = AuthCookieNames.AntiforgeryHeader;
+    private const string AntiforgeryRequestCookieName = AuthCookieNames.AntiforgeryRequest;
+    private const string OnboardingNotCompleteType = "https://runcoach.app/problems/onboarding-not-complete";
+
+    private static readonly Uri BaseUri = new("https://localhost");
+
+    /// <summary>
+    /// Scenario (a) per task description — seeds prior onboarding + plan
+    /// stream, drives the regenerate handler with an intent, then asserts:
+    /// (1) two Plan streams exist in Marten, (2) the new plan's
+    /// <see cref="PlanGenerated.PreviousPlanId"/> equals the prior plan id,
+    /// (3) the onboarding stream contains a fresh
+    /// <see cref="PlanLinkedToUser"/> referencing the new plan, and
+    /// (4) <c>UserProfile.CurrentPlanId</c> points at the new plan.
+    /// </summary>
+    [Fact]
+    public async Task Regenerate_With_Intent_Creates_Second_Plan_Stream_With_PreviousPlanId_Linkage()
+    {
+        // Arrange — provision an Identity row + seed the prior plan stream
+        //   and onboarding events directly so the runner is in the
+        //   post-onboarding branch the regenerate flow targets.
+        var userId = await SeedUserAsync();
+        var initialPlanId = Guid.NewGuid();
+        await SeedInitialPlanStreamAsync(userId, initialPlanId);
+        await SeedOnboardingCompletionAsync(userId, initialPlanId);
+
+        var idempotencyKey = Guid.NewGuid();
+        var intent = new RegenerationIntent("I just got injured");
+
+        // Act — invoke the handler directly with a real Marten session.
+        var actualResponse = await InvokeHandlerAsync(
+            new RegeneratePlanCommand(userId, intent, idempotencyKey));
+
+        // Assert — handler returned a fresh planId tagged "generated".
+        actualResponse.PlanId.Should().NotBe(initialPlanId, because: "regeneration must produce a new plan id");
+        actualResponse.Status.Should().Be("generated");
+        var newPlanId = actualResponse.PlanId;
+
+        // (1) two distinct Plan streams exist in Marten.
+        var allPlans = await LoadAllPlanProjectionsAsync(userId);
+        allPlans.Should().HaveCount(2, because: "the prior plan stays in Marten as audit trail; the new plan is a second stream");
+        allPlans.Select(p => p.PlanId).Should().BeEquivalentTo(new[] { initialPlanId, newPlanId });
+
+        // (2) the new Plan stream's `PreviousPlanId` resolves to the prior plan id.
+        var newPlan = allPlans.Single(p => p.PlanId == newPlanId);
+        newPlan.PreviousPlanId.Should().Be(initialPlanId, because: "the regenerate handler threads priorPlanId through GeneratePlanAsync into PlanGenerated.PreviousPlanId");
+
+        // (3) the onboarding stream now carries a fresh PlanLinkedToUser
+        //     referencing the new plan id. The initial seed appended one such
+        //     event for the prior plan, so we expect two PlanLinkedToUser
+        //     events on the stream — order-preserved with the new event last.
+        var planLinks = await LoadPlanLinkedEventsAsync(userId, userId);
+        planLinks.Should().HaveCount(2);
+        planLinks.Select(e => e.PlanId).Should().Equal(initialPlanId, newPlanId);
+
+        // (4) UserProfile.CurrentPlanId now points at the new plan via the
+        //     UserProfileFromOnboardingProjection apply branch on the
+        //     freshly-appended PlanLinkedToUser event.
+        var userProfile = await LoadUserProfileAsync(userId);
+        userProfile.Should().NotBeNull();
+        userProfile!.CurrentPlanId.Should().Be(newPlanId);
+    }
+
+    /// <summary>
+    /// Scenario (b) per task description — regenerate without an intent body
+    /// succeeds and produces the same shape as the with-intent flow. The
+    /// handler accepts a null <c>RegeneratePlanCommand.Intent</c> and the
+    /// stub plan generator does not branch on the intent value.
+    /// </summary>
+    [Fact]
+    public async Task Regenerate_Without_Intent_Succeeds_And_Creates_New_Plan_Stream()
+    {
+        // Arrange
+        var userId = await SeedUserAsync();
+        var initialPlanId = Guid.NewGuid();
+        await SeedInitialPlanStreamAsync(userId, initialPlanId);
+        await SeedOnboardingCompletionAsync(userId, initialPlanId);
+
+        // Act
+        var actualResponse = await InvokeHandlerAsync(
+            new RegeneratePlanCommand(userId, Intent: null, Guid.NewGuid()));
+
+        // Assert
+        actualResponse.PlanId.Should().NotBe(initialPlanId);
+        actualResponse.Status.Should().Be("generated");
+
+        var allPlans = await LoadAllPlanProjectionsAsync(userId);
+        allPlans.Should().HaveCount(2);
+        allPlans.Single(p => p.PlanId == actualResponse.PlanId)
+            .PreviousPlanId.Should().Be(initialPlanId);
+    }
+
+    /// <summary>
+    /// Scenario (c) per task description — submitting regenerate before the
+    /// runner has finished onboarding returns 409 ProblemDetails. The
+    /// controller's <c>UserProfile.OnboardingCompletedAt</c> gate trips
+    /// before the command would reach the Wolverine handler. Driven through
+    /// the live HTTP pipeline because the gate sits on the controller.
+    /// </summary>
+    [Fact]
+    public async Task Regenerate_Before_Onboarding_Completion_Returns_409()
+    {
+        // Arrange — register but do NOT seed any onboarding events. The
+        //   runner has an ApplicationUser row but no UserProfile row at all
+        //   (and even if one existed, OnboardingCompletedAt would be null).
+        //   Either case lands the controller's gate-fail path.
+        var (client, _, antiforgeryToken) = await RegisterAndPrepareCookieClientAsync();
+
+        // Act
+        using var request = BuildRegenerateRequest(antiforgeryToken, idempotencyKey: Guid.NewGuid(), intent: null);
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+        var problem = await response.Content.ReadFromJsonAsync<Microsoft.AspNetCore.Mvc.ProblemDetails>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        problem.Should().NotBeNull();
+        problem!.Type.Should().Be(OnboardingNotCompleteType);
+    }
+
+    /// <summary>
+    /// Scenario (d) per task description — sending the same idempotency key
+    /// twice returns the byte-identical response with the same plan id, and
+    /// no third Plan stream / no extra <see cref="PlanLinkedToUser"/> event
+    /// is appended on the second call. This is the load-bearing safety net
+    /// against duplicate submissions on retry.
+    /// </summary>
+    [Fact]
+    public async Task Regenerate_With_Same_IdempotencyKey_Returns_Same_PlanId_Without_Side_Effects()
+    {
+        // Arrange
+        var userId = await SeedUserAsync();
+        var initialPlanId = Guid.NewGuid();
+        var idempotencyKey = Guid.NewGuid();
+        await SeedInitialPlanStreamAsync(userId, initialPlanId);
+        await SeedOnboardingCompletionAsync(userId, initialPlanId);
+
+        // First call — produces the new plan.
+        var firstResponse = await InvokeHandlerAsync(
+            new RegeneratePlanCommand(userId, new RegenerationIntent("first"), idempotencyKey));
+        var firstPlanId = firstResponse.PlanId;
+
+        // Act — second call with the same key. The intent payload here
+        //   intentionally differs from the first call so a (broken) re-run
+        //   path that ignores idempotency would generate a different plan
+        //   id, making the cache-hit vs. cache-miss branches visibly
+        //   distinguishable in the assertion below.
+        var secondResponse = await InvokeHandlerAsync(
+            new RegeneratePlanCommand(userId, new RegenerationIntent("second-different-but-ignored"), idempotencyKey));
+
+        // Assert — same plan id, same body shape.
+        secondResponse.PlanId.Should().Be(firstPlanId, because: "the idempotency store memoizes the first response under this key");
+        secondResponse.Status.Should().Be(firstResponse.Status);
+
+        // No third Plan stream — exactly two exist (prior + first regenerate).
+        var allPlans = await LoadAllPlanProjectionsAsync(userId);
+        allPlans.Should().HaveCount(2, because: "the second submission is a memoized replay; nothing is appended");
+        allPlans.Select(p => p.PlanId).Should().BeEquivalentTo(new[] { initialPlanId, firstPlanId });
+
+        // No extra PlanLinkedToUser was appended — onboarding stream still
+        //   carries exactly two such events (initial seed + first regenerate).
+        var planLinks = await LoadPlanLinkedEventsAsync(userId, userId);
+        planLinks.Should().HaveCount(2);
+        planLinks.Select(e => e.PlanId).Should().Equal(initialPlanId, firstPlanId);
+    }
+
+    /// <summary>
+    /// Marten state lives in <c>runcoach_events</c>, which Respawn skips.
+    /// Reset it explicitly so seeded streams + idempotency markers do not
+    /// leak between tests.
+    /// </summary>
+    public override async ValueTask DisposeAsync()
+    {
+        await Factory.Services.ResetAllMartenDataAsync();
+        await base.DisposeAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    private static async Task<string> PrimeAntiforgeryAsync(HttpClient client, CookieContainer container)
+    {
+        using var response = await client.GetAsync("/api/v1/auth/xsrf", TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        var requestCookie = container.GetCookies(BaseUri)
+            .Cast<Cookie>()
+            .FirstOrDefault(c => c.Name == AntiforgeryRequestCookieName);
+        requestCookie.Should().NotBeNull("/xsrf must issue the SPA-readable request token cookie");
+        return requestCookie!.Value;
+    }
+
+    private static HttpRequestMessage BuildRegenerateRequest(string antiforgeryToken, Guid idempotencyKey, string? intent)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/plan/regenerate");
+        request.Headers.Add(AntiforgeryHeaderName, antiforgeryToken);
+        request.Content = JsonContent.Create(new RegeneratePlanRequestDto(
+            idempotencyKey,
+            intent is null ? null : new RegenerationIntentRequestDto(intent)));
+        return request;
+    }
+
+    private static MacroPlanOutput BuildMacro(string goal)
+    {
+        return new MacroPlanOutput
+        {
+            TotalWeeks = 16,
+            GoalDescription = goal,
+            Phases = new[]
+            {
+                new PlanPhaseOutput
+                {
+                    PhaseType = PhaseType.Base,
+                    Weeks = 8,
+                    WeeklyDistanceStartKm = 30,
+                    WeeklyDistanceEndKm = 50,
+                    IntensityDistribution = "80/20 easy/hard",
+                    AllowedWorkoutTypes = new[] { WorkoutType.Easy, WorkoutType.LongRun, WorkoutType.Recovery },
+                    TargetPaceEasySecPerKm = 360,
+                    TargetPaceFastSecPerKm = 300,
+                    Notes = "Aerobic base build.",
+                    IncludesDeload = true,
+                },
+            },
+            Rationale = "Progressive base then build to race specificity.",
+            Warnings = "Stop and reassess if any sharp pain emerges.",
+        };
+    }
+
+    private static MesoWeekOutput BuildMeso(int weekNumber, PhaseType phase, bool isDeload)
+    {
+        var restSlot = new MesoDaySlotOutput
+        {
+            SlotType = DaySlotType.Rest,
+            WorkoutType = null,
+            Notes = "Recovery.",
+        };
+        var easySlot = new MesoDaySlotOutput
+        {
+            SlotType = DaySlotType.Run,
+            WorkoutType = WorkoutType.Easy,
+            Notes = "Easy aerobic.",
+        };
+
+        return new MesoWeekOutput
+        {
+            WeekNumber = weekNumber,
+            PhaseType = phase,
+            WeeklyTargetKm = isDeload ? 30 : 45,
+            IsDeloadWeek = isDeload,
+            Sunday = easySlot,
+            Monday = restSlot,
+            Tuesday = easySlot,
+            Wednesday = restSlot,
+            Thursday = easySlot,
+            Friday = restSlot,
+            Saturday = easySlot,
+            WeekSummary = $"Week {weekNumber} - {phase}.",
+        };
+    }
+
+    private static MicroWorkoutListOutput BuildMicro()
+    {
+        return new MicroWorkoutListOutput
+        {
+            Workouts = new[]
+            {
+                new WorkoutOutput
+                {
+                    DayOfWeek = 0,
+                    WorkoutType = WorkoutType.Easy,
+                    Title = "Easy Aerobic Run",
+                    TargetDistanceKm = 8,
+                    TargetDurationMinutes = 50,
+                    TargetPaceEasySecPerKm = 360,
+                    TargetPaceFastSecPerKm = 360,
+                    Segments = new[]
+                    {
+                        new WorkoutSegmentOutput
+                        {
+                            SegmentType = SegmentType.Warmup,
+                            DurationMinutes = 10,
+                            TargetPaceSecPerKm = 400,
+                            Intensity = IntensityProfile.Easy,
+                            Repetitions = 1,
+                            Notes = "Warm up gradually.",
+                        },
+                        new WorkoutSegmentOutput
+                        {
+                            SegmentType = SegmentType.Work,
+                            DurationMinutes = 30,
+                            TargetPaceSecPerKm = 360,
+                            Intensity = IntensityProfile.Easy,
+                            Repetitions = 1,
+                            Notes = "Steady aerobic effort.",
+                        },
+                        new WorkoutSegmentOutput
+                        {
+                            SegmentType = SegmentType.Cooldown,
+                            DurationMinutes = 10,
+                            TargetPaceSecPerKm = 420,
+                            Intensity = IntensityProfile.Easy,
+                            Repetitions = 1,
+                            Notes = "Cool down easy.",
+                        },
+                    },
+                    WarmupNotes = "10 min walk-jog.",
+                    CooldownNotes = "10 min walk-jog.",
+                    CoachingNotes = "Conversational pace.",
+                    PerceivedEffort = 3,
+                },
+            },
+        };
+    }
+
+    private async Task<Guid> SeedUserAsync()
+    {
+        // Provision an Identity row directly through UserManager so the
+        // UserProfile projection has an FK target. The cookie-flow register
+        // path is exercised by Scenario (c); here we want a user without
+        // having to drive register + login + antiforgery on every test.
+        using var scope = Factory.Services.CreateScope();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var email = $"regen-{Guid.NewGuid():N}@example.test";
+        var user = new ApplicationUser { Email = email, UserName = email };
+        var result = await users.CreateAsync(user, StrongPassword);
+        result.Succeeded.Should()
+            .BeTrue(because: $"seed must succeed — got [{string.Join(", ", result.Errors.Select(e => e.Code))}]");
+        return user.Id;
+    }
+
+    private async Task<RegeneratePlanResponse> InvokeHandlerAsync(RegeneratePlanCommand cmd)
+    {
+        // Open a single per-call DI scope so `IDocumentSession`,
+        //   `IIdempotencyStore`, and `IPlanGenerationService` (via the stub
+        //   factory below) all share one session — the same lifetime contract
+        //   Wolverine's transactional middleware enforces in production.
+        // Marten is configured with TenancyStyle.Conjoined; the production
+        // path uses InvokeForTenantAsync(userId, …) to bracket the handler in
+        // a tenanted session. Mirror that here by opening a session tenanted
+        // to the command's UserId so IIdempotencyStore.Record can stamp the
+        // marker's tenant column without rejecting the *DEFAULT* placeholder.
+        var store = Factory.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(cmd.UserId.ToString());
+        var idempotency = new MartenIdempotencyStore(
+            session,
+            TimeProvider.System,
+            NullLogger<MartenIdempotencyStore>.Instance);
+        var planGen = new StubPlanGenerationService();
+
+        var response = await RegeneratePlanHandler.Handle(
+            cmd,
+            session,
+            planGen,
+            idempotency,
+            NullLogger<RegeneratePlanHandler>.Instance,
+            TestContext.Current.CancellationToken);
+
+        // The Wolverine handler itself never calls SaveChangesAsync — the
+        //   transactional middleware does. Stand in for the framework here so
+        //   the staged events + idempotency marker actually commit. The
+        //   MartenEntityFrameworkCore transaction-participant wiring then
+        //   runs the inline projection's EF write inside the same DB
+        //   transaction (per DEC-060 / R-069).
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return response;
+    }
+
+    private async Task SeedInitialPlanStreamAsync(Guid userId, Guid planId)
+    {
+        // Append the canonical Slice 1 event sequence so the inline
+        // PlanProjection materializes a complete PlanProjectionDto document.
+        // Tenant the session to the user — Marten is configured with
+        // TenancyStyle.Conjoined so the regenerate handler reads the stream
+        // back through a userId-tenanted session, and a default-tenant seed
+        // would land on a different physical row.
+        var store = Factory.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        var generated = new PlanGenerated(
+            planId,
+            userId,
+            BuildMacro(goal: "Initial plan"),
+            new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero),
+            PromptVersion: "coaching-v1",
+            ModelId: "claude-sonnet-4-5",
+            PreviousPlanId: null);
+        var events = new object[]
+        {
+            generated,
+            new MesoCycleCreated(1, BuildMeso(1, PhaseType.Base, isDeload: false)),
+            new MesoCycleCreated(2, BuildMeso(2, PhaseType.Base, isDeload: false)),
+            new MesoCycleCreated(3, BuildMeso(3, PhaseType.Build, isDeload: false)),
+            new MesoCycleCreated(4, BuildMeso(4, PhaseType.Build, isDeload: true)),
+            new FirstMicroCycleCreated(BuildMicro()),
+        };
+        session.Events.StartStream<PlanProjectionDto>(planId, events);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task SeedOnboardingCompletionAsync(Guid userId, Guid initialPlanId)
+    {
+        // Drive the onboarding stream to completion via the projection
+        // pipeline rather than direct EF row inserts. Three events are the
+        // minimum the regenerate flow needs:
+        //   - OnboardingStarted  -> seeds OnboardingView + UserProfile rows
+        //   - PlanLinkedToUser   -> sets CurrentPlanId on both projections
+        //   - OnboardingCompleted-> sets OnboardingCompletedAt on the EF row
+        // OnboardingProjection is registered ProjectionLifecycle.Inline, so
+        // this commit also materializes the OnboardingView the regenerate
+        // handler reads via session.LoadAsync<OnboardingView>(userId).
+        // Marten's TenancyStyle.Conjoined requires the seed to use a
+        // userId-tenanted session so the projection lands on the same
+        // tenant column the handler queries.
+        var store = Factory.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        var startedAt = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+        var completedAt = new DateTimeOffset(2026, 4, 1, 12, 5, 0, TimeSpan.Zero);
+        session.Events.StartStream<OnboardingView>(
+            userId,
+            new OnboardingStarted(userId, startedAt),
+            new PlanLinkedToUser(userId, initialPlanId),
+            new OnboardingCompleted(initialPlanId, completedAt));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<IReadOnlyList<PlanProjectionDto>> LoadAllPlanProjectionsAsync(Guid tenantId)
+    {
+        // Marten is configured with TenancyStyle.Conjoined so the projections
+        // live behind the tenant column; query through the user-tenanted
+        // session that mirrors how the controller reads them.
+        var store = Factory.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.QuerySession(tenantId.ToString());
+        var query = session.Query<PlanProjectionDto>();
+        return await Marten.QueryableExtensions.ToListAsync(query, TestContext.Current.CancellationToken);
+    }
+
+    private async Task<IReadOnlyList<PlanLinkedToUser>> LoadPlanLinkedEventsAsync(Guid streamId, Guid tenantId)
+    {
+        // FetchStreamAsync also resolves through the tenant column when
+        // TenancyStyle.Conjoined is active.
+        var store = Factory.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.QuerySession(tenantId.ToString());
+        var events = await session.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+        return events
+            .Select(e => e.Data)
+            .OfType<PlanLinkedToUser>()
+            .ToList();
+    }
+
+    private async Task<RunnerOnboardingProfile?> LoadUserProfileAsync(Guid userId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<RunCoachDbContext>();
+        var query = db.RunnerOnboardingProfiles
+            .AsNoTracking()
+            .Where(p => p.UserId == userId);
+        return await EntityFrameworkQueryableExtensions
+            .SingleOrDefaultAsync(query, TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<(HttpClient Client, CookieContainer Container, string AntiforgeryToken)>
+        RegisterAndPrepareCookieClientAsync()
+    {
+        var container = new CookieContainer();
+        var client = Factory.CreateDefaultClient(new CookieContainerHandler(container));
+        client.BaseAddress = BaseUri;
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        var antiforgeryToken = await PrimeAntiforgeryAsync(client, container);
+
+        var email = $"regen-{Guid.NewGuid():N}@example.test";
+        using var registerRequest = new HttpRequestMessage(HttpMethod.Post, "/api/v1/auth/register");
+        registerRequest.Headers.Add(AntiforgeryHeaderName, antiforgeryToken);
+        registerRequest.Content = JsonContent.Create(new RegisterRequestDto(email, StrongPassword));
+        using var registerResponse = await client.SendAsync(registerRequest, TestContext.Current.CancellationToken);
+        registerResponse.StatusCode.Should().Be(HttpStatusCode.Created, because: "register helper must succeed");
+
+        // /register creates the ApplicationUser but does NOT sign in — the
+        //   SPA flow is register → login. Run the login call here so the
+        //   session cookie lands in the container.
+        antiforgeryToken = await PrimeAntiforgeryAsync(client, container);
+        using var loginRequest = new HttpRequestMessage(HttpMethod.Post, "/api/v1/auth/login");
+        loginRequest.Headers.Add(AntiforgeryHeaderName, antiforgeryToken);
+        loginRequest.Content = JsonContent.Create(new LoginRequestDto(email, StrongPassword));
+        using var loginResponse = await client.SendAsync(loginRequest, TestContext.Current.CancellationToken);
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK, because: "login helper must succeed");
+
+        antiforgeryToken = await PrimeAntiforgeryAsync(client, container);
+        return (client, container, antiforgeryToken);
+    }
+
+    /// <summary>
+    /// Deterministic stub for <see cref="IPlanGenerationService"/> used by
+    /// every direct-handler integration test in this class. Returns the
+    /// canonical Slice 1 event sequence threading <paramref name="previousPlanId"/>
+    /// onto <see cref="PlanGenerated.PreviousPlanId"/> exactly the way the
+    /// production service does — so the integration tests cover the
+    /// regenerate handler's wiring (idempotency check, view load,
+    /// stream-creation, PlanLinkedToUser append) without depending on the
+    /// live LLM.
+    /// </summary>
+    private sealed class StubPlanGenerationService : IPlanGenerationService
+    {
+        public Task<PlanEventSequence> GeneratePlanAsync(
+            OnboardingView profileSnapshot,
+            Guid userId,
+            Guid planId,
+            RegenerationIntent? intent,
+            Guid? previousPlanId,
+            CancellationToken ct)
+        {
+            _ = profileSnapshot;
+            _ = intent;
+
+            var generated = new PlanGenerated(
+                planId,
+                userId,
+                BuildMacro(goal: "Regenerated plan"),
+                new DateTimeOffset(2026, 4, 25, 12, 0, 0, TimeSpan.Zero),
+                PromptVersion: "coaching-v1",
+                ModelId: "claude-sonnet-4-5",
+                PreviousPlanId: previousPlanId);
+
+            var mesos = new[]
+            {
+                new MesoCycleCreated(1, BuildMeso(1, PhaseType.Base, isDeload: false)),
+                new MesoCycleCreated(2, BuildMeso(2, PhaseType.Base, isDeload: false)),
+                new MesoCycleCreated(3, BuildMeso(3, PhaseType.Build, isDeload: false)),
+                new MesoCycleCreated(4, BuildMeso(4, PhaseType.Build, isDeload: true)),
+            };
+            var micro = new FirstMicroCycleCreated(BuildMicro());
+
+            return Task.FromResult(new PlanEventSequence(generated, mesos, micro));
+        }
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanRegenerateIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanRegenerateIntegrationTests.cs
@@ -3,10 +3,13 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using FluentAssertions;
 using Marten;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using RunCoach.Api.Infrastructure;
 using RunCoach.Api.Infrastructure.Idempotency;
 using RunCoach.Api.Modules.Coaching.Models;
@@ -18,6 +21,7 @@ using RunCoach.Api.Modules.Identity.Entities;
 using RunCoach.Api.Modules.Training.Plan;
 using RunCoach.Api.Modules.Training.Plan.Models;
 using RunCoach.Api.Tests.Infrastructure;
+using Wolverine;
 
 namespace RunCoach.Api.Tests.Modules.Training.Plan;
 
@@ -184,7 +188,7 @@ public class PlanRegenerateIntegrationTests(RunCoachAppFactory factory) : DbBack
         //   runner has an ApplicationUser row but no UserProfile row at all
         //   (and even if one existed, OnboardingCompletedAt would be null).
         //   Either case lands the controller's gate-fail path.
-        var (client, _, antiforgeryToken) = await RegisterAndPrepareCookieClientAsync();
+        var (client, _, antiforgeryToken, _) = await RegisterAndPrepareCookieClientAsync(Factory);
 
         // Act
         using var request = BuildRegenerateRequest(antiforgeryToken, idempotencyKey: Guid.NewGuid(), intent: null);
@@ -197,6 +201,165 @@ public class PlanRegenerateIntegrationTests(RunCoachAppFactory factory) : DbBack
             cancellationToken: TestContext.Current.CancellationToken);
         problem.Should().NotBeNull();
         problem!.Type.Should().Be(OnboardingNotCompleteType);
+    }
+
+    /// <summary>
+    /// HTTP-layer happy path: drives <c>POST /api/v1/plan/regenerate</c> over
+    /// the live ASP.NET Core pipeline (cookie auth + antiforgery + sanitizer +
+    /// Wolverine dispatch + handler) and asserts the controller's
+    /// <see cref="PlanRenderingController.Regenerate"/> success branch returns
+    /// 200 with a fresh <c>planId</c> + <c>status: "generated"</c>. A follow-up
+    /// <c>GET /api/v1/plan/current</c> proves the
+    /// <c>UserProfileFromOnboardingProjection</c> apply branch flipped
+    /// <c>RunnerOnboardingProfile.CurrentPlanId</c> to the new plan id atomically with
+    /// the Marten append. Closes the SonarCloud coverage gap on the controller's
+    /// success path that the direct-handler tests above cannot exercise.
+    /// </summary>
+    [Fact]
+    public async Task Regenerate_HTTP_With_Valid_Onboarding_Returns_200_And_New_Plan()
+    {
+        // Arrange — register, complete onboarding, seed an initial plan stream
+        //   so the regenerate handler has a prior `CurrentPlanId` to thread
+        //   onto `PlanGenerated.PreviousPlanId`. Override `IMessageBus` with a
+        //   stub that runs the real handler body against a fresh tenanted
+        //   Marten session — mirrors what Wolverine transactional middleware
+        //   brackets in production while bypassing the WAF-derived host
+        //   handler discovery; `WithWebHostBuilder` does not re-run the
+        //   Wolverine assembly scan. Threads `StubPlanGenerationService`
+        //   through the real handler so no live LLM call fires.
+        using var customFactory = Factory.WithWebHostBuilder(b =>
+            b.ConfigureTestServices(svc =>
+                svc.AddSingleton(BuildRegenerateBusStub(Factory))));
+
+        var (client, _, antiforgeryToken, userId) = await RegisterAndPrepareCookieClientAsync(customFactory);
+        var initialPlanId = Guid.NewGuid();
+        await SeedInitialPlanStreamAsync(userId, initialPlanId);
+        await SeedOnboardingCompletionAsync(userId, initialPlanId);
+
+        var idempotencyKey = Guid.NewGuid();
+
+        // Act — POST /api/v1/plan/regenerate with an intent free-text.
+        using var request = BuildRegenerateRequest(antiforgeryToken, idempotencyKey, intent: "Need more long runs");
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert — 200 with the controller's RegeneratePlanResponse shape.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var actualResponse = await response.Content.ReadFromJsonAsync<RegeneratePlanResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        actualResponse.Should().NotBeNull();
+        actualResponse!.PlanId.Should().NotBe(initialPlanId, because: "regeneration must produce a new plan id");
+        actualResponse.PlanId.Should().NotBe(Guid.Empty);
+        actualResponse.Status.Should().Be("generated");
+
+        // Follow-up GET /api/v1/plan/current must return the freshly-projected
+        //   PlanProjectionDto for the new plan id — proves the Marten inline
+        //   projection committed inside the same transaction the regenerate
+        //   handler appended on, and that UserProfileFromOnboardingProjection
+        //   moved RunnerOnboardingProfile.CurrentPlanId to the new plan id.
+        using var getResponse = await client.GetAsync(
+            "/api/v1/plan/current",
+            TestContext.Current.CancellationToken);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var actualPlan = await getResponse.Content.ReadFromJsonAsync<PlanProjectionDto>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        actualPlan.Should().NotBeNull();
+        actualPlan!.PlanId.Should().Be(actualResponse.PlanId);
+        actualPlan.PreviousPlanId.Should().Be(initialPlanId);
+    }
+
+    /// <summary>
+    /// HTTP-layer happy path with no intent — same as the previous test but
+    /// the request body omits the optional <c>intent</c> block. Exercises the
+    /// controller branch where <c>request.Intent is null</c> bypasses
+    /// sanitization entirely and a null <see cref="RegenerationIntent"/> flows
+    /// to the handler.
+    /// </summary>
+    [Fact]
+    public async Task Regenerate_HTTP_Without_Intent_Returns_200()
+    {
+        // Arrange — see BuildRegenerateBusStub doc; we override IMessageBus
+        //   rather than IPlanGenerationService because the WAF-derived host
+        //   does not re-run Wolverine's assembly scan and would otherwise
+        //   surface IndeterminateRoutesException for RegeneratePlanCommand.
+        using var customFactory = Factory.WithWebHostBuilder(b =>
+            b.ConfigureTestServices(svc =>
+                svc.AddSingleton(BuildRegenerateBusStub(Factory))));
+
+        var (client, _, antiforgeryToken, userId) = await RegisterAndPrepareCookieClientAsync(customFactory);
+        var initialPlanId = Guid.NewGuid();
+        await SeedInitialPlanStreamAsync(userId, initialPlanId);
+        await SeedOnboardingCompletionAsync(userId, initialPlanId);
+
+        // Act — POST regenerate with intent=null.
+        using var request = BuildRegenerateRequest(antiforgeryToken, idempotencyKey: Guid.NewGuid(), intent: null);
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var actualResponse = await response.Content.ReadFromJsonAsync<RegeneratePlanResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        actualResponse.Should().NotBeNull();
+        actualResponse!.PlanId.Should().NotBe(initialPlanId);
+        actualResponse.Status.Should().Be("generated");
+    }
+
+    /// <summary>
+    /// HTTP-layer 400 path — the controller validates raw <c>intent.freeText</c>
+    /// against <see cref="RegenerationIntent.RawMaxFreeTextLength"/> BEFORE
+    /// invoking the sanitizer, so a 501-character payload trips the cap and
+    /// returns 400 ProblemDetails without touching Wolverine or the handler.
+    /// </summary>
+    [Fact]
+    public async Task Regenerate_HTTP_With_Oversize_FreeText_Returns_400()
+    {
+        // Arrange — onboarding seeded so the 400 path is exercised AFTER the
+        //   onboarding-complete gate (otherwise the 409 gate would short-circuit
+        //   first and we would not be testing the length validation branch).
+        var (client, _, antiforgeryToken, userId) = await RegisterAndPrepareCookieClientAsync(Factory);
+        var initialPlanId = Guid.NewGuid();
+        await SeedInitialPlanStreamAsync(userId, initialPlanId);
+        await SeedOnboardingCompletionAsync(userId, initialPlanId);
+
+        var oversizeFreeText = new string('x', RegenerationIntent.RawMaxFreeTextLength + 1);
+
+        // Act
+        using var request = BuildRegenerateRequest(antiforgeryToken, idempotencyKey: Guid.NewGuid(), intent: oversizeFreeText);
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+        var problem = await response.Content.ReadFromJsonAsync<Microsoft.AspNetCore.Mvc.ProblemDetails>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        problem.Should().NotBeNull();
+        problem!.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    /// <summary>
+    /// HTTP-layer 401 path — anonymous request (no cookie / no bearer token)
+    /// must be rejected by the <see cref="AuthPolicies.CookieOrBearer"/> policy
+    /// before the controller body executes.
+    /// </summary>
+    [Fact]
+    public async Task Regenerate_HTTP_Without_Auth_Returns_401()
+    {
+        // Arrange — anonymous client. Antiforgery is bypassed by the auth gate
+        //   running first; both unauthenticated and antiforgery-missing requests
+        //   land on 401 because the auth challenge wins the precedence race.
+        var client = Factory.CreateDefaultClient();
+        client.BaseAddress = BaseUri;
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/plan/regenerate")
+        {
+            Content = JsonContent.Create(new RegeneratePlanRequestDto(Guid.NewGuid(), Intent: null)),
+        };
+
+        // Act
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
     /// <summary>
@@ -391,6 +554,106 @@ public class PlanRegenerateIntegrationTests(RunCoachAppFactory factory) : DbBack
         };
     }
 
+    /// <summary>
+    /// Builds an <see cref="IMessageBus"/> stub whose
+    /// <c>InvokeForTenantAsync&lt;RegeneratePlanResponse&gt;</c> implementation
+    /// runs the real <see cref="RegeneratePlanHandler.Handle"/> body against a
+    /// fresh tenanted Marten session — exactly the contract Wolverine's
+    /// transactional middleware brackets in production. The stub threads
+    /// <see cref="StubPlanGenerationService"/> as <see cref="IPlanGenerationService"/>
+    /// so the six-call macro/meso/micro chain is replaced with the deterministic
+    /// canonical event sequence (no live LLM). Used in HTTP integration tests
+    /// where <c>WithWebHostBuilder</c> rebuilds the WAF host and Wolverine's
+    /// assembly-discovery codegen does not re-fire — without this stub the
+    /// controller's <c>bus.InvokeForTenantAsync</c> call surfaces
+    /// <c>IndeterminateRoutesException</c>.
+    /// </summary>
+    private static IMessageBus BuildRegenerateBusStub(RunCoachAppFactory factory)
+    {
+        var bus = Substitute.For<IMessageBus>();
+        bus
+            .InvokeForTenantAsync<RegeneratePlanResponse>(
+                Arg.Any<string>(),
+                Arg.Any<object>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<TimeSpan?>())
+            .Returns(async call =>
+            {
+                var tenantId = call.ArgAt<string>(0);
+                var cmd = (RegeneratePlanCommand)call.ArgAt<object>(1);
+                var ct = call.ArgAt<CancellationToken>(2);
+
+                // Open a session tenanted to the dispatching userId, the same
+                //   way `IMessageBus.InvokeForTenantAsync` would inside Wolverine's
+                //   transactional middleware. The handler stages events +
+                //   idempotency marker on this session; the framework would
+                //   commit them via auto-applied transactions — here we call
+                //   `SaveChangesAsync` explicitly to mirror that contract.
+                var store = factory.Services.GetRequiredService<IDocumentStore>();
+                await using var session = store.LightweightSession(tenantId);
+                var idempotency = new MartenIdempotencyStore(
+                    session,
+                    TimeProvider.System,
+                    NullLogger<MartenIdempotencyStore>.Instance);
+                var planGen = new StubPlanGenerationService();
+
+                var response = await RegeneratePlanHandler.Handle(
+                    cmd,
+                    session,
+                    planGen,
+                    idempotency,
+                    NullLogger<RegeneratePlanHandler>.Instance,
+                    ct);
+
+                await session.SaveChangesAsync(ct);
+                return response;
+            });
+        return bus;
+    }
+
+    private static async Task<(HttpClient Client, CookieContainer Container, string AntiforgeryToken, Guid UserId)>
+        RegisterAndPrepareCookieClientAsync(Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program> factory)
+    {
+        var container = new CookieContainer();
+        var client = factory.CreateDefaultClient(new CookieContainerHandler(container));
+        client.BaseAddress = BaseUri;
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        var antiforgeryToken = await PrimeAntiforgeryAsync(client, container);
+
+        var email = $"regen-{Guid.NewGuid():N}@example.test";
+        using var registerRequest = new HttpRequestMessage(HttpMethod.Post, "/api/v1/auth/register");
+        registerRequest.Headers.Add(AntiforgeryHeaderName, antiforgeryToken);
+        registerRequest.Content = JsonContent.Create(new RegisterRequestDto(email, StrongPassword));
+        using var registerResponse = await client.SendAsync(registerRequest, TestContext.Current.CancellationToken);
+        registerResponse.StatusCode.Should().Be(HttpStatusCode.Created, because: "register helper must succeed");
+
+        // /register creates the ApplicationUser but does NOT sign in — the
+        //   SPA flow is register → login. Run the login call here so the
+        //   session cookie lands in the container.
+        antiforgeryToken = await PrimeAntiforgeryAsync(client, container);
+        using var loginRequest = new HttpRequestMessage(HttpMethod.Post, "/api/v1/auth/login");
+        loginRequest.Headers.Add(AntiforgeryHeaderName, antiforgeryToken);
+        loginRequest.Content = JsonContent.Create(new LoginRequestDto(email, StrongPassword));
+        using var loginResponse = await client.SendAsync(loginRequest, TestContext.Current.CancellationToken);
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK, because: "login helper must succeed");
+
+        antiforgeryToken = await PrimeAntiforgeryAsync(client, container);
+
+        // Resolve the registered ApplicationUser's id off UserManager so seed
+        // helpers (SeedInitialPlanStreamAsync / SeedOnboardingCompletionAsync)
+        // can land events on the same userId the cookie-authenticated client
+        // identifies as. Both factories share the same Testcontainers Postgres
+        // via the env-var override on the assembly-wide RunCoachAppFactory, so
+        // a UserManager scope from the inner factory's Services container sees
+        // the row that was just created through the outer client's HTTP call.
+        using var scope = factory.Services.CreateScope();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var registered = await users.FindByEmailAsync(email);
+        registered.Should().NotBeNull(because: "the registered user must exist after the /register call");
+        return (client, container, antiforgeryToken, registered!.Id);
+    }
+
     private async Task<Guid> SeedUserAsync()
     {
         // Provision an Identity row directly through UserManager so the
@@ -536,37 +799,6 @@ public class PlanRegenerateIntegrationTests(RunCoachAppFactory factory) : DbBack
         return await EntityFrameworkQueryableExtensions
             .SingleOrDefaultAsync(query, TestContext.Current.CancellationToken)
             .ConfigureAwait(false);
-    }
-
-    private async Task<(HttpClient Client, CookieContainer Container, string AntiforgeryToken)>
-        RegisterAndPrepareCookieClientAsync()
-    {
-        var container = new CookieContainer();
-        var client = Factory.CreateDefaultClient(new CookieContainerHandler(container));
-        client.BaseAddress = BaseUri;
-        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-        var antiforgeryToken = await PrimeAntiforgeryAsync(client, container);
-
-        var email = $"regen-{Guid.NewGuid():N}@example.test";
-        using var registerRequest = new HttpRequestMessage(HttpMethod.Post, "/api/v1/auth/register");
-        registerRequest.Headers.Add(AntiforgeryHeaderName, antiforgeryToken);
-        registerRequest.Content = JsonContent.Create(new RegisterRequestDto(email, StrongPassword));
-        using var registerResponse = await client.SendAsync(registerRequest, TestContext.Current.CancellationToken);
-        registerResponse.StatusCode.Should().Be(HttpStatusCode.Created, because: "register helper must succeed");
-
-        // /register creates the ApplicationUser but does NOT sign in — the
-        //   SPA flow is register → login. Run the login call here so the
-        //   session cookie lands in the container.
-        antiforgeryToken = await PrimeAntiforgeryAsync(client, container);
-        using var loginRequest = new HttpRequestMessage(HttpMethod.Post, "/api/v1/auth/login");
-        loginRequest.Headers.Add(AntiforgeryHeaderName, antiforgeryToken);
-        loginRequest.Content = JsonContent.Create(new LoginRequestDto(email, StrongPassword));
-        using var loginResponse = await client.SendAsync(loginRequest, TestContext.Current.CancellationToken);
-        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK, because: "login helper must succeed");
-
-        antiforgeryToken = await PrimeAntiforgeryAsync(client, container);
-        return (client, container, antiforgeryToken);
     }
 
     /// <summary>

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanRegenerateIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanRegenerateIntegrationTests.cs
@@ -336,16 +336,52 @@ public class PlanRegenerateIntegrationTests(RunCoachAppFactory factory) : DbBack
     }
 
     /// <summary>
+    /// HTTP-layer 400 path — the controller rejects a request whose
+    /// <c>idempotencyKey</c> is <c>Guid.Empty</c> (all-zeros UUID) with
+    /// 400 ProblemDetails of
+    /// <c>type = "https://runcoach.app/problems/invalid-idempotency-key"</c>.
+    /// This gate is controller-side, before the Wolverine dispatch, so no
+    /// handler body executes.
+    /// </summary>
+    [Fact]
+    public async Task Regenerate_HTTP_With_EmptyIdempotencyKey_Returns_400()
+    {
+        // Arrange — onboarding seeded so the empty-key check runs AFTER the
+        //   onboarding-complete gate (otherwise the 409 gate would short-circuit
+        //   first and we would not be testing the idempotency-key branch).
+        var (client, _, antiforgeryToken, userId) = await RegisterAndPrepareCookieClientAsync(Factory);
+        var initialPlanId = Guid.NewGuid();
+        await SeedInitialPlanStreamAsync(userId, initialPlanId);
+        await SeedOnboardingCompletionAsync(userId, initialPlanId);
+
+        // Act — POST with idempotencyKey = 00000000-0000-0000-0000-000000000000.
+        using var request = BuildRegenerateRequest(antiforgeryToken, idempotencyKey: Guid.Empty, intent: null);
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+        var problem = await response.Content.ReadFromJsonAsync<Microsoft.AspNetCore.Mvc.ProblemDetails>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        problem.Should().NotBeNull();
+        problem!.Type.Should().Be("https://runcoach.app/problems/invalid-idempotency-key");
+    }
+
+    /// <summary>
     /// HTTP-layer 401 path — anonymous request (no cookie / no bearer token)
     /// must be rejected by the <see cref="AuthPolicies.CookieOrBearer"/> policy
-    /// before the controller body executes.
+    /// before the controller body executes. Antiforgery validation is
+    /// configured; authenticated requests missing <c>X-XSRF-TOKEN</c> return
+    /// 400 (see <see cref="Regenerate_HTTP_Authenticated_Without_Antiforgery_Returns_400"/>).
+    /// Anonymous requests return 401 because the auth challenge runs before
+    /// the antiforgery middleware.
     /// </summary>
     [Fact]
     public async Task Regenerate_HTTP_Without_Auth_Returns_401()
     {
-        // Arrange — anonymous client. Antiforgery is bypassed by the auth gate
-        //   running first; both unauthenticated and antiforgery-missing requests
-        //   land on 401 because the auth challenge wins the precedence race.
+        // Arrange — anonymous client. The middleware order is Authentication →
+        //   Authorization → Antiforgery, so an unauthenticated request never
+        //   reaches the antiforgery gate; the 401 challenge fires first.
         var client = Factory.CreateDefaultClient();
         client.BaseAddress = BaseUri;
         client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -360,6 +396,188 @@ public class PlanRegenerateIntegrationTests(RunCoachAppFactory factory) : DbBack
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    /// <summary>
+    /// intent-1 (conf 75) — Authenticated user missing the <c>X-XSRF-TOKEN</c>
+    /// antiforgery header receives 400, not 401. The middleware order is
+    /// Authentication → Authorization → Antiforgery (via
+    /// <c>UseAntiforgeryProblemDetailsBridge</c>), so an authenticated request
+    /// passes auth checks before the antiforgery gate fires a 400.
+    /// Completes the spec / test alignment flagged in review finding intent-1.
+    /// </summary>
+    [Fact]
+    public async Task Regenerate_HTTP_Authenticated_Without_Antiforgery_Returns_400()
+    {
+        // Arrange — register and log in a user so the session cookie is in
+        //   the container, but deliberately omit X-XSRF-TOKEN from the
+        //   regenerate POST. The antiforgery bridge middleware must intercept
+        //   the failure and return 400 ProblemDetails before the controller
+        //   body executes.
+        var (client, _, _, userId) = await RegisterAndPrepareCookieClientAsync(Factory);
+        var initialPlanId = Guid.NewGuid();
+        await SeedInitialPlanStreamAsync(userId, initialPlanId);
+        await SeedOnboardingCompletionAsync(userId, initialPlanId);
+
+        // Build request WITHOUT the antiforgery header.
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/plan/regenerate")
+        {
+            Content = JsonContent.Create(new RegeneratePlanRequestDto(Guid.NewGuid(), Intent: null)),
+        };
+
+        // Act
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert — antiforgery bridge fires 400, not 401. The session cookie
+        //   authenticates the user; the missing header is the only failure.
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+        var problem = await response.Content.ReadFromJsonAsync<Microsoft.AspNetCore.Mvc.ProblemDetails>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        problem.Should().NotBeNull();
+        problem!.Type.Should().Be("https://runcoach.app/problems/antiforgery-validation-failed");
+    }
+
+    /// <summary>
+    /// security-1 / bug-2 (conf 88) — a 500-character payload of all
+    /// <c>&lt;</c> chars (the worst-case bracket-escape expansion input) must
+    /// succeed with 200 OK now that
+    /// <see cref="RegenerationIntent.MaxFreeTextLength"/> is sized to
+    /// <c>RawMaxFreeTextLength × MaxEscapeExpansionFactor + DelimiterOverhead</c>
+    /// (2700). A 500-char input of <c>&lt;</c> expands to ~2058 chars after
+    /// entity-escaping (<c>&amp;lt;</c>) — well under 2700 — and must NOT
+    /// produce an unhandled 500 from the <see cref="RegenerationIntent"/>
+    /// constructor's length guard.
+    /// </summary>
+    [Fact]
+    public async Task Regenerate_HTTP_With_BracketHeavy_FreeText_Returns_200()
+    {
+        // security-1 / bug-2: bracket-heavy input at cap must not produce 500.
+        // Arrange
+        using var customFactory = Factory.WithWebHostBuilder(b =>
+            b.ConfigureTestServices(svc =>
+                svc.AddSingleton(BuildRegenerateBusStub(Factory))));
+
+        var (client, _, antiforgeryToken, userId) = await RegisterAndPrepareCookieClientAsync(customFactory);
+        var initialPlanId = Guid.NewGuid();
+        await SeedInitialPlanStreamAsync(userId, initialPlanId);
+        await SeedOnboardingCompletionAsync(userId, initialPlanId);
+
+        // 500 '<' chars — worst-case bracket-escape expansion. Each '<'
+        // becomes "&lt;" (4 chars), so sanitized body is ~2000 chars before
+        // the delimiter wrapper adds its overhead (~58 chars). Total is well
+        // under MaxFreeTextLength (2700).
+        var bracketHeavyText = new string('<', RegenerationIntent.RawMaxFreeTextLength);
+
+        // Act
+        using var request = BuildRegenerateRequest(antiforgeryToken, Guid.NewGuid(), intent: bracketHeavyText);
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert — must succeed; 500 would indicate RegenerationIntent
+        //   constructor threw because MaxFreeTextLength was sized too small.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var actualResponse = await response.Content.ReadFromJsonAsync<RegeneratePlanResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        actualResponse.Should().NotBeNull();
+        actualResponse!.PlanId.Should().NotBe(Guid.Empty);
+        actualResponse.Status.Should().Be("generated");
+    }
+
+    /// <summary>
+    /// test-5 (conf 92) — a <see cref="RegenerationIntent.RawMaxFreeTextLength"/>-char
+    /// payload (exactly 500 plain ASCII chars) must succeed with 200 OK.
+    /// Combined with <see cref="Regenerate_HTTP_With_Oversize_FreeText_Returns_400"/>
+    /// (501 chars → 400), this pair pins the boundary on both sides against a
+    /// <c>&gt;</c> vs <c>&gt;=</c> regression in the controller's length check.
+    /// </summary>
+    [Fact]
+    public async Task Regenerate_HTTP_With_FreeText_AtRawMaxFreeTextLength_Returns_200()
+    {
+        // test-5: at-cap plain ASCII input (500 chars) must succeed.
+        // Arrange
+        using var customFactory = Factory.WithWebHostBuilder(b =>
+            b.ConfigureTestServices(svc =>
+                svc.AddSingleton(BuildRegenerateBusStub(Factory))));
+
+        var (client, _, antiforgeryToken, userId) = await RegisterAndPrepareCookieClientAsync(customFactory);
+        var initialPlanId = Guid.NewGuid();
+        await SeedInitialPlanStreamAsync(userId, initialPlanId);
+        await SeedOnboardingCompletionAsync(userId, initialPlanId);
+
+        var atCapText = new string('a', RegenerationIntent.RawMaxFreeTextLength);
+
+        // Act
+        using var request = BuildRegenerateRequest(antiforgeryToken, Guid.NewGuid(), intent: atCapText);
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var actualResponse = await response.Content.ReadFromJsonAsync<RegeneratePlanResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        actualResponse.Should().NotBeNull();
+        actualResponse!.PlanId.Should().NotBe(Guid.Empty);
+        actualResponse.Status.Should().Be("generated");
+    }
+
+    /// <summary>
+    /// test-4 (conf 90) — pins that the controller's sanitizer wiring is
+    /// active on the regenerate path. Posts a known free-text and captures
+    /// the <see cref="RegeneratePlanCommand"/> the bus stub receives, then
+    /// asserts the captured intent's <c>FreeText</c> is the Spotlighting-
+    /// wrapped form produced by <see cref="IPromptSanitizer.SanitizeAsync"/>
+    /// rather than the raw string. A regression that removed the
+    /// <c>sanitizer.SanitizeAsync</c> call would pass through the raw text
+    /// without the <c>&lt;REGENERATION_INTENT id="..."&gt;…&lt;/REGENERATION_INTENT&gt;</c>
+    /// wrapper and fail this assertion.
+    /// </summary>
+    [Fact]
+    public async Task Regenerate_HTTP_Sanitizer_Wraps_FreeText_In_Spotlighting_Delimiter()
+    {
+        // test-4: capture the command that the bus stub receives and verify
+        //   the intent freeText is the sanitized, delimiter-wrapped form.
+        RegeneratePlanCommand? capturedCmd = null;
+
+        var bus = Substitute.For<IMessageBus>();
+        bus
+            .InvokeForTenantAsync<RegeneratePlanResponse>(
+                Arg.Any<string>(),
+                Arg.Any<object>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<TimeSpan?>())
+            .Returns(async call =>
+            {
+                var tenantId = call.ArgAt<string>(0);
+                var cmd = (RegeneratePlanCommand)call.ArgAt<object>(1);
+                var ct = call.ArgAt<CancellationToken>(2);
+                capturedCmd = cmd;
+                return await RunHandlerOnFreshSessionAsync(Factory, tenantId, cmd, ct);
+            });
+
+        using var customFactory = Factory.WithWebHostBuilder(b =>
+            b.ConfigureTestServices(svc => svc.AddSingleton(bus)));
+
+        var (client, _, antiforgeryToken, userId) = await RegisterAndPrepareCookieClientAsync(customFactory);
+        var initialPlanId = Guid.NewGuid();
+        await SeedInitialPlanStreamAsync(userId, initialPlanId);
+        await SeedOnboardingCompletionAsync(userId, initialPlanId);
+
+        const string RawFreeText = "need-injury-handling";
+
+        // Act
+        using var request = BuildRegenerateRequest(antiforgeryToken, Guid.NewGuid(), intent: RawFreeText);
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert — controller must have called sanitizer; the captured command
+        //   intent must carry the Spotlighting-wrapped output, not the raw string.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        capturedCmd.Should().NotBeNull(because: "bus stub must have been called");
+        capturedCmd!.Intent.Should().NotBeNull(because: "non-null freeText must produce a non-null sanitized intent");
+        capturedCmd.Intent!.FreeText.Should().StartWith(
+            "<REGENERATION_INTENT id=\"",
+            because: "the controller must call IPromptSanitizer which wraps the text in a Spotlighting delimiter");
+        capturedCmd.Intent.FreeText.Should().Contain(
+            RawFreeText,
+            because: "the raw text must be present (encoded) inside the delimiter wrapper");
     }
 
     /// <summary>
@@ -582,33 +800,51 @@ public class PlanRegenerateIntegrationTests(RunCoachAppFactory factory) : DbBack
                 var tenantId = call.ArgAt<string>(0);
                 var cmd = (RegeneratePlanCommand)call.ArgAt<object>(1);
                 var ct = call.ArgAt<CancellationToken>(2);
-
-                // Open a session tenanted to the dispatching userId, the same
-                //   way `IMessageBus.InvokeForTenantAsync` would inside Wolverine's
-                //   transactional middleware. The handler stages events +
-                //   idempotency marker on this session; the framework would
-                //   commit them via auto-applied transactions — here we call
-                //   `SaveChangesAsync` explicitly to mirror that contract.
-                var store = factory.Services.GetRequiredService<IDocumentStore>();
-                await using var session = store.LightweightSession(tenantId);
-                var idempotency = new MartenIdempotencyStore(
-                    session,
-                    TimeProvider.System,
-                    NullLogger<MartenIdempotencyStore>.Instance);
-                var planGen = new StubPlanGenerationService();
-
-                var response = await RegeneratePlanHandler.Handle(
-                    cmd,
-                    session,
-                    planGen,
-                    idempotency,
-                    NullLogger<RegeneratePlanHandler>.Instance,
-                    ct);
-
-                await session.SaveChangesAsync(ct);
-                return response;
+                return await RunHandlerOnFreshSessionAsync(factory, tenantId, cmd, ct);
             });
         return bus;
+    }
+
+    /// <summary>
+    /// Opens a fresh tenanted <see cref="IDocumentSession"/>, wires
+    /// <see cref="MartenIdempotencyStore"/> and <see cref="StubPlanGenerationService"/>,
+    /// invokes <see cref="RegeneratePlanHandler.Handle"/>, then calls
+    /// <c>SaveChangesAsync</c> to mirror Wolverine's transactional middleware
+    /// commit. Extracted to eliminate duplication between
+    /// <see cref="BuildRegenerateBusStub"/> and the capture-based bus stub
+    /// in <c>Regenerate_HTTP_Sanitizer_Wraps_FreeText_In_Spotlighting_Delimiter</c>
+    /// (simplify-2).
+    /// </summary>
+    private static async Task<RegeneratePlanResponse> RunHandlerOnFreshSessionAsync(
+        RunCoachAppFactory factory,
+        string tenantId,
+        RegeneratePlanCommand cmd,
+        CancellationToken ct)
+    {
+        // Open a session tenanted to the dispatching userId, the same
+        //   way `IMessageBus.InvokeForTenantAsync` would inside Wolverine's
+        //   transactional middleware. The handler stages events +
+        //   idempotency marker on this session; the framework would
+        //   commit them via auto-applied transactions — here we call
+        //   `SaveChangesAsync` explicitly to mirror that contract.
+        var store = factory.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(tenantId);
+        var idempotency = new MartenIdempotencyStore(
+            session,
+            TimeProvider.System,
+            NullLogger<MartenIdempotencyStore>.Instance);
+        var planGen = new StubPlanGenerationService();
+
+        var response = await RegeneratePlanHandler.Handle(
+            cmd,
+            session,
+            planGen,
+            idempotency,
+            NullLogger<RegeneratePlanHandler>.Instance,
+            ct);
+
+        await session.SaveChangesAsync(ct);
+        return response;
     }
 
     private static async Task<(HttpClient Client, CookieContainer Container, string AntiforgeryToken, Guid UserId)>
@@ -670,42 +906,18 @@ public class PlanRegenerateIntegrationTests(RunCoachAppFactory factory) : DbBack
         return user.Id;
     }
 
-    private async Task<RegeneratePlanResponse> InvokeHandlerAsync(RegeneratePlanCommand cmd)
+    private Task<RegeneratePlanResponse> InvokeHandlerAsync(RegeneratePlanCommand cmd)
     {
-        // Open a single per-call DI scope so `IDocumentSession`,
-        //   `IIdempotencyStore`, and `IPlanGenerationService` (via the stub
-        //   factory below) all share one session — the same lifetime contract
-        //   Wolverine's transactional middleware enforces in production.
         // Marten is configured with TenancyStyle.Conjoined; the production
         // path uses InvokeForTenantAsync(userId, …) to bracket the handler in
         // a tenanted session. Mirror that here by opening a session tenanted
         // to the command's UserId so IIdempotencyStore.Record can stamp the
         // marker's tenant column without rejecting the *DEFAULT* placeholder.
-        var store = Factory.Services.GetRequiredService<IDocumentStore>();
-        await using var session = store.LightweightSession(cmd.UserId.ToString());
-        var idempotency = new MartenIdempotencyStore(
-            session,
-            TimeProvider.System,
-            NullLogger<MartenIdempotencyStore>.Instance);
-        var planGen = new StubPlanGenerationService();
-
-        var response = await RegeneratePlanHandler.Handle(
+        return RunHandlerOnFreshSessionAsync(
+            Factory,
+            cmd.UserId.ToString(),
             cmd,
-            session,
-            planGen,
-            idempotency,
-            NullLogger<RegeneratePlanHandler>.Instance,
             TestContext.Current.CancellationToken);
-
-        // The Wolverine handler itself never calls SaveChangesAsync — the
-        //   transactional middleware does. Stand in for the framework here so
-        //   the staged events + idempotency marker actually commit. The
-        //   MartenEntityFrameworkCore transaction-participant wiring then
-        //   runs the inline projection's EF write inside the same DB
-        //   transaction (per DEC-060 / R-069).
-        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
-
-        return response;
     }
 
     private async Task SeedInitialPlanStreamAsync(Guid userId, Guid planId)

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/RegenerateTransactionScopeTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/RegenerateTransactionScopeTests.cs
@@ -1,0 +1,243 @@
+using FluentAssertions;
+using Marten;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using RunCoach.Api.Infrastructure.Idempotency;
+using RunCoach.Api.Modules.Coaching.Models;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+using RunCoach.Api.Modules.Training.Plan;
+using RunCoach.Api.Modules.Training.Plan.Models;
+
+namespace RunCoach.Api.Tests.Modules.Training.Plan;
+
+/// <summary>
+/// Unit-level R-066 + R-069 atomicity regression test for the regenerate
+/// handler (spec 13 § Unit 5 Verification; DEC-060). Models the same shape as
+/// <see cref="Modules.Coaching.Onboarding.InvokeAsyncTransactionScopeTests"/>:
+/// stub <see cref="IPlanGenerationService"/> so it throws on the simulated
+/// 4th meso call, drive the handler, then assert the handler propagates the
+/// exception AND every staged side-effect that would have produced an
+/// observable post-condition (new Plan stream, fresh
+/// <see cref="PlanLinkedToUser"/> event, recorded idempotency response) was
+/// never reached.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The handler itself never calls <c>SaveChangesAsync</c>; Wolverine's
+/// transactional middleware owns the commit. When
+/// <see cref="IPlanGenerationService.GeneratePlanAsync"/> throws, control
+/// unwinds before the handler reaches <c>StartStream</c>, the
+/// <c>PlanLinkedToUser</c> append, or <c>IIdempotencyStore.Record</c>. The
+/// negative assertions on those three call sites prove the handler leaves
+/// the session with no pending writes related to the regeneration — Wolverine
+/// then aborts the transaction so the prior plan stream is unaffected, no
+/// new Plan stream exists, and <c>UserProfile.CurrentPlanId</c> stays at its
+/// prior value (per the <see cref="UserProfileFromOnboardingProjection"/>
+/// inline projection wiring established in
+/// <see cref="Infrastructure.MartenConfiguration"/>).
+/// </para>
+/// <para>
+/// Per DEC-060 / R-069 the dual-write atomicity claim — that exactly one
+/// Postgres transaction (and one <c>backend_xid</c>) covers the entire
+/// handler — is upheld by Marten's
+/// <c>UseEntityFrameworkCoreTransactionParticipant</c> wiring. That
+/// single-transaction property is asserted via the framework-level test
+/// <c>UserProfileFromOnboardingProjection</c> integration coverage rather
+/// than a separate <c>pg_stat_activity.backend_xid</c> observer probe (the
+/// observer probe is deferred per the same rationale recorded in
+/// <c>InvokeAsyncTransactionScopeTests</c>).
+/// </para>
+/// </remarks>
+public class RegenerateTransactionScopeTests
+{
+    [Fact]
+    public async Task Handle_When_PlanGeneration_Throws_Handler_Throws_And_No_Writes_Are_Staged()
+    {
+        // Arrange — set up the runner with a prior plan linked via the
+        //   onboarding view, then make plan generation explode mid-call.
+        var session = Substitute.For<IDocumentSession>();
+        var planGen = Substitute.For<IPlanGenerationService>();
+        var idempotency = Substitute.For<IIdempotencyStore>();
+        var userId = Guid.NewGuid();
+        var idempotencyKey = Guid.NewGuid();
+        var priorPlanId = Guid.NewGuid();
+
+        // Idempotency miss — the request is brand new, so the handler must
+        //   proceed past the short-circuit branch.
+        idempotency
+            .SeenAsync<RegeneratePlanResponse>(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((RegeneratePlanResponse?)null);
+
+        // The onboarding view must carry a non-null CurrentPlanId so the
+        //   handler reaches the plan-generation call. Without this slot the
+        //   handler would throw a different InvalidOperationException
+        //   (defense-in-depth path) before the simulated 4th-meso failure.
+        var view = BuildViewWithPriorPlan(userId, priorPlanId);
+        session.LoadAsync<OnboardingView>(userId, Arg.Any<CancellationToken>()).Returns(view);
+
+        // Stub plan generation to throw — this stands in for "the 4th meso
+        //   call rejected" in the deeper LLM chain. The handler does not
+        //   distinguish which call inside `GeneratePlanAsync` failed, only
+        //   that the call did.
+        planGen
+            .GeneratePlanAsync(
+                Arg.Any<OnboardingView>(),
+                Arg.Any<Guid>(),
+                Arg.Any<Guid>(),
+                Arg.Any<RegenerationIntent?>(),
+                Arg.Any<Guid?>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsyncForAnyArgs(new InvalidOperationException("simulated plan-generation failure on the 4th meso call"));
+
+        // Act
+        var act = async () => await RegeneratePlanHandler.Handle(
+            new RegeneratePlanCommand(userId, Intent: null, idempotencyKey),
+            session,
+            planGen,
+            idempotency,
+            NullLogger<RegeneratePlanHandler>.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert — handler propagates the exception so Wolverine's
+        //   transactional middleware rolls back the session.
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("simulated plan-generation failure*");
+
+        // The handler MUST NOT have staged the new Plan stream — that call
+        //   sits AFTER the plan-generation await on the happy path. If it
+        //   ever fires before the await, the generation failure would still
+        //   leave staged writes on the session for the framework to
+        //   accidentally commit on a parallel happy path. Negative coverage
+        //   ensures the call sites stay below the failing await.
+        session.Events.DidNotReceiveWithAnyArgs()
+            .StartStream<PlanProjectionDto>(Arg.Any<Guid>(), Arg.Any<object[]>());
+
+        // The fresh PlanLinkedToUser event (which would flip
+        //   `UserProfile.CurrentPlanId` to a new value via the EF projection)
+        //   must never have been appended. This is the load-bearing
+        //   atomicity guarantee from DEC-060 / R-069: failed regeneration
+        //   leaves the prior plan link intact.
+        session.Events.DidNotReceiveWithAnyArgs()
+            .Append(Arg.Any<Guid>(), Arg.Any<PlanLinkedToUser>());
+
+        // Idempotency record never lands — so on retry the runner gets a
+        //   fresh attempt instead of a memoized half-state response. This is
+        //   the same negative invariant the onboarding-side test asserts.
+        idempotency.DidNotReceiveWithAnyArgs()
+            .Record<RegeneratePlanResponse>(Arg.Any<Guid>(), Arg.Any<RegeneratePlanResponse>());
+
+        // The handler never calls SaveChangesAsync directly — the framework's
+        //   transactional middleware owns that call. Asserting the negative
+        //   here keeps the contract explicit: a future refactor that
+        //   accidentally commits mid-handler would break atomicity and this
+        //   test is the trip wire.
+        await session.DidNotReceiveWithAnyArgs().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_When_Idempotency_Hit_Short_Circuits_Without_Touching_PlanGen_Or_Session()
+    {
+        // Arrange — the idempotency store already holds a recorded response
+        //   under this key (e.g. the runner re-submitted after a network
+        //   blip). The handler must return the cached payload byte-for-byte
+        //   and append nothing.
+        var session = Substitute.For<IDocumentSession>();
+        var planGen = Substitute.For<IPlanGenerationService>();
+        var idempotency = Substitute.For<IIdempotencyStore>();
+        var userId = Guid.NewGuid();
+        var idempotencyKey = Guid.NewGuid();
+        var cachedPlanId = Guid.NewGuid();
+        var cachedResponse = new RegeneratePlanResponse(cachedPlanId, "generated");
+
+        idempotency
+            .SeenAsync<RegeneratePlanResponse>(idempotencyKey, Arg.Any<CancellationToken>())
+            .Returns(cachedResponse);
+
+        // Act
+        var actual = await RegeneratePlanHandler.Handle(
+            new RegeneratePlanCommand(userId, Intent: null, idempotencyKey),
+            session,
+            planGen,
+            idempotency,
+            NullLogger<RegeneratePlanHandler>.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert — byte-identical replay.
+        actual.Should().Be(cachedResponse);
+
+        // Plan generation MUST NOT have been invoked on the cache-hit branch.
+        await planGen.DidNotReceiveWithAnyArgs()
+            .GeneratePlanAsync(
+                Arg.Any<OnboardingView>(),
+                Arg.Any<Guid>(),
+                Arg.Any<Guid>(),
+                Arg.Any<RegenerationIntent?>(),
+                Arg.Any<Guid?>(),
+                Arg.Any<CancellationToken>());
+
+        // No reads of the onboarding view either — the cache hit short-
+        //   circuits before the LoadAsync call.
+        await session.DidNotReceiveWithAnyArgs()
+            .LoadAsync<OnboardingView>(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+
+        // No writes were staged on the session.
+        session.Events.DidNotReceiveWithAnyArgs()
+            .StartStream<PlanProjectionDto>(Arg.Any<Guid>(), Arg.Any<object[]>());
+        session.Events.DidNotReceiveWithAnyArgs()
+            .Append(Arg.Any<Guid>(), Arg.Any<PlanLinkedToUser>());
+
+        // And the handler did NOT re-record the response — replaying the
+        //   cached payload is a pure read.
+        idempotency.DidNotReceiveWithAnyArgs()
+            .Record<RegeneratePlanResponse>(Arg.Any<Guid>(), Arg.Any<RegeneratePlanResponse>());
+    }
+
+    private static OnboardingView BuildViewWithPriorPlan(Guid userId, Guid priorPlanId) => new()
+    {
+        Id = userId,
+        UserId = userId,
+        Status = OnboardingStatus.Completed,
+        OnboardingStartedAt = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero),
+        OnboardingCompletedAt = new DateTimeOffset(2026, 4, 1, 12, 5, 0, TimeSpan.Zero),
+        CurrentPlanId = priorPlanId,
+        PrimaryGoal = new PrimaryGoalAnswer { Goal = PrimaryGoal.GeneralFitness, Description = "fitness" },
+        TargetEvent = null,
+        CurrentFitness = new CurrentFitnessAnswer
+        {
+            TypicalWeeklyKm = 30,
+            LongestRecentRunKm = 12,
+            RecentRaceDistanceKm = null,
+            RecentRaceTimeIso = null,
+            Description = "moderate",
+        },
+        WeeklySchedule = new WeeklyScheduleAnswer
+        {
+            MaxRunDaysPerWeek = 4,
+            TypicalSessionMinutes = 45,
+            Monday = true,
+            Tuesday = false,
+            Wednesday = true,
+            Thursday = false,
+            Friday = true,
+            Saturday = false,
+            Sunday = true,
+            Description = "evenings",
+        },
+        InjuryHistory = new InjuryHistoryAnswer
+        {
+            HasActiveInjury = false,
+            ActiveInjuryDescription = string.Empty,
+            PastInjurySummary = "none",
+        },
+        Preferences = new PreferencesAnswer
+        {
+            PreferredUnits = PreferredUnits.Kilometers,
+            PreferTrail = false,
+            ComfortableWithIntensity = true,
+            Description = "ok",
+        },
+        OutstandingClarifications = [],
+    };
+}

--- a/frontend/e2e/regenerate-plan.spec.ts
+++ b/frontend/e2e/regenerate-plan.spec.ts
@@ -1,0 +1,455 @@
+import { randomUUID } from 'node:crypto'
+import { expect, test, type Page, type Route } from '@playwright/test'
+
+// End-to-end coverage of the regenerate-from-settings flow.
+//
+// Strategy:
+//   1. Use the real backend for `register` so the auth cookie + antiforgery
+//      pair are seeded the same way the runtime app expects. The
+//      `__Host-RunCoach` cookie carries the session straight into the rest
+//      of the flow.
+//   2. Stub `GET /api/v1/onboarding/state` with a `Completed` shape so the
+//      home redirect-guard lets the SPA land on `/` without walking the
+//      onboarding chat — onboarding completion is a precondition here, not
+//      the unit under test.
+//   3. Stub `GET /api/v1/plan/current` with a state-machine-style fixture
+//      that returns plan A before the regenerate call lands and plan B
+//      after. The two projections differ in macro phase composition + in
+//      workout titles so the post-regeneration assertions can compare plan
+//      content directly (plan-A "Base/Build/Taper" → plan-B
+//      "Base/Recovery").
+//   4. Stub `POST /api/v1/plan/regenerate` with deterministic responses
+//      that flip the shared state machine to "regenerated" on the first
+//      POST. The stub captures every observed `idempotencyKey` +
+//      `intent.freeText` so the test can assert the wire contract the
+//      dialog upholds.
+//   5. Drive the UI: navigate to `/settings`, click "Regenerate plan",
+//      submit the dialog with the canonical injury intent text, assert
+//      the dialog closes, navigate to `/`, assert plan B's macro/workout
+//      content replaces plan A's, and assert the network sequence: one
+//      POST `/api/v1/plan/regenerate` followed by at least one GET
+//      `/api/v1/plan/current`.
+
+const SESSION_COOKIE = '__Host-RunCoach'
+const VALID_PASSWORD = 'Correct-Horse-9!'
+
+// Fresh email per run so the suite is re-runnable against a shared dev
+// Postgres without collisions. `npm run e2e:clean` flushes the orphans.
+const uniqueEmail = (): string => `e2e-${randomUUID()}@runcoach.test`
+
+// Wire-format integer enum duplicated inline so the stub round-trips the
+// exact JSON the page-level Zod schema accepts. Holding the e2e suite at
+// arm's length from the production model module keeps the integers under
+// explicit test-side control.
+const OnboardingStatus = { NotStarted: 0, InProgress: 1, Completed: 2 } as const
+
+const planAId = '8a4b9b2a-1d3f-4f1c-9aab-5e2c1f0b1234'
+const planBId = '7e1d9b2a-1d3f-4f1c-9aab-5e2c1f0b9876'
+const userId = '00000000-0000-0000-0000-000000000001'
+
+// Canonical user-facing copy for the regeneration intent. The test must
+// echo it exactly so the stub assertion confirms the dialog passed it
+// through to the wire body unchanged.
+const INJURY_INTENT = 'I just got injured, please reduce volume'
+
+interface PlanFixture {
+  planId: string
+  previousPlanId: string | null
+  goalDescription: string
+  rationale: string
+  phases: ReadonlyArray<{
+    phaseType: string
+    weeks: number
+    weeklyDistanceStartKm: number
+    weeklyDistanceEndKm: number
+    targetPaceEasySecPerKm: number
+    targetPaceFastSecPerKm: number
+    intensityDistribution: string
+    allowedWorkoutTypes: ReadonlyArray<string>
+    notes: string
+    includesDeload: boolean
+  }>
+  weeklyTargets: ReadonlyArray<number>
+  workoutTitlePrefix: string
+}
+
+// Plan A — the user's current plan before regeneration. Three macro phases
+// totaling 12 weeks; standard pace-zone-index aerobic build.
+const PLAN_A: PlanFixture = {
+  planId: planAId,
+  previousPlanId: null,
+  goalDescription: 'Build aerobic base for a half marathon.',
+  rationale: 'Daniels-Gilbert zones drive the pace targets across phases.',
+  phases: [
+    {
+      phaseType: 'Base',
+      weeks: 4,
+      weeklyDistanceStartKm: 30,
+      weeklyDistanceEndKm: 40,
+      targetPaceEasySecPerKm: 360,
+      targetPaceFastSecPerKm: 330,
+      intensityDistribution: '80/20',
+      allowedWorkoutTypes: ['Easy', 'LongRun', 'Recovery'],
+      notes: 'Aerobic foundation — pace-zone index easy.',
+      includesDeload: false,
+    },
+    {
+      phaseType: 'Build',
+      weeks: 5,
+      weeklyDistanceStartKm: 40,
+      weeklyDistanceEndKm: 55,
+      targetPaceEasySecPerKm: 350,
+      targetPaceFastSecPerKm: 300,
+      intensityDistribution: '80/20',
+      allowedWorkoutTypes: ['Easy', 'LongRun', 'Tempo', 'Interval'],
+      notes: 'Threshold sessions enter the rotation.',
+      includesDeload: true,
+    },
+    {
+      phaseType: 'Taper',
+      weeks: 3,
+      weeklyDistanceStartKm: 30,
+      weeklyDistanceEndKm: 25,
+      targetPaceEasySecPerKm: 360,
+      targetPaceFastSecPerKm: 320,
+      intensityDistribution: '90/10',
+      allowedWorkoutTypes: ['Easy', 'Recovery', 'Tempo'],
+      notes: 'Reduce volume, keep intensity sharp.',
+      includesDeload: false,
+    },
+  ],
+  weeklyTargets: [30, 33, 36, 28],
+  workoutTitlePrefix: 'Plan-A',
+}
+
+// Plan B — the regenerated plan. The user said "I just got injured, please
+// reduce volume", so the deterministic-stub response models that: shorter
+// timeline, lower mileage targets, no Tempo/Interval phase, distinct
+// workout-title prefix. `previousPlanId` references plan A so the post-
+// regeneration Settings surface can prove the audit linkage between the
+// two plans.
+const PLAN_B: PlanFixture = {
+  planId: planBId,
+  previousPlanId: planAId,
+  goalDescription: 'Recovery-first easy mileage following an injury setback.',
+  rationale: 'Reduced volume per the regeneration intent provided by user.',
+  phases: [
+    {
+      phaseType: 'Base',
+      weeks: 6,
+      weeklyDistanceStartKm: 18,
+      weeklyDistanceEndKm: 28,
+      targetPaceEasySecPerKm: 380,
+      targetPaceFastSecPerKm: 360,
+      intensityDistribution: '95/5',
+      allowedWorkoutTypes: ['Easy', 'Recovery'],
+      notes: 'Lower volume — pace-zone index easy only.',
+      includesDeload: true,
+    },
+    {
+      phaseType: 'Recovery',
+      weeks: 2,
+      weeklyDistanceStartKm: 15,
+      weeklyDistanceEndKm: 12,
+      targetPaceEasySecPerKm: 400,
+      targetPaceFastSecPerKm: 380,
+      intensityDistribution: '100/0',
+      allowedWorkoutTypes: ['Recovery'],
+      notes: 'Full deload week — short recovery jogs only.',
+      includesDeload: false,
+    },
+  ],
+  weeklyTargets: [18, 21, 24, 20],
+  workoutTitlePrefix: 'Plan-B',
+}
+
+// Build a plan-projection JSON payload from the given plan fixture. The
+// shape mirrors what the page-level Zod schema parses. Pads
+// `microWorkoutsByWeek[1]` with one workout per day-of-week so `TodayCard`
+// always picks a workout regardless of when the suite runs (no rest-day
+// flake).
+const buildPlanProjection = (fixture: PlanFixture) => {
+  const dayOfWeekKeys = [
+    'sunday',
+    'monday',
+    'tuesday',
+    'wednesday',
+    'thursday',
+    'friday',
+    'saturday',
+  ] as const
+
+  const totalWeeks = fixture.phases.reduce((sum, phase) => sum + phase.weeks, 0)
+
+  const runSlot = { slotType: 'Run', workoutType: 'Easy', notes: '' }
+  const buildMesoWeek = (weekNumber: number, weeklyTargetKm: number) => ({
+    weekNumber,
+    phaseType: fixture.phases[0].phaseType,
+    weeklyTargetKm,
+    isDeloadWeek: weekNumber === 4,
+    weekSummary: `Week ${weekNumber} — ${fixture.workoutTitlePrefix} pace-zone index easy mileage.`,
+    ...Object.fromEntries(dayOfWeekKeys.map((key) => [key, runSlot])),
+  })
+
+  const buildWorkout = (dayOfWeek: number, dayName: string) => ({
+    dayOfWeek,
+    workoutType: 'Easy',
+    title: `${fixture.workoutTitlePrefix} ${dayName} run`,
+    targetDistanceKm: 8,
+    targetDurationMinutes: 48,
+    targetPaceEasySecPerKm: fixture.phases[0].targetPaceEasySecPerKm,
+    targetPaceFastSecPerKm: fixture.phases[0].targetPaceFastSecPerKm,
+    segments: [
+      {
+        segmentType: 'Work',
+        durationMinutes: 48,
+        targetPaceSecPerKm: fixture.phases[0].targetPaceEasySecPerKm,
+        intensity: 'Easy',
+        repetitions: 1,
+        notes: 'Steady aerobic effort.',
+      },
+    ],
+    warmupNotes: 'Five minutes brisk walk.',
+    cooldownNotes: 'Five minutes walk + stretch.',
+    coachingNotes: 'Hold pace-zone index easy throughout.',
+    perceivedEffort: 4,
+  })
+
+  return {
+    planId: fixture.planId,
+    userId,
+    generatedAt: '2026-04-25T12:00:00.000Z',
+    previousPlanId: fixture.previousPlanId,
+    promptVersion: 'plan-generation-v1',
+    modelId: 'claude-sonnet-4-6',
+    macro: {
+      totalWeeks,
+      goalDescription: fixture.goalDescription,
+      rationale: fixture.rationale,
+      warnings: '',
+      phases: fixture.phases.map((phase) => ({ ...phase })),
+    },
+    mesoWeeks: fixture.weeklyTargets.map((target, index) => buildMesoWeek(index + 1, target)),
+    microWorkoutsByWeek: {
+      1: {
+        workouts: [
+          buildWorkout(0, 'Sunday'),
+          buildWorkout(1, 'Monday'),
+          buildWorkout(2, 'Tuesday'),
+          buildWorkout(3, 'Wednesday'),
+          buildWorkout(4, 'Thursday'),
+          buildWorkout(5, 'Friday'),
+          buildWorkout(6, 'Saturday'),
+        ],
+      },
+    },
+  }
+}
+
+interface StubState {
+  // Whether the regenerate call has landed yet. Drives which plan fixture
+  // (A or B) the `GET /plan/current` stub serves on each request.
+  hasRegenerated: boolean
+  // Number of GET /plan/current requests served. Lets the test prove a
+  // post-regenerate refetch happened (RTK Query invalidation).
+  planCurrentRequests: number
+  // Number of POST /plan/regenerate requests served. The happy-path
+  // exercises exactly one.
+  regenerateRequests: number
+  // Idempotency keys observed on POST /plan/regenerate. Asserts the
+  // dialog mints a UUID-shaped key for every distinct submission.
+  idempotencyKeys: string[]
+  // Free-text intent observed on POST /plan/regenerate. Asserts the
+  // dialog passes the textarea contents through unchanged.
+  observedIntents: Array<string | null>
+}
+
+const installStubs = async (page: Page, state: StubState): Promise<void> => {
+  // Onboarding state stub — Completed from the first request so the home
+  // redirect-guard lets `/` and `/settings` render without any chat traffic.
+  await page.route('**/api/v1/onboarding/state', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        userId,
+        status: OnboardingStatus.Completed,
+        currentTopic: null,
+        completedTopics: 6,
+        totalTopics: 6,
+        isComplete: true,
+        outstandingClarifications: [],
+        primaryGoal: null,
+        targetEvent: null,
+        currentFitness: null,
+        weeklySchedule: null,
+        injuryHistory: null,
+        preferences: null,
+        currentPlanId: state.hasRegenerated ? planBId : planAId,
+      }),
+    })
+  })
+
+  // Plan stub — flips A → B once `state.hasRegenerated` is true. The
+  // shared state machine keeps the projection consistent across the home
+  // surface, the settings surface, and the post-invalidation refetch.
+  await page.route('**/api/v1/plan/current', async (route: Route) => {
+    state.planCurrentRequests += 1
+    const fixture = state.hasRegenerated ? PLAN_B : PLAN_A
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildPlanProjection(fixture)),
+    })
+  })
+
+  // Regenerate stub — captures the wire body, flips the state machine to
+  // "regenerated", returns the canonical 200 success shape. Modeled after
+  // `RegeneratePlanResponseDto` (`{ planId, status }`).
+  await page.route('**/api/v1/plan/regenerate', async (route: Route) => {
+    const body = (await route.request().postDataJSON()) as {
+      idempotencyKey?: string
+      intent?: { freeText?: string }
+    }
+    if (typeof body.idempotencyKey === 'string') {
+      state.idempotencyKeys.push(body.idempotencyKey)
+    }
+    state.observedIntents.push(body.intent?.freeText ?? null)
+    state.regenerateRequests += 1
+    state.hasRegenerated = true
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ planId: planBId, status: 'generated' }),
+    })
+  })
+}
+
+test('register → settings → regenerate with intent → home shows new plan', async ({ page }) => {
+  const email = uniqueEmail()
+  const stubState: StubState = {
+    hasRegenerated: false,
+    planCurrentRequests: 0,
+    regenerateRequests: 0,
+    idempotencyKeys: [],
+    observedIntents: [],
+  }
+  await installStubs(page, stubState)
+
+  // Track the network request order so the post-flow assertion can prove
+  // the wire contract: a single POST /api/v1/plan/regenerate followed by
+  // at least one GET /api/v1/plan/current (the invalidation refetch).
+  const observedRequests: string[] = []
+  page.on('request', (request) => {
+    const url = request.url()
+    if (url.includes('/api/v1/plan/regenerate') && request.method() === 'POST') {
+      observedRequests.push('POST /api/v1/plan/regenerate')
+    } else if (url.includes('/api/v1/plan/current') && request.method() === 'GET') {
+      observedRequests.push('GET /api/v1/plan/current')
+    }
+  })
+
+  // 1. Register a fresh user → real backend issues the session cookie. The
+  //    register page chains login automatically; on success the SPA tries
+  //    to land on `/`, the home redirect-guard sees the stubbed Completed
+  //    onboarding shape, and `HomePage` renders plan A.
+  await page.goto('/register')
+  await page.getByLabel('Email').fill(email)
+  await page.getByLabel('Password').fill(VALID_PASSWORD)
+  await page.getByRole('button', { name: /create account/i }).click()
+  await expect(page).toHaveURL('/')
+  await expect(page.getByTestId('home-page')).toBeVisible()
+
+  // Capture plan A's render so we can compare against plan B post-regen.
+  // The macro-phase-segment `data-phase` attribute is the most stable
+  // selector — workout titles depend on the day-of-week resolution which
+  // we deliberately avoid coupling to the calendar.
+  const planAPhases = await page
+    .getByTestId('macro-phase-segment')
+    .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-phase')))
+  expect(planAPhases).toEqual(['Base', 'Build', 'Taper'])
+
+  const planAHomeHtml = await page.getByTestId('home-page').innerHTML()
+  expect(planAHomeHtml).toContain('Plan-A')
+
+  // 2. Navigate to /settings. The route is gated by `<RequireAuth>` and the
+  //    page renders the "Plan" section with the Regenerate button + the
+  //    current plan's `generatedAt` timestamp.
+  await page.goto('/settings')
+  await expect(page).toHaveURL('/settings')
+  await expect(page.getByTestId('settings-page')).toBeVisible()
+  await expect(page.getByTestId('settings-plan-section')).toBeVisible()
+  await expect(page.getByTestId('settings-plan-generated-at')).toBeVisible()
+  await expect(page.getByTestId('settings-regenerate-button')).toBeVisible()
+
+  // 3. Open the regenerate dialog. The dialog must contain the optional
+  //    intent textarea labeled "Anything we should know? (optional)" plus
+  //    a "Regenerate" submit button.
+  await page.getByTestId('settings-regenerate-button').click()
+  const dialog = page.getByTestId('regenerate-plan-dialog')
+  await expect(dialog).toBeVisible()
+  await expect(page.getByLabel('Anything we should know? (optional)')).toBeVisible()
+  const submitButton = page.getByTestId('regenerate-plan-submit')
+  await expect(submitButton).toBeVisible()
+
+  // 4. Submit with the canonical injury intent. The dialog must (a) pass
+  //    the freeText through unchanged on the wire, (b) close on success,
+  //    (c) trigger a Plan-tag invalidation that refetches plan B.
+  await page.getByLabel('Anything we should know? (optional)').fill(INJURY_INTENT)
+  await submitButton.click()
+
+  // Dialog closes once the mutation resolves. The `regenerate-plan-dialog`
+  // markup unmounts entirely (parent `isOpen` flips false), not just hidden.
+  await expect(dialog).toBeHidden()
+
+  // 5. Navigate back to / — the SPA already fired the invalidation refetch
+  //    when the dialog closed, but we navigate explicitly so the home
+  //    surface re-renders with plan B replacing plan A. After the
+  //    navigation the home surface must reflect plan B's macro composition
+  //    plus workout titles.
+  await page.goto('/')
+  await expect(page).toHaveURL('/')
+  await expect(page.getByTestId('home-page')).toBeVisible()
+
+  // Plan B's macro phases are deterministically distinct from plan A's:
+  // two phases (Base + Recovery) instead of three. This is the strongest
+  // assertion that the projection swap actually drives the render.
+  await expect
+    .poll(
+      async () =>
+        page
+          .getByTestId('macro-phase-segment')
+          .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-phase'))),
+      { timeout: 5_000 },
+    )
+    .toEqual(['Base', 'Recovery'])
+
+  const planBHomeHtml = await page.getByTestId('home-page').innerHTML()
+  expect(planBHomeHtml).toContain('Plan-B')
+  expect(planBHomeHtml).not.toContain('Plan-A')
+  expect(planBHomeHtml).not.toEqual(planAHomeHtml)
+
+  // 6. Wire-contract assertions. Exactly one regenerate POST landed; the
+  //    idempotency key was UUID-shaped; the freeText round-tripped without
+  //    mutation; and the network sequence showed POST regenerate followed
+  //    by at least one GET plan/current (the invalidation refetch).
+  expect(stubState.regenerateRequests).toBe(1)
+  expect(stubState.idempotencyKeys).toHaveLength(1)
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+  expect(stubState.idempotencyKeys[0]).toMatch(uuidPattern)
+  expect(stubState.observedIntents).toEqual([INJURY_INTENT])
+
+  const regenerateIndex = observedRequests.indexOf('POST /api/v1/plan/regenerate')
+  expect(regenerateIndex).toBeGreaterThanOrEqual(0)
+  const followingPlanGet = observedRequests
+    .slice(regenerateIndex + 1)
+    .find((entry) => entry === 'GET /api/v1/plan/current')
+  expect(followingPlanGet).toBe('GET /api/v1/plan/current')
+
+  // 7. The session cookie is still present — regeneration did not tear
+  //    down auth. Belt-and-suspenders against a regression that logs the
+  //    user out mid-flow.
+  const cookies = await page.context().cookies()
+  expect(cookies.find((cookie) => cookie.name === SESSION_COOKIE)).toBeDefined()
+})

--- a/frontend/src/app/api/plan.api.spec.ts
+++ b/frontend/src/app/api/plan.api.spec.ts
@@ -1,0 +1,128 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiSlice } from '~/api/api-slice'
+import { planApi } from './plan.api'
+
+// Build a real store wired to the shared `apiSlice` so the `regeneratePlan`
+// mutation's `query: (body) => ({...})` factory and the `getCurrentPlan`
+// query factory actually execute. The dialog spec mocks
+// `useRegeneratePlanMutation` and so never reaches the factory; this spec
+// dispatches the endpoint thunks directly with `fetch` stubbed at the global
+// level (matching the pattern in `base-query.spec.ts`).
+//
+// `fetchBaseQuery({ baseUrl: '/api' })` joins the relative `baseUrl` with
+// each endpoint's `url` and hands the result to `new Request(...)`. Undici's
+// Request constructor (used by node's fetch in the test environment) rejects
+// relative URLs even when `window.location` is configured, so we wrap
+// `Request` to resolve any leading-slash URL against the jsdom origin
+// (`https://localhost:5173/`) for the duration of these tests.
+const OriginalRequest = globalThis.Request
+class PatchedRequest extends OriginalRequest {
+  constructor(input: RequestInfo | URL, init?: RequestInit) {
+    if (typeof input === 'string' && input.startsWith('/')) {
+      super(new URL(input, 'https://localhost:5173').toString(), init)
+      return
+    }
+    super(input, init)
+  }
+}
+
+const jsonResponse = (body: Record<string, unknown>, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const makeStore = () =>
+  configureStore({
+    reducer: { [apiSlice.reducerPath]: apiSlice.reducer },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(apiSlice.middleware),
+  })
+
+describe('planApi.regeneratePlan query factory', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ planId: 'plan-1', status: 'generated' }))
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('Request', PatchedRequest)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('issues a POST to /api/v1/plan/regenerate with the supplied body', async () => {
+    const store = makeStore()
+    const result = await store.dispatch(
+      planApi.endpoints.regeneratePlan.initiate({
+        idempotencyKey: '00000000-0000-0000-0000-00000000abcd',
+        intent: { freeText: 'less volume' },
+      }),
+    )
+
+    expect(result.data).toEqual({ planId: 'plan-1', status: 'generated' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const request = fetchMock.mock.calls[0][0] as Request
+    expect(request).toBeInstanceOf(Request)
+    expect(request.method).toBe('POST')
+    expect(request.url).toContain('/api/v1/plan/regenerate')
+    const sentBody = await request.clone().json()
+    expect(sentBody).toEqual({
+      idempotencyKey: '00000000-0000-0000-0000-00000000abcd',
+      intent: { freeText: 'less volume' },
+    })
+  })
+
+  it('serializes a body without the optional intent block when omitted', async () => {
+    const store = makeStore()
+    await store.dispatch(
+      planApi.endpoints.regeneratePlan.initiate({
+        idempotencyKey: '00000000-0000-0000-0000-00000000abcd',
+      }),
+    )
+
+    const request = fetchMock.mock.calls[0][0] as Request
+    const sentBody = await request.clone().json()
+    expect(sentBody).toEqual({ idempotencyKey: '00000000-0000-0000-0000-00000000abcd' })
+  })
+})
+
+describe('planApi.getCurrentPlan query factory', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        planId: 'plan-1',
+        userId: 'user-1',
+        generatedAt: '2026-04-25T15:00:00.000Z',
+        previousPlanId: null,
+        promptVersion: 'coaching-v1',
+        modelId: 'claude-sonnet-4-6',
+        macro: null,
+        mesoWeeks: [],
+        microWorkoutsByWeek: {},
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('Request', PatchedRequest)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('issues a GET to /api/v1/plan/current', async () => {
+    const store = makeStore()
+    const result = await store.dispatch(planApi.endpoints.getCurrentPlan.initiate(undefined))
+
+    expect(result.data?.planId).toBe('plan-1')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const request = fetchMock.mock.calls[0][0] as Request
+    expect(request.method).toBe('GET')
+    expect(request.url).toContain('/api/v1/plan/current')
+  })
+})

--- a/frontend/src/app/api/plan.api.ts
+++ b/frontend/src/app/api/plan.api.ts
@@ -1,22 +1,65 @@
 import { apiSlice } from '~/api/api-slice'
 import type { PlanProjectionDto } from '~/modules/plan/models/plan.model'
 
+/**
+ * Wire shape for the optional regeneration intent block on
+ * `POST /api/v1/plan/regenerate`. Mirrors
+ * `RunCoach.Api.Modules.Training.Plan.RegenerationIntentRequestDto` —
+ * `freeText` is capped at 500 characters server-side BEFORE sanitization.
+ */
+export interface RegenerationIntentRequestDto {
+  freeText: string
+}
+
+/**
+ * Request body for `POST /api/v1/plan/regenerate`. Mirrors
+ * `RunCoach.Api.Modules.Training.Plan.RegeneratePlanRequestDto`. The
+ * client supplies `idempotencyKey` via `crypto.randomUUID()` so retries
+ * short-circuit to the same `planId` rather than producing a second
+ * Plan stream (spec 13 § Unit 5 R05.1).
+ */
+export interface RegeneratePlanRequestDto {
+  idempotencyKey: string
+  intent?: RegenerationIntentRequestDto
+}
+
+/**
+ * Response shape returned by `POST /api/v1/plan/regenerate`. Mirrors
+ * `RunCoach.Api.Modules.Training.Plan.RegeneratePlanResponse`. `status`
+ * is always `"generated"` on the success path; modeled as a string so
+ * future slices can introduce richer values without breaking existing
+ * clients.
+ */
+export interface RegeneratePlanResponseDto {
+  planId: string
+  status: string
+}
+
 // Plan endpoints are injected into the root `apiSlice` so every request
 // shares the same cookie + antiforgery base query. URL segments (e.g.
 // `/v1/plan/current`) are relative to the global `/api` prefix supplied by
 // the base query.
 //
-// `getCurrentPlan` carries the `Plan` tag so any mutation that invalidates
-// `Plan` causes the home surface to refetch the projection automatically
-// (spec 13 § Unit 4 R04.1).
+// `getCurrentPlan` is tagged `Plan` so the `regeneratePlan` mutation can
+// declare `invalidatesTags: ['Plan']` and have the home surface refetch the
+// fresh projection automatically (spec 13 § Unit 4 R04.1, § Unit 5).
 export const planApi = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
     getCurrentPlan: builder.query<PlanProjectionDto, undefined>({
       query: () => ({ url: '/v1/plan/current', method: 'GET' }),
       providesTags: ['Plan'],
     }),
+    regeneratePlan: builder.mutation<RegeneratePlanResponseDto, RegeneratePlanRequestDto>({
+      query: (body) => ({
+        url: '/v1/plan/regenerate',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: ['Plan'],
+    }),
   }),
 })
 
 /** Auto-generated RTK Query hooks for the plan endpoints. */
-export const { useGetCurrentPlanQuery, useLazyGetCurrentPlanQuery } = planApi
+export const { useGetCurrentPlanQuery, useLazyGetCurrentPlanQuery, useRegeneratePlanMutation } =
+  planApi

--- a/frontend/src/app/modules/app/app.component.tsx
+++ b/frontend/src/app/modules/app/app.component.tsx
@@ -7,6 +7,7 @@ import { RequireAuth } from '~/modules/auth/components/require-auth.component'
 import { useAuthBootstrap, useAuthBroadcastListener } from '~/modules/auth/hooks/auth.hooks'
 import { OnboardingPage } from '~/modules/onboarding/pages/onboarding.page'
 import { HomePage } from '~/modules/plan/pages/home.page'
+import { SettingsPage } from '~/modules/settings/pages/settings.page'
 import { LoginPage } from '~/pages/login/login.page'
 import { RegisterPage } from '~/pages/register/register.page'
 
@@ -138,6 +139,14 @@ const AppShell = () => {
             <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
               <HomePage />
             </OnboardingRedirectGuard>
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/settings"
+        element={
+          <RequireAuth>
+            <SettingsPage />
           </RequireAuth>
         }
       />

--- a/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.spec.tsx
+++ b/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.spec.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MutationResult {
+  unwrap: () => Promise<{ planId: string; status: string }>
+}
+
+const { regenerateMock, mutationStateRef } = vi.hoisted(() => ({
+  regenerateMock: vi.fn<(arg: unknown) => MutationResult>(),
+  mutationStateRef: { isLoading: false },
+}))
+
+vi.mock('~/api/plan.api', () => ({
+  useRegeneratePlanMutation: () => [regenerateMock, mutationStateRef],
+}))
+
+import { RegeneratePlanDialog } from './regenerate-plan-dialog.component'
+
+const renderDialog = (onClose: () => void) =>
+  render(<RegeneratePlanDialog isOpen={true} onClose={onClose} />)
+
+describe('RegeneratePlanDialog', () => {
+  beforeEach(() => {
+    regenerateMock.mockReset()
+    mutationStateRef.isLoading = false
+    // Stable idempotency key so we can assert exact body shape.
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-0000-0000-00000000abcd')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders nothing when isOpen is false', () => {
+    render(<RegeneratePlanDialog isOpen={false} onClose={vi.fn()} />)
+    expect(screen.queryByTestId('regenerate-plan-dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders the dialog with replacement copy and an optional intent textarea', () => {
+    renderDialog(vi.fn())
+    expect(screen.getByTestId('regenerate-plan-dialog')).toBeInTheDocument()
+    expect(screen.getByText('This replaces your current plan.')).toBeInTheDocument()
+    expect(screen.getByLabelText(/anything we should know/i)).toBeInTheDocument()
+    const textarea = screen.getByTestId('regenerate-plan-intent') as HTMLTextAreaElement
+    expect(textarea.maxLength).toBe(500)
+  })
+
+  it('submits without an intent block when textarea is empty', async () => {
+    const onClose = vi.fn()
+    regenerateMock.mockReturnValue({
+      unwrap: () => Promise.resolve({ planId: 'plan-1', status: 'generated' }),
+    })
+    renderDialog(onClose)
+    await userEvent.click(screen.getByTestId('regenerate-plan-submit'))
+    expect(regenerateMock).toHaveBeenCalledWith({
+      idempotencyKey: '00000000-0000-0000-0000-00000000abcd',
+    })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('submits the trimmed intent free-text and closes on success', async () => {
+    const onClose = vi.fn()
+    regenerateMock.mockReturnValue({
+      unwrap: () => Promise.resolve({ planId: 'plan-2', status: 'generated' }),
+    })
+    renderDialog(onClose)
+    await userEvent.type(
+      screen.getByTestId('regenerate-plan-intent'),
+      '  reducing volume due to injury  ',
+    )
+    await userEvent.click(screen.getByTestId('regenerate-plan-submit'))
+    expect(regenerateMock).toHaveBeenCalledWith({
+      idempotencyKey: '00000000-0000-0000-0000-00000000abcd',
+      intent: { freeText: 'reducing volume due to injury' },
+    })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows an error message when the mutation fails and keeps the dialog open', async () => {
+    const onClose = vi.fn()
+    regenerateMock.mockReturnValue({
+      unwrap: () => Promise.reject(new Error('boom')),
+    })
+    renderDialog(onClose)
+    await userEvent.click(screen.getByTestId('regenerate-plan-submit'))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/could not regenerate/i)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('disables the submit button and shows progress copy while regenerating', () => {
+    mutationStateRef.isLoading = true
+    renderDialog(vi.fn())
+    const submit = screen.getByTestId('regenerate-plan-submit')
+    expect(submit).toBeDisabled()
+    expect(submit).toHaveTextContent(/regenerating/i)
+  })
+
+  it('invokes onClose when Cancel is clicked', async () => {
+    const onClose = vi.fn()
+    renderDialog(onClose)
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.spec.tsx
+++ b/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.spec.tsx
@@ -158,4 +158,54 @@ describe('RegeneratePlanDialog', () => {
     fireEvent.keyDown(backdrop, { key: 'a' })
     expect(onClose).not.toHaveBeenCalled()
   })
+
+  it('shows 500 characters remaining when textarea is empty, 250 at half capacity, and 0 at limit', () => {
+    renderDialog(vi.fn())
+    const textarea = screen.getByTestId('regenerate-plan-intent')
+
+    expect(screen.getByText('500 characters remaining')).toBeInTheDocument()
+
+    fireEvent.change(textarea, { target: { value: 'a'.repeat(250) } })
+    expect(screen.getByText('250 characters remaining')).toBeInTheDocument()
+
+    fireEvent.change(textarea, { target: { value: 'a'.repeat(500) } })
+    expect(screen.getByText('0 characters remaining')).toBeInTheDocument()
+  })
+
+  it('uses the same idempotency key on retry after a transient failure', async () => {
+    // Override the constant stub with an incrementing mock so that a broken
+    // implementation calling randomUUID() per-submit would produce different
+    // values and the assertion would catch it.
+    let callCount = 0
+    vi.spyOn(crypto, 'randomUUID').mockImplementation(
+      () =>
+        `00000000-0000-0000-0000-${String(++callCount).padStart(12, '0')}` as ReturnType<
+          typeof crypto.randomUUID
+        >,
+    )
+
+    const onClose = vi.fn()
+    regenerateMock
+      .mockReturnValueOnce({ unwrap: () => Promise.reject(new Error('transient')) })
+      .mockReturnValue({
+        unwrap: () => Promise.resolve({ planId: 'plan-retry', status: 'generated' }),
+      })
+
+    renderDialog(onClose)
+
+    // First submit — fails
+    await userEvent.click(screen.getByTestId('regenerate-plan-submit'))
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+
+    // Second submit — succeeds
+    await userEvent.click(screen.getByTestId('regenerate-plan-submit'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+
+    expect(regenerateMock).toHaveBeenCalledTimes(2)
+    const [firstCall, secondCall] = regenerateMock.mock.calls as [
+      [{ idempotencyKey: string }],
+      [{ idempotencyKey: string }],
+    ]
+    expect(firstCall[0].idempotencyKey).toBe(secondCall[0].idempotencyKey)
+  })
 })

--- a/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.spec.tsx
+++ b/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -101,5 +101,61 @@ describe('RegeneratePlanDialog', () => {
     renderDialog(onClose)
     await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the dialog when the Escape key is pressed while idle', () => {
+    const onClose = vi.fn()
+    renderDialog(onClose)
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not close on Escape while the regenerate mutation is in flight', () => {
+    mutationStateRef.isLoading = true
+    const onClose = vi.fn()
+    renderDialog(onClose)
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('closes the dialog when the backdrop is clicked while idle', async () => {
+    const onClose = vi.fn()
+    renderDialog(onClose)
+    await userEvent.click(screen.getByTestId('regenerate-plan-backdrop'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not close on backdrop click while the mutation is in flight', async () => {
+    mutationStateRef.isLoading = true
+    const onClose = vi.fn()
+    renderDialog(onClose)
+    await userEvent.click(screen.getByTestId('regenerate-plan-backdrop'))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('closes the dialog when Enter is pressed on the backdrop', () => {
+    const onClose = vi.fn()
+    renderDialog(onClose)
+    const backdrop = screen.getByTestId('regenerate-plan-backdrop')
+    const prevented = !fireEvent.keyDown(backdrop, { key: 'Enter' })
+    expect(prevented).toBe(true)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the dialog when Space is pressed on the backdrop', () => {
+    const onClose = vi.fn()
+    renderDialog(onClose)
+    const backdrop = screen.getByTestId('regenerate-plan-backdrop')
+    const prevented = !fireEvent.keyDown(backdrop, { key: ' ' })
+    expect(prevented).toBe(true)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores backdrop key events that are not Enter or Space', () => {
+    const onClose = vi.fn()
+    renderDialog(onClose)
+    const backdrop = screen.getByTestId('regenerate-plan-backdrop')
+    fireEvent.keyDown(backdrop, { key: 'a' })
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.tsx
+++ b/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useRef, useState, type FormEvent, type ReactElement } from 'react'
+import { useRegeneratePlanMutation } from '~/api/plan.api'
+
+/**
+ * Maximum length of the optional regeneration-intent free-text. Mirrors
+ * `RunCoach.Api.Modules.Coaching.Models.RegenerationIntent.RawMaxFreeTextLength`
+ * (spec 13 § Unit 5 R05.1). The textarea enforces this with both `maxLength`
+ * and a remaining-character counter so the user is never able to over-type.
+ */
+const INTENT_MAX_LENGTH = 500
+
+export interface RegeneratePlanDialogProps {
+  /**
+   * Whether the dialog is visible. The Settings page owns this state so
+   * the trigger button + dialog can be tested in isolation and so the
+   * dialog can fully unmount when closed (resets the textarea + any
+   * transient mutation state).
+   */
+  isOpen: boolean
+  /**
+   * Called when the dialog requests close — Cancel button, backdrop click,
+   * Escape key, or successful regeneration. The parent flips `isOpen` to
+   * `false` in response.
+   */
+  onClose: () => void
+}
+
+/**
+ * Modal dialog launched from `/settings` to regenerate the runner's plan.
+ * Renders an optional free-text textarea (capped at 500 characters) plus a
+ * "Regenerate" submit button. The mutation is fired with a freshly-generated
+ * idempotency key so retries short-circuit server-side; on success the
+ * dialog closes and `invalidatesTags: ["Plan"]` causes the home surface to
+ * refetch the new projection (spec 13 § Unit 5 R05.6, R05.7, R05.8).
+ *
+ * The component uses the native `<dialog>` element rather than a Radix
+ * primitive because the project does not yet pull in `@radix-ui/react-dialog`
+ * — the spec's reference to "shadcn/ui" is aspirational. When that dep
+ * lands the markup can be swapped without altering the behaviour contract.
+ */
+export const RegeneratePlanDialog = ({
+  isOpen,
+  onClose,
+}: RegeneratePlanDialogProps): ReactElement | null => {
+  if (!isOpen) {
+    return null
+  }
+  return <RegeneratePlanDialogBody onClose={onClose} />
+}
+
+interface RegeneratePlanDialogBodyProps {
+  onClose: () => void
+}
+
+/**
+ * Inner body of the dialog. Mounted only when the parent has flipped
+ * `isOpen` to `true`, so transient state (textarea content, error message)
+ * resets simply by virtue of the component remounting — no in-effect
+ * `setState` reset path required.
+ */
+const RegeneratePlanDialogBody = ({ onClose }: RegeneratePlanDialogBodyProps): ReactElement => {
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const [intent, setIntent] = useState('')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [regenerate, { isLoading }] = useRegeneratePlanMutation()
+
+  // Move focus to the textarea on first paint so screen-reader users land
+  // inside the form immediately.
+  useEffect(() => {
+    queueMicrotask(() => textareaRef.current?.focus())
+  }, [])
+
+  // Close-on-Escape — the native <dialog> element handles this for free,
+  // but we are using a positioned div so we wire it up manually to keep
+  // the markup stable for tests (jsdom does not implement HTMLDialogElement).
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape' && !isLoading) {
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isLoading, onClose])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault()
+    setErrorMessage(null)
+    const trimmed = intent.trim()
+    try {
+      await regenerate({
+        idempotencyKey: crypto.randomUUID(),
+        ...(trimmed.length > 0 ? { intent: { freeText: trimmed } } : {}),
+      }).unwrap()
+      onClose()
+    } catch {
+      setErrorMessage('We could not regenerate your plan. Please try again in a moment.')
+    }
+  }
+
+  const remaining = INTENT_MAX_LENGTH - intent.length
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4"
+      onClick={() => {
+        if (!isLoading) onClose()
+      }}
+      data-testid="regenerate-plan-backdrop"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="regenerate-plan-title"
+        aria-describedby="regenerate-plan-description"
+        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+        data-testid="regenerate-plan-dialog"
+      >
+        <h2 id="regenerate-plan-title" className="text-lg font-semibold text-slate-900">
+          Regenerate plan
+        </h2>
+        <p id="regenerate-plan-description" className="mt-2 text-sm text-slate-600">
+          This replaces your current plan.
+        </p>
+
+        <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
+          <label htmlFor="regenerate-plan-intent" className="text-sm font-medium text-slate-700">
+            Anything we should know? (optional)
+          </label>
+          <textarea
+            id="regenerate-plan-intent"
+            ref={textareaRef}
+            value={intent}
+            onChange={(event) => setIntent(event.target.value)}
+            maxLength={INTENT_MAX_LENGTH}
+            rows={4}
+            disabled={isLoading}
+            placeholder="e.g. coming back from a calf strain, want to focus on long runs…"
+            className="w-full resize-none rounded border border-slate-300 px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-60"
+            data-testid="regenerate-plan-intent"
+          />
+          <div className="flex justify-end text-xs text-slate-500" aria-live="polite">
+            {remaining} characters remaining
+          </div>
+
+          {errorMessage !== null ? (
+            <p
+              role="alert"
+              className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+            >
+              {errorMessage}
+            </p>
+          ) : null}
+
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isLoading}
+              className="rounded px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"
+              data-testid="regenerate-plan-submit"
+            >
+              {isLoading ? 'Regenerating…' : 'Regenerate'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.tsx
+++ b/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactElement, type SubmitEvent } from 'react'
+import { useEffect, useMemo, useRef, useState, type ReactElement, type SubmitEvent } from 'react'
 import { useRegeneratePlanMutation } from '~/api/plan.api'
 
 /**
@@ -33,10 +33,8 @@ export interface RegeneratePlanDialogProps {
  * dialog closes and `invalidatesTags: ["Plan"]` causes the home surface to
  * refetch the new projection (spec 13 § Unit 5 R05.6, R05.7, R05.8).
  *
- * The component uses the native `<dialog>` element rather than a Radix
- * primitive because the project does not yet pull in `@radix-ui/react-dialog`
- * — the spec's reference to "shadcn/ui" is aspirational. When that dep
- * lands the markup can be swapped without altering the behaviour contract.
+ * Uses a positioned div rather than the native `<dialog>` element so
+ * jsdom-based tests can mount it deterministically.
  */
 export const RegeneratePlanDialog = ({
   isOpen,
@@ -59,8 +57,8 @@ interface RegeneratePlanDialogBodyProps {
  * `setState` reset path required.
  */
 const RegeneratePlanDialogBody = ({ onClose }: RegeneratePlanDialogBodyProps): ReactElement => {
-  const dialogRef = useRef<HTMLDivElement | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const idempotencyKey = useMemo(() => crypto.randomUUID(), [])
   const [intent, setIntent] = useState('')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [regenerate, { isLoading }] = useRegeneratePlanMutation()
@@ -92,7 +90,7 @@ const RegeneratePlanDialogBody = ({ onClose }: RegeneratePlanDialogBodyProps): R
     const trimmed = intent.trim()
     try {
       await regenerate({
-        idempotencyKey: crypto.randomUUID(),
+        idempotencyKey,
         ...(trimmed.length > 0 ? { intent: { freeText: trimmed } } : {}),
       }).unwrap()
       onClose()
@@ -122,7 +120,6 @@ const RegeneratePlanDialogBody = ({ onClose }: RegeneratePlanDialogBodyProps): R
       data-testid="regenerate-plan-backdrop"
     >
       <div
-        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="regenerate-plan-title"

--- a/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.tsx
+++ b/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type FormEvent, type ReactElement } from 'react'
+import { useEffect, useRef, useState, type ReactElement, type SubmitEvent } from 'react'
 import { useRegeneratePlanMutation } from '~/api/plan.api'
 
 /**
@@ -86,7 +86,7 @@ const RegeneratePlanDialogBody = ({ onClose }: RegeneratePlanDialogBodyProps): R
     }
   }, [isLoading, onClose])
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+  const handleSubmit = async (event: SubmitEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault()
     setErrorMessage(null)
     const trimmed = intent.trim()
@@ -103,11 +103,21 @@ const RegeneratePlanDialogBody = ({ onClose }: RegeneratePlanDialogBodyProps): R
 
   const remaining = INTENT_MAX_LENGTH - intent.length
 
+  const closeIfIdle = (): void => {
+    if (!isLoading) onClose()
+  }
+
   return (
     <div
+      role="presentation"
+      tabIndex={-1}
       className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4"
-      onClick={() => {
-        if (!isLoading) onClose()
+      onClick={closeIfIdle}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          closeIfIdle()
+        }
       }}
       data-testid="regenerate-plan-backdrop"
     >
@@ -119,6 +129,7 @@ const RegeneratePlanDialogBody = ({ onClose }: RegeneratePlanDialogBodyProps): R
         aria-describedby="regenerate-plan-description"
         className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
         onClick={(event) => event.stopPropagation()}
+        onKeyDown={(event) => event.stopPropagation()}
         data-testid="regenerate-plan-dialog"
       >
         <h2 id="regenerate-plan-title" className="text-lg font-semibold text-slate-900">

--- a/frontend/src/app/modules/settings/pages/settings-page.spec.tsx
+++ b/frontend/src/app/modules/settings/pages/settings-page.spec.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PlanProjectionDto } from '~/modules/plan/models/plan.model'
+
+interface QueryResult {
+  data?: PlanProjectionDto
+  isLoading: boolean
+  isError: boolean
+}
+
+const { getCurrentPlanMock } = vi.hoisted(() => ({
+  getCurrentPlanMock: vi.fn<() => QueryResult>(),
+}))
+
+vi.mock('~/api/plan.api', () => ({
+  useGetCurrentPlanQuery: () => getCurrentPlanMock(),
+}))
+
+vi.mock('~/modules/settings/components/regenerate-plan-dialog.component', () => ({
+  RegeneratePlanDialog: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="regenerate-plan-dialog-stub">dialog</div> : null,
+}))
+
+import { SettingsPage } from './settings.page'
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/settings']}>
+      <SettingsPage />
+    </MemoryRouter>,
+  )
+
+const buildPlanStub = (overrides: Partial<PlanProjectionDto> = {}): PlanProjectionDto => ({
+  planId: 'plan-1',
+  userId: 'user-1',
+  generatedAt: '2026-04-25T15:00:00.000Z',
+  previousPlanId: null,
+  promptVersion: 'coaching-v1',
+  modelId: 'claude-sonnet-4-6',
+  macro: null,
+  mesoWeeks: [],
+  microWorkoutsByWeek: {},
+  ...overrides,
+})
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    getCurrentPlanMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the loading status while the plan is in flight', () => {
+    getCurrentPlanMock.mockReturnValue({ data: undefined, isLoading: true, isError: false })
+    renderPage()
+    expect(screen.getByRole('status')).toHaveTextContent(/loading plan details/i)
+  })
+
+  it('shows the generatedAt timestamp and a regenerate button when the plan loads', () => {
+    getCurrentPlanMock.mockReturnValue({
+      data: buildPlanStub(),
+      isLoading: false,
+      isError: false,
+    })
+    renderPage()
+    expect(screen.getByTestId('settings-plan-generated-at')).toBeInTheDocument()
+    expect(screen.getByTestId('settings-regenerate-button')).toBeInTheDocument()
+  })
+
+  it('does not render the previous-plan link when previousPlanId is null', () => {
+    getCurrentPlanMock.mockReturnValue({
+      data: buildPlanStub({ previousPlanId: null }),
+      isLoading: false,
+      isError: false,
+    })
+    renderPage()
+    expect(screen.queryByTestId('settings-previous-plan-link')).not.toBeInTheDocument()
+  })
+
+  it('renders the placeholder previous-plan link when previousPlanId is non-null', () => {
+    getCurrentPlanMock.mockReturnValue({
+      data: buildPlanStub({ previousPlanId: 'plan-0' }),
+      isLoading: false,
+      isError: false,
+    })
+    renderPage()
+    expect(screen.getByTestId('settings-previous-plan-link')).toBeInTheDocument()
+  })
+
+  it('opens the regenerate dialog when the button is clicked', async () => {
+    getCurrentPlanMock.mockReturnValue({
+      data: buildPlanStub(),
+      isLoading: false,
+      isError: false,
+    })
+    renderPage()
+    expect(screen.queryByTestId('regenerate-plan-dialog-stub')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByTestId('settings-regenerate-button'))
+    expect(screen.getByTestId('regenerate-plan-dialog-stub')).toBeInTheDocument()
+  })
+
+  it('falls back gracefully when the plan query errors', () => {
+    getCurrentPlanMock.mockReturnValue({ data: undefined, isLoading: false, isError: true })
+    renderPage()
+    expect(screen.getByText(/could not load your current plan/i)).toBeInTheDocument()
+    // The Regenerate button should still be available so the user can retry.
+    expect(screen.getByTestId('settings-regenerate-button')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/modules/settings/pages/settings-page.spec.tsx
+++ b/frontend/src/app/modules/settings/pages/settings-page.spec.tsx
@@ -19,8 +19,15 @@ vi.mock('~/api/plan.api', () => ({
 }))
 
 vi.mock('~/modules/settings/components/regenerate-plan-dialog.component', () => ({
-  RegeneratePlanDialog: ({ isOpen }: { isOpen: boolean }) =>
-    isOpen ? <div data-testid="regenerate-plan-dialog-stub">dialog</div> : null,
+  RegeneratePlanDialog: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
+    isOpen ? (
+      <div data-testid="regenerate-plan-dialog-stub">
+        dialog
+        <button type="button" onClick={onClose} data-testid="regenerate-plan-dialog-close-stub">
+          close
+        </button>
+      </div>
+    ) : null,
 }))
 
 import { SettingsPage } from './settings.page'
@@ -109,5 +116,33 @@ describe('SettingsPage', () => {
     expect(screen.getByText(/could not load your current plan/i)).toBeInTheDocument()
     // The Regenerate button should still be available so the user can retry.
     expect(screen.getByTestId('settings-regenerate-button')).toBeInTheDocument()
+  })
+
+  it('closes the regenerate dialog when the dialog requests close', async () => {
+    getCurrentPlanMock.mockReturnValue({
+      data: buildPlanStub(),
+      isLoading: false,
+      isError: false,
+    })
+    renderPage()
+    await userEvent.click(screen.getByTestId('settings-regenerate-button'))
+    expect(screen.getByTestId('regenerate-plan-dialog-stub')).toBeInTheDocument()
+    await userEvent.click(screen.getByTestId('regenerate-plan-dialog-close-stub'))
+    expect(screen.queryByTestId('regenerate-plan-dialog-stub')).not.toBeInTheDocument()
+  })
+
+  it('renders the raw generatedAt string when Date parsing returns NaN', () => {
+    getCurrentPlanMock.mockReturnValue({
+      data: buildPlanStub({ generatedAt: 'definitely-not-a-date' }),
+      isLoading: false,
+      isError: false,
+    })
+    renderPage()
+    const summary = screen.getByTestId('settings-plan-generated-at')
+    expect(summary).toHaveTextContent('definitely-not-a-date')
+    const time = summary.querySelector('time')
+    expect(time).not.toBeNull()
+    expect(time).toHaveAttribute('dateTime', 'definitely-not-a-date')
+    expect(time?.textContent).toBe('definitely-not-a-date')
   })
 })

--- a/frontend/src/app/modules/settings/pages/settings.page.tsx
+++ b/frontend/src/app/modules/settings/pages/settings.page.tsx
@@ -1,0 +1,130 @@
+import { useState, type ReactElement } from 'react'
+import { Link } from 'react-router-dom'
+import { useGetCurrentPlanQuery } from '~/api/plan.api'
+import { RegeneratePlanDialog } from '~/modules/settings/components/regenerate-plan-dialog.component'
+
+/**
+ * `/settings` route surface — Slice 1's only Settings content is the "Plan"
+ * section: current plan's `generatedAt` timestamp, an optional placeholder
+ * link to the previous plan when `previousPlanId` is non-null (no-op target
+ * in Slice 1; lands when adaptation history matters in Slice 3+), and a
+ * "Regenerate plan" button that opens `RegeneratePlanDialog`.
+ *
+ * The page is gated by `<RequireAuth>` at the route table level (spec 13
+ * § Unit 5 R05.6 / R05.7 / R05.8).
+ */
+export const SettingsPage = (): ReactElement => {
+  const { data: plan, isLoading, isError } = useGetCurrentPlanQuery(undefined)
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+
+  return (
+    <main
+      className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-8 bg-slate-50 px-4 py-8"
+      data-testid="settings-page"
+    >
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-slate-900">Settings</h1>
+        <Link to="/" className="text-sm font-medium text-slate-600 hover:text-slate-900">
+          Back to plan
+        </Link>
+      </header>
+
+      <section
+        className="rounded-lg border border-slate-200 bg-white p-6"
+        data-testid="settings-plan-section"
+      >
+        <h2 className="text-lg font-semibold text-slate-900">Plan</h2>
+
+        <PlanSummary
+          isLoading={isLoading}
+          isError={isError}
+          generatedAt={plan?.generatedAt}
+          previousPlanId={plan?.previousPlanId ?? null}
+        />
+
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={() => setIsDialogOpen(true)}
+            className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
+            data-testid="settings-regenerate-button"
+          >
+            Regenerate plan
+          </button>
+        </div>
+      </section>
+
+      <RegeneratePlanDialog isOpen={isDialogOpen} onClose={() => setIsDialogOpen(false)} />
+    </main>
+  )
+}
+
+interface PlanSummaryProps {
+  isLoading: boolean
+  isError: boolean
+  generatedAt: string | undefined
+  previousPlanId: string | null
+}
+
+/**
+ * Renders the small "current plan was generated at …" summary block above
+ * the Regenerate button. Extracted so the page-level component stays under
+ * the 100-line guideline.
+ */
+const PlanSummary = ({
+  isLoading,
+  isError,
+  generatedAt,
+  previousPlanId,
+}: PlanSummaryProps): ReactElement => {
+  if (isLoading) {
+    return (
+      <p className="mt-2 text-sm text-slate-500" role="status" aria-live="polite">
+        Loading plan details…
+      </p>
+    )
+  }
+
+  if (isError || generatedAt === undefined) {
+    return (
+      <p className="mt-2 text-sm text-slate-500">
+        We could not load your current plan details right now.
+      </p>
+    )
+  }
+
+  return (
+    <div className="mt-2 flex flex-col gap-1 text-sm text-slate-600">
+      <p data-testid="settings-plan-generated-at">
+        Current plan generated <time dateTime={generatedAt}>{formatGeneratedAt(generatedAt)}</time>
+      </p>
+      {previousPlanId !== null ? (
+        // The link target is intentionally a no-op (`#`) in Slice 1; viewing
+        // historical plans lands when adaptation history matters in Slice 3+.
+        <a
+          href="#"
+          className="text-sm text-slate-500 underline-offset-2 hover:underline"
+          data-testid="settings-previous-plan-link"
+          onClick={(event) => event.preventDefault()}
+        >
+          View previous plan
+        </a>
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * Render the ISO-8601 `generatedAt` string in the user's locale. Falls back
+ * to the raw string if `Date` parsing fails (e.g. a future schema bump
+ * sneaks a non-ISO value through).
+ */
+const formatGeneratedAt = (generatedAt: string): string => {
+  const parsed = new Date(generatedAt)
+  if (Number.isNaN(parsed.getTime())) {
+    return generatedAt
+  }
+  return parsed.toLocaleString()
+}
+
+export default SettingsPage

--- a/frontend/src/app/modules/settings/pages/settings.page.tsx
+++ b/frontend/src/app/modules/settings/pages/settings.page.tsx
@@ -4,10 +4,10 @@ import { useGetCurrentPlanQuery } from '~/api/plan.api'
 import { RegeneratePlanDialog } from '~/modules/settings/components/regenerate-plan-dialog.component'
 
 /**
- * `/settings` route surface — Slice 1's only Settings content is the "Plan"
- * section: current plan's `generatedAt` timestamp, an optional placeholder
- * link to the previous plan when `previousPlanId` is non-null (no-op target
- * in Slice 1; lands when adaptation history matters in Slice 3+), and a
+ * `/settings` route surface. Renders the "Plan" section: current plan's
+ * `generatedAt` timestamp, an optional previous-plan button when
+ * `previousPlanId` is non-null (currently a placeholder with no destination
+ * route; spec 13 § Unit 5 R05.6 tracks the destination route), and a
  * "Regenerate plan" button that opens `RegeneratePlanDialog`.
  *
  * The page is gated by `<RequireAuth>` at the route table level (spec 13

--- a/frontend/src/app/modules/settings/pages/settings.page.tsx
+++ b/frontend/src/app/modules/settings/pages/settings.page.tsx
@@ -99,16 +99,13 @@ const PlanSummary = ({
         Current plan generated <time dateTime={generatedAt}>{formatGeneratedAt(generatedAt)}</time>
       </p>
       {previousPlanId !== null ? (
-        // The link target is intentionally a no-op (`#`) in Slice 1; viewing
-        // historical plans lands when adaptation history matters in Slice 3+.
-        <a
-          href="#"
-          className="text-sm text-slate-500 underline-offset-2 hover:underline"
+        <button
+          type="button"
+          className="text-left text-sm text-slate-500 underline-offset-2 hover:underline"
           data-testid="settings-previous-plan-link"
-          onClick={(event) => event.preventDefault()}
         >
           View previous plan
-        </a>
+        </button>
       ) : null}
     </div>
   )


### PR DESCRIPTION
## Summary

Slice 1 Unit 5 (Regenerate from Settings) — full-stack. Backend `POST /api/v1/plan/regenerate` accepts a `RegenerationIntent` (optional `freeText` ≤500 chars), routes through the prompt sanitizer with section delimiters, calls `IPlanGenerationService`, appends a `PlanRegenerated` event, and returns the new plan. Idempotency key is required; concurrent submissions surface as 409 conflict via Marten's optimistic-concurrency `MoveToErrorQueue` policy. Frontend ships the settings page and modal regenerate dialog with a confirmation step.

Also includes a fix (ad59625) for `SanitizationOTelTests` — the global `ActivityListener` was occasionally pinning to a span from a different test's call, producing a flake on pre-push. Clear-`_captured`-then-LastOrDefault eliminates the cross-test pollution. 5/5 consecutive pre-push runs PASS at 783 tests after the fix.

## Stacked on
`slice-1c-plan-view`. Retarget to `main` after PR-1C merges.

## Testing
- `dotnet test` integration tests for happy path, idempotency replay, 409 on concurrent, 400 on intent.freeText overflow.
- `vitest run` for the settings page + dialog.
- Playwright E2E `frontend/e2e/regenerate-plan.spec.ts`.

## Follow-ups found
- 400-validation E2E for `intent.freeText` cap (deferred to Slice 2 or Slice 3 per cycle plan).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings page with a Regenerate Plan dialog and UI (500‑char intent, live counter, loading/error states).
  * New plan-regeneration API (POST /api/v1/plan/regenerate) with optional sanitized free-text intent and idempotency support.

* **Behavior Changes**
  * Regeneration is blocked with a 409 conflict when onboarding is incomplete.

* **Tests**
  * Expanded unit, integration, transaction, end-to-end, and API tests covering sanitization, idempotency, validation, and happy/error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->