### PR TITLE
feat(coaching,plan): onboarding turn handler, plan generation service, dec-057 regression test (6/6)

### DIFF
--- a/backend/REVIEW.md
+++ b/backend/REVIEW.md
@@ -117,6 +117,15 @@
   `userId + ":" + streamPurpose` truncated to 16 bytes). This makes
   `StartStream<T>(deterministicId, ...)` naturally idempotent — retries hit
   a primary-key violation and are handled as "already started."
+- **Onboarding stream id carve-out:** The onboarding stream's id is the raw
+  `userId` (not `DeterministicGuid(userId, "onboarding")`). Reason:
+  `OnboardingProjection.Create(OnboardingStarted)` couples
+  `OnboardingView.Id = @event.UserId`, and Marten's `SingleStreamProjection`
+  treats the document id as the stream id. Decoupling them would require
+  reworking the projection's identity binding — out of scope for the
+  current slice. The `DeterministicGuid` helper exists in
+  `Infrastructure/DeterministicGuid.cs` for new 1:1-per-user aggregates that
+  do NOT have this projection-binding constraint.
 - For aggregates that are 1:many per user (e.g., Plan), use
   `CombGuidIdGeneration.NewGuid()` per instance and store the current id on
   the EF projection row.

--- a/backend/src/RunCoach.Api/Infrastructure/DeterministicGuid.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/DeterministicGuid.cs
@@ -1,0 +1,66 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace RunCoach.Api.Infrastructure;
+
+/// <summary>
+/// Helpers for deriving deterministic Guids from a stable input pair (typically
+/// a user id plus a stream-purpose tag). Produces a UUID-v5-shaped Guid: SHA-1
+/// over the UTF-8 bytes of <c>{userId:D}:{streamPurpose}</c>, truncated to
+/// 16 bytes with the version (5) and IETF variant bits set.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use this for Marten stream ids on aggregates that are 1:1 with the user.
+/// Repeating the call returns the same Guid, so <c>StartStream&lt;T&gt;</c>
+/// retries hit a primary-key violation and surface as "already started"
+/// rather than creating a duplicate stream. See backend/REVIEW.md "Marten
+/// event-stream identity".
+/// </para>
+/// </remarks>
+public static class DeterministicGuid
+{
+    /// <summary>
+    /// Derives a UUID-v5-shaped Guid from a user id plus a stream-purpose
+    /// label. Same inputs always yield the same Guid.
+    /// </summary>
+    /// <param name="userId">The runner's authenticated user id.</param>
+    /// <param name="streamPurpose">
+    /// Short stable label that disambiguates this stream from other 1:1 streams
+    /// the same user owns (e.g. <c>"onboarding"</c>). Trimmed and case-sensitive.
+    /// </param>
+    /// <returns>A deterministic Guid suitable for use as a Marten stream id.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="streamPurpose"/> is null, empty, or whitespace.
+    /// </exception>
+    public static Guid From(Guid userId, string streamPurpose)
+    {
+        if (string.IsNullOrWhiteSpace(streamPurpose))
+        {
+            throw new ArgumentException("Stream purpose must be non-empty.", nameof(streamPurpose));
+        }
+
+        var input = Encoding.UTF8.GetBytes(
+            string.Create(
+                CultureInfo.InvariantCulture,
+                $"{userId:D}:{streamPurpose}"));
+
+        Span<byte> hash = stackalloc byte[20];
+
+        // RFC 4122 §4.3 specifies SHA-1 as the hash for UUID v5; it is used as
+        // an identity-derivation function here, not for any security purpose.
+#pragma warning disable CA5350
+        SHA1.HashData(input, hash);
+#pragma warning restore CA5350
+
+        Span<byte> bytes = stackalloc byte[16];
+        hash[..16].CopyTo(bytes);
+
+        // RFC 4122 §4.3: set version (5) and IETF variant bits.
+        bytes[6] = (byte)((bytes[6] & 0x0F) | 0x50);
+        bytes[8] = (byte)((bytes[8] & 0x3F) | 0x80);
+
+        return new Guid(bytes);
+    }
+}

--- a/backend/src/RunCoach.Api/Infrastructure/DeterministicGuid.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/DeterministicGuid.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
@@ -34,6 +35,14 @@ public static class DeterministicGuid
     /// <exception cref="ArgumentException">
     /// Thrown when <paramref name="streamPurpose"/> is null, empty, or whitespace.
     /// </exception>
+    [SuppressMessage(
+        "Security",
+        "S4790:Using weak hashing algorithms is security-sensitive",
+        Justification = "RFC 4122 §4.3 mandates SHA-1 for UUID v5; SHA-1 is used here as an identity-derivation function (deterministic id from a name+namespace pair), not for any security primitive (no signing, password hashing, MAC, or integrity check). The output is a 16-byte stream id, never a credential.")]
+    [SuppressMessage(
+        "Security",
+        "CA5350:Do Not Use Weak Cryptographic Algorithms",
+        Justification = "RFC 4122 §4.3 specifies SHA-1 for UUID v5; non-cryptographic identity derivation only.")]
     public static Guid From(Guid userId, string streamPurpose)
     {
         if (string.IsNullOrWhiteSpace(streamPurpose))
@@ -47,20 +56,21 @@ public static class DeterministicGuid
                 $"{userId:D}:{streamPurpose}"));
 
         Span<byte> hash = stackalloc byte[20];
-
-        // RFC 4122 §4.3 specifies SHA-1 as the hash for UUID v5; it is used as
-        // an identity-derivation function here, not for any security purpose.
-#pragma warning disable CA5350
         SHA1.HashData(input, hash);
-#pragma warning restore CA5350
 
         Span<byte> bytes = stackalloc byte[16];
         hash[..16].CopyTo(bytes);
 
-        // RFC 4122 §4.3: set version (5) and IETF variant bits.
+        // RFC 4122 §4.3: set version (5) and IETF variant bits in the canonical
+        // big-endian layout (byte 6 holds the version nibble, byte 8 holds the
+        // variant bits).
         bytes[6] = (byte)((bytes[6] & 0x0F) | 0x50);
         bytes[8] = (byte)((bytes[8] & 0x3F) | 0x80);
 
-        return new Guid(bytes);
+        // Construct from big-endian bytes so the canonical layout is preserved
+        // (Guid's default ctor expects Windows mixed-endian; using the
+        // bigEndian:true overload introduced in .NET 8 keeps the version digit
+        // visible in `ToString("D")` and `ToByteArray(bigEndian: true)`).
+        return new Guid(bytes, bigEndian: true);
     }
 }

--- a/backend/src/RunCoach.Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -73,8 +73,8 @@ public static class ServiceCollectionExtensions
 
         // Plan generation orchestrator — plain DI service per Slice 1 § Unit 2
         // (DEC-057 / R-066). NOT a Wolverine handler: invoked inline by the
-        // caller's `[AggregateHandler]` body so events commit on the caller's
-        // session inside one Marten transaction.
+        // caller's static handler body (e.g. OnboardingTurnHandler.Handle) so
+        // events commit on the caller's session inside one Marten transaction.
         services.AddScoped<IPlanGenerationService, PlanGenerationService>();
 
         return services;

--- a/backend/src/RunCoach.Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using RunCoach.Api.Modules.Coaching;
 using RunCoach.Api.Modules.Coaching.Prompts;
 using RunCoach.Api.Modules.Coaching.Sanitization;
 using RunCoach.Api.Modules.Training.Computations;
+using RunCoach.Api.Modules.Training.Plan;
 
 namespace RunCoach.Api.Infrastructure;
 
@@ -69,6 +70,12 @@ public static class ServiceCollectionExtensions
         // cross-tenant session.
         services.AddScoped<IIdempotencyStore, MartenIdempotencyStore>();
         services.AddHostedService<IdempotencySweeper>();
+
+        // Plan generation orchestrator — plain DI service per Slice 1 § Unit 2
+        // (DEC-057 / R-066). NOT a Wolverine handler: invoked inline by the
+        // caller's `[AggregateHandler]` body so events commit on the caller's
+        // session inside one Marten transaction.
+        services.AddScoped<IPlanGenerationService, PlanGenerationService>();
 
         return services;
     }

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/AnthropicContentBlock.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/AnthropicContentBlock.cs
@@ -22,4 +22,42 @@ public sealed record AnthropicContentBlock
     /// </summary>
     [Description("Runner-visible text payload for a Text block. Empty string for non-Text blocks.")]
     public required string Text { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Validates the block-type / text-payload contract: <c>Text</c> blocks must carry non-empty
+    /// text, <c>Thinking</c> blocks must carry an empty string. The wire schema cannot express
+    /// this dependency (DEC-058 keeps the schema closed-shape for grammar caching), so the
+    /// invariant is enforced at the .NET boundary by callers (e.g. <c>OnboardingTurnOutputValidator</c>).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the block's <see cref="Type"/> and <see cref="Text"/> combination is invalid.
+    /// </exception>
+    public void Validate()
+    {
+        switch (Type)
+        {
+            case AnthropicContentBlockType.Text:
+                if (string.IsNullOrEmpty(Text))
+                {
+                    throw new InvalidOperationException(
+                        "AnthropicContentBlock with Type=Text must carry a non-empty Text payload.");
+                }
+
+                break;
+
+            case AnthropicContentBlockType.Thinking:
+                if (!string.IsNullOrEmpty(Text))
+                {
+                    throw new InvalidOperationException(
+                        "AnthropicContentBlock with Type=Thinking must carry an empty Text payload " +
+                        "(the schema reserves Text for runner-visible Text blocks only).");
+                }
+
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown AnthropicContentBlockType '{Type}'.");
+        }
+    }
 }

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Entities/RunnerOnboardingProfile.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Entities/RunnerOnboardingProfile.cs
@@ -23,8 +23,8 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding.Entities;
 /// <c>UserProfileFromOnboardingProjection</c> apply method per DEC-060 / R-069,
 /// which runs as a Marten transaction participant on the same Postgres
 /// connection as the event append — atomic by construction. Wolverine
-/// <c>[AggregateHandler]</c> bodies must not mutate this entity directly
-/// (DEC-060 prohibition on dual-write).
+/// onboarding-handler bodies must not mutate this entity directly (DEC-060
+/// prohibition on dual-write).
 /// </remarks>
 [Table("UserProfile")]
 public class RunnerOnboardingProfile : ITenanted

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/OnboardingProgressDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/OnboardingProgressDto.cs
@@ -2,9 +2,13 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
 
 /// <summary>
 /// Progress indicator surface for the chat UI's <c>TopicProgressIndicator</c>.
+/// Property names mirror the flat counters on <see cref="OnboardingStateDto"/>
+/// so the discriminated-union Zod schema on the frontend can share the same
+/// shape — every progress payload on the wire reads
+/// <c>{ completedTopics, totalTopics }</c>.
 /// </summary>
-/// <param name="Completed">Count of topics that have a captured answer.</param>
-/// <param name="Total">Total number of topics in the onboarding flow (six per DEC-047).</param>
+/// <param name="CompletedTopics">Count of topics that have a captured answer.</param>
+/// <param name="TotalTopics">Total number of topics in the onboarding flow (six per DEC-047).</param>
 public sealed record OnboardingProgressDto(
-    int Completed,
-    int Total);
+    int CompletedTopics,
+    int TotalTopics);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/OnboardingProgressDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/OnboardingProgressDto.cs
@@ -7,8 +7,55 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
 /// shape — every progress payload on the wire reads
 /// <c>{ completedTopics, totalTopics }</c>.
 /// </summary>
+/// <remarks>
+/// Construction validates <c>0 &lt;= CompletedTopics &lt;= TotalTopics</c> and
+/// <c>TotalTopics &gt;= 1</c> so the frontend's <c>completed / total</c> ratio
+/// cannot collapse to NaN or a negative value, even when the wire payload is
+/// reconstructed via JSON deserialization.
+/// </remarks>
 /// <param name="CompletedTopics">Count of topics that have a captured answer.</param>
 /// <param name="TotalTopics">Total number of topics in the onboarding flow (six per DEC-047).</param>
 public sealed record OnboardingProgressDto(
     int CompletedTopics,
-    int TotalTopics);
+    int TotalTopics)
+{
+    /// <summary>Gets count of topics that have a captured answer.</summary>
+    public int CompletedTopics { get; init; } = ValidateCompleted(CompletedTopics, TotalTopics);
+
+    /// <summary>Gets total number of topics in the onboarding flow.</summary>
+    public int TotalTopics { get; init; } = ValidateTotal(TotalTopics);
+
+    private static int ValidateTotal(int totalTopics)
+    {
+        if (totalTopics < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(totalTopics),
+                totalTopics,
+                "TotalTopics must be at least 1.");
+        }
+
+        return totalTopics;
+    }
+
+    private static int ValidateCompleted(int completedTopics, int totalTopics)
+    {
+        if (completedTopics < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(completedTopics),
+                completedTopics,
+                "CompletedTopics cannot be negative.");
+        }
+
+        if (totalTopics >= 1 && completedTopics > totalTopics)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(completedTopics),
+                completedTopics,
+                $"CompletedTopics ({completedTopics}) cannot exceed TotalTopics ({totalTopics}).");
+        }
+
+        return completedTopics;
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/OnboardingStateDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/OnboardingStateDto.cs
@@ -1,0 +1,44 @@
+namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+/// <summary>
+/// GET /api/v1/onboarding/state response payload (Slice 1 § Unit 1 R01.10).
+/// Surfaces the runner's current onboarding view + the deterministic
+/// completion-gate verdict so the chat UI can resume the flow without a
+/// separate roundtrip to compute progress.
+/// </summary>
+/// <param name="UserId">The runner's user id.</param>
+/// <param name="Status">Lifecycle status of the onboarding stream.</param>
+/// <param name="CurrentTopic">The most recently asked topic, or null on a fresh stream.</param>
+/// <param name="CompletedTopics">Number of topics with a captured answer.</param>
+/// <param name="TotalTopics">Total topics for the runner (5 when not race-training, 6 when race-training).</param>
+/// <param name="IsComplete">
+/// True when the onboarding stream is in <see cref="OnboardingStatus.Completed"/> AND the
+/// deterministic completion gate is satisfied — surfaces the gate verdict to the
+/// chat UI's resume-flow logic.
+/// </param>
+/// <param name="OutstandingClarifications">
+/// Topics with an unresolved <see cref="ClarificationRequested"/> event. The completion
+/// gate fails while this list is non-empty.
+/// </param>
+/// <param name="PrimaryGoal">Captured PrimaryGoal answer or null.</param>
+/// <param name="TargetEvent">Captured TargetEvent answer or null.</param>
+/// <param name="CurrentFitness">Captured CurrentFitness answer or null.</param>
+/// <param name="WeeklySchedule">Captured WeeklySchedule answer or null.</param>
+/// <param name="InjuryHistory">Captured InjuryHistory answer or null.</param>
+/// <param name="Preferences">Captured Preferences answer or null.</param>
+/// <param name="CurrentPlanId">Currently active plan id once <see cref="PlanLinkedToUser"/> has fired; null otherwise.</param>
+public sealed record OnboardingStateDto(
+    Guid UserId,
+    OnboardingStatus Status,
+    OnboardingTopic? CurrentTopic,
+    int CompletedTopics,
+    int TotalTopics,
+    bool IsComplete,
+    IReadOnlyList<OnboardingTopic> OutstandingClarifications,
+    PrimaryGoalAnswer? PrimaryGoal,
+    TargetEventAnswer? TargetEvent,
+    CurrentFitnessAnswer? CurrentFitness,
+    WeeklyScheduleAnswer? WeeklySchedule,
+    InjuryHistoryAnswer? InjuryHistory,
+    PreferencesAnswer? Preferences,
+    Guid? CurrentPlanId);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/OnboardingTurnRequestDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/OnboardingTurnRequestDto.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
 
 /// <summary>
@@ -10,5 +12,5 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
 /// </param>
 /// <param name="Text">The user's free-text input for the current onboarding turn.</param>
 public sealed record OnboardingTurnRequestDto(
-    Guid IdempotencyKey,
+    [property: JsonRequired] Guid IdempotencyKey,
     string Text);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/OnboardingTurnResponseDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/OnboardingTurnResponseDto.cs
@@ -6,6 +6,14 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
 /// Response payload for POST /api/v1/onboarding/turns. Carries either the next assistant turn
 /// (Kind = Ask) or the completion signal with a generated plan id (Kind = Complete).
 /// </summary>
+/// <remarks>
+/// <para>
+/// The DTO is logically a discriminated union but is encoded as a flat record so the
+/// frontend Zod schema can read it without a custom converter. Producers should
+/// always use the static <see cref="Ask"/> / <see cref="Complete"/> factories — the
+/// positional constructor remains public only for System.Text.Json deserialization.
+/// </para>
+/// </remarks>
 /// <param name="Kind">Discriminator: Ask or Complete.</param>
 /// <param name="AssistantBlocks">
 /// Anthropic content blocks from the assistant turn, carried as a <see cref="JsonElement"/> so
@@ -34,4 +42,58 @@ public sealed record OnboardingTurnResponseDto(
     OnboardingTopic? Topic,
     SuggestedInputType? SuggestedInputType,
     OnboardingProgressDto Progress,
-    Guid? PlanId);
+    Guid? PlanId)
+{
+    /// <summary>
+    /// Constructs an <see cref="OnboardingTurnKind.Ask"/>-shaped response. Validates
+    /// that the per-Kind invariant holds (topic + suggestedInputType present, planId absent).
+    /// </summary>
+    /// <param name="assistantBlocks">The assistant turn content blocks.</param>
+    /// <param name="topic">The topic being asked about.</param>
+    /// <param name="suggestedInputType">The input control the SPA should render.</param>
+    /// <param name="progress">Topic-completion progress for the UI.</param>
+    /// <returns>A well-formed Ask response.</returns>
+    public static OnboardingTurnResponseDto Ask(
+        JsonElement assistantBlocks,
+        OnboardingTopic topic,
+        SuggestedInputType suggestedInputType,
+        OnboardingProgressDto progress)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+        return new OnboardingTurnResponseDto(
+            Kind: OnboardingTurnKind.Ask,
+            AssistantBlocks: assistantBlocks,
+            Topic: topic,
+            SuggestedInputType: suggestedInputType,
+            Progress: progress,
+            PlanId: null);
+    }
+
+    /// <summary>
+    /// Constructs an <see cref="OnboardingTurnKind.Complete"/>-shaped response. Validates
+    /// that the per-Kind invariant holds (planId present, topic + suggestedInputType absent).
+    /// </summary>
+    /// <param name="assistantBlocks">The assistant turn content blocks.</param>
+    /// <param name="progress">Topic-completion progress for the UI (typically 6/6).</param>
+    /// <param name="planId">The generated plan id.</param>
+    /// <returns>A well-formed Complete response.</returns>
+    public static OnboardingTurnResponseDto Complete(
+        JsonElement assistantBlocks,
+        OnboardingProgressDto progress,
+        Guid planId)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+        if (planId == Guid.Empty)
+        {
+            throw new ArgumentException("PlanId must not be Guid.Empty for a Complete response.", nameof(planId));
+        }
+
+        return new OnboardingTurnResponseDto(
+            Kind: OnboardingTurnKind.Complete,
+            AssistantBlocks: assistantBlocks,
+            Topic: null,
+            SuggestedInputType: null,
+            Progress: progress,
+            PlanId: planId);
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/ReviseAnswerRequestDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/ReviseAnswerRequestDto.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
 
@@ -17,5 +18,5 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
 /// <c>JsonSerializer.SerializeToDocument(NormalizedValue)</c> or equivalent.
 /// </param>
 public sealed record ReviseAnswerRequestDto(
-    OnboardingTopic Topic,
-    JsonElement NormalizedValue);
+    [property: JsonRequired] OnboardingTopic Topic,
+    [property: JsonRequired] JsonElement NormalizedValue);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingAlreadyCompleteException.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingAlreadyCompleteException.cs
@@ -1,0 +1,24 @@
+namespace RunCoach.Api.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Thrown by <see cref="OnboardingTurnHandler"/> when a runner attempts to submit
+/// a fresh turn against a stream that already terminated with
+/// <see cref="OnboardingCompleted"/>. The controller surface translates the
+/// exception into HTTP 409 Conflict with an RFC 7807 ProblemDetails body per
+/// the onboarding state-engine feature spec.
+/// </summary>
+public sealed class OnboardingAlreadyCompleteException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OnboardingAlreadyCompleteException"/> class.
+    /// </summary>
+    /// <param name="userId">The runner's user id.</param>
+    public OnboardingAlreadyCompleteException(Guid userId)
+        : base($"Onboarding is already complete for user {userId}; submit a regenerate request instead of a fresh turn.")
+    {
+        UserId = userId;
+    }
+
+    /// <summary>Gets the user id whose stream is already terminal.</summary>
+    public Guid UserId { get; }
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingCompletionGate.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingCompletionGate.cs
@@ -1,0 +1,150 @@
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+namespace RunCoach.Api.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Deterministic completion gate per Slice 1 § Unit 1 R01.6 — a pure function
+/// over <see cref="OnboardingView"/> that returns whether the onboarding flow
+/// has captured every required slot AND has no outstanding clarifications.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The gate is intentionally separate from any LLM judgment. The
+/// <c>ReadyForPlan</c> field on <see cref="OnboardingTurnOutput"/> is an
+/// additive precondition only — the handler never appends
+/// <see cref="OnboardingCompleted"/> unless this gate also returns true.
+/// </para>
+/// <para>
+/// Required slots are <c>PrimaryGoal</c>, <c>WeeklySchedule</c>,
+/// <c>CurrentFitness</c>, <c>InjuryHistory</c>, <c>Preferences</c>.
+/// <c>TargetEvent</c> is required only when <c>PrimaryGoal == RaceTraining</c>.
+/// </para>
+/// </remarks>
+public static class OnboardingCompletionGate
+{
+    /// <summary>
+    /// Evaluates the gate against the supplied <paramref name="view"/>.
+    /// </summary>
+    /// <param name="view">The runner's in-flight onboarding projection.</param>
+    /// <returns><see langword="true"/> if every required slot is captured AND
+    /// there are no outstanding clarifications; <see langword="false"/> otherwise.</returns>
+    public static bool IsSatisfied(OnboardingView view)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+
+        if (view.PrimaryGoal is null
+            || view.WeeklySchedule is null
+            || view.CurrentFitness is null
+            || view.InjuryHistory is null
+            || view.Preferences is null)
+        {
+            return false;
+        }
+
+        if (view.PrimaryGoal.Goal == PrimaryGoal.RaceTraining && view.TargetEvent is null)
+        {
+            return false;
+        }
+
+        if (view.OutstandingClarifications.Count > 0)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the next topic the deterministic next-topic selector should ask
+    /// about, or <see langword="null"/> when the gate is satisfied.
+    /// </summary>
+    /// <param name="view">The runner's in-flight onboarding projection.</param>
+    /// <returns>The next topic to ask, or <see langword="null"/> when complete.</returns>
+    public static OnboardingTopic? NextTopic(OnboardingView view)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+
+        if (view.PrimaryGoal is null)
+        {
+            return OnboardingTopic.PrimaryGoal;
+        }
+
+        if (view.PrimaryGoal.Goal == PrimaryGoal.RaceTraining && view.TargetEvent is null)
+        {
+            return OnboardingTopic.TargetEvent;
+        }
+
+        if (view.CurrentFitness is null)
+        {
+            return OnboardingTopic.CurrentFitness;
+        }
+
+        if (view.WeeklySchedule is null)
+        {
+            return OnboardingTopic.WeeklySchedule;
+        }
+
+        if (view.InjuryHistory is null)
+        {
+            return OnboardingTopic.InjuryHistory;
+        }
+
+        if (view.Preferences is null)
+        {
+            return OnboardingTopic.Preferences;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Counts how many of the canonical six topics have a captured answer on
+    /// the <paramref name="view"/>. <c>TargetEvent</c> only counts when the
+    /// runner's <c>PrimaryGoal</c> is race training; otherwise it is treated
+    /// as N/A and excluded from both the numerator AND the denominator —
+    /// callers receive a progress indicator that reflects the runner's actual
+    /// remaining work.
+    /// </summary>
+    /// <param name="view">The runner's in-flight onboarding projection.</param>
+    /// <returns>The (completed, total) pair the chat UI's progress indicator renders.</returns>
+    public static (int Completed, int Total) Progress(OnboardingView view)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+
+        var requiresTargetEvent = view.PrimaryGoal?.Goal == PrimaryGoal.RaceTraining;
+        var total = requiresTargetEvent ? 6 : 5;
+        var completed = 0;
+
+        if (view.PrimaryGoal is not null)
+        {
+            completed++;
+        }
+
+        if (requiresTargetEvent && view.TargetEvent is not null)
+        {
+            completed++;
+        }
+
+        if (view.CurrentFitness is not null)
+        {
+            completed++;
+        }
+
+        if (view.WeeklySchedule is not null)
+        {
+            completed++;
+        }
+
+        if (view.InjuryHistory is not null)
+        {
+            completed++;
+        }
+
+        if (view.Preferences is not null)
+        {
+            completed++;
+        }
+
+        return (completed, total);
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingController.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingController.cs
@@ -1,0 +1,209 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Marten;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.JsonWebTokens;
+using RunCoach.Api.Infrastructure;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+using Wolverine;
+
+namespace RunCoach.Api.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Slice 1 onboarding endpoints — submit a turn, read current state, revise an
+/// answer. Per Slice 1 § Unit 1 / DEC-055 every state-changing route is gated
+/// by both <see cref="AuthPolicies.CookieOrBearer"/> and
+/// <see cref="Microsoft.AspNetCore.Antiforgery.RequireAntiforgeryTokenAttribute"/>;
+/// the read endpoint requires auth but no antiforgery token (idempotent GETs
+/// are out of scope for the framework's antiforgery middleware).
+/// </summary>
+[ApiController]
+[Route("api/v1/onboarding")]
+[Authorize(Policy = AuthPolicies.CookieOrBearer)]
+public sealed partial class OnboardingController(
+    IMessageBus bus,
+    IDocumentSession session,
+    ILogger<OnboardingController> logger) : ControllerBase
+{
+    private const string AlreadyCompleteType = "https://runcoach.app/problems/onboarding-already-complete";
+    private const string MissingUserType = "https://runcoach.app/problems/missing-user-claim";
+
+    /// <summary>POST /api/v1/onboarding/turns — submit a single onboarding turn.</summary>
+    /// <remarks>
+    /// Dispatches a <see cref="SubmitUserTurn"/> command to the
+    /// <see cref="OnboardingTurnHandler"/>. The handler runs inside one Marten
+    /// transaction; on success the response carries either the next assistant
+    /// turn (kind=Ask) or the completion signal with a generated plan id
+    /// (kind=Complete). Idempotency is handled by the handler — sending the
+    /// same <see cref="OnboardingTurnRequestDto.IdempotencyKey"/> twice returns
+    /// the byte-identical prior response and appends nothing.
+    /// </remarks>
+    [HttpPost("turns")]
+    [Microsoft.AspNetCore.Antiforgery.RequireAntiforgeryToken]
+    [ProducesResponseType(typeof(OnboardingTurnResponseDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> SubmitTurn(
+        [FromBody] OnboardingTurnRequestDto request,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryGetUserId(out var userId))
+        {
+            return MissingUserClaim();
+        }
+
+        try
+        {
+            var response = await bus
+                .InvokeAsync<OnboardingTurnResponseDto>(
+                    new SubmitUserTurn(userId, request.IdempotencyKey, request.Text ?? string.Empty),
+                    ct)
+                .ConfigureAwait(false);
+            return Ok(response);
+        }
+        catch (OnboardingAlreadyCompleteException ex)
+        {
+            LogAlreadyComplete(logger, ex.UserId);
+            return Problem(
+                type: AlreadyCompleteType,
+                title: "Onboarding is already complete.",
+                detail: "Submit a regenerate request via Settings → Plan instead of a fresh turn.",
+                statusCode: StatusCodes.Status409Conflict);
+        }
+    }
+
+    /// <summary>GET /api/v1/onboarding/state — read the current onboarding view.</summary>
+    /// <remarks>
+    /// Returns 404 before the runner has submitted any turn (no stream); 200
+    /// with the projection otherwise. The completion gate's outcome is
+    /// surfaced as <c>isComplete</c> on the response so the chat UI can
+    /// distinguish "all six topics captured but a clarification is still
+    /// outstanding" from "everything captured AND no outstanding clarifications".
+    /// </remarks>
+    [HttpGet("state")]
+    [ProducesResponseType(typeof(OnboardingStateDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetState(CancellationToken ct)
+    {
+        if (!TryGetUserId(out var userId))
+        {
+            return MissingUserClaim();
+        }
+
+        var view = await session.LoadAsync<OnboardingView>(userId, ct).ConfigureAwait(false);
+        if (view is null)
+        {
+            return NotFound();
+        }
+
+        var (completed, total) = OnboardingCompletionGate.Progress(view);
+        var dto = new OnboardingStateDto(
+            UserId: view.UserId,
+            Status: view.Status,
+            CurrentTopic: view.CurrentTopic,
+            CompletedTopics: completed,
+            TotalTopics: total,
+            IsComplete: OnboardingCompletionGate.IsSatisfied(view) && view.Status == OnboardingStatus.Completed,
+            OutstandingClarifications: view.OutstandingClarifications,
+            PrimaryGoal: view.PrimaryGoal,
+            TargetEvent: view.TargetEvent,
+            CurrentFitness: view.CurrentFitness,
+            WeeklySchedule: view.WeeklySchedule,
+            InjuryHistory: view.InjuryHistory,
+            Preferences: view.Preferences,
+            CurrentPlanId: view.CurrentPlanId);
+        return Ok(dto);
+    }
+
+    /// <summary>POST /api/v1/onboarding/answers/revise — overwrite a captured answer.</summary>
+    /// <remarks>
+    /// Appends a fresh <see cref="AnswerCaptured"/> event to the runner's
+    /// onboarding stream so the audit trail is preserved (the prior captured
+    /// answer remains addressable in the event log). Returns the updated view.
+    /// </remarks>
+    [HttpPost("answers/revise")]
+    [Microsoft.AspNetCore.Antiforgery.RequireAntiforgeryToken]
+    [ProducesResponseType(typeof(OnboardingStateDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ReviseAnswer(
+        [FromBody] ReviseAnswerRequestDto request,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryGetUserId(out var userId))
+        {
+            return MissingUserClaim();
+        }
+
+        var view = await session.LoadAsync<OnboardingView>(userId, ct).ConfigureAwait(false);
+        if (view is null)
+        {
+            return NotFound();
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        session.Events.Append(
+            userId,
+            new AnswerCaptured(request.Topic, request.NormalizedValue, Confidence: 1.0, CapturedAt: now));
+        await session.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        // Re-load post-revise so the response reflects the freshly applied
+        // answer (the inline projection materializes alongside the append).
+        view = await session.LoadAsync<OnboardingView>(userId, ct).ConfigureAwait(false);
+        if (view is null)
+        {
+            return NotFound();
+        }
+
+        var (completed, total) = OnboardingCompletionGate.Progress(view);
+        var dto = new OnboardingStateDto(
+            UserId: view.UserId,
+            Status: view.Status,
+            CurrentTopic: view.CurrentTopic,
+            CompletedTopics: completed,
+            TotalTopics: total,
+            IsComplete: OnboardingCompletionGate.IsSatisfied(view) && view.Status == OnboardingStatus.Completed,
+            OutstandingClarifications: view.OutstandingClarifications,
+            PrimaryGoal: view.PrimaryGoal,
+            TargetEvent: view.TargetEvent,
+            CurrentFitness: view.CurrentFitness,
+            WeeklySchedule: view.WeeklySchedule,
+            InjuryHistory: view.InjuryHistory,
+            Preferences: view.Preferences,
+            CurrentPlanId: view.CurrentPlanId);
+        return Ok(dto);
+    }
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Information,
+        Message = "Onboarding turn rejected: stream already complete user={UserId}")]
+    private static partial void LogAlreadyComplete(ILogger logger, Guid userId);
+
+    private bool TryGetUserId(out Guid userId)
+    {
+        // Cookie auth writes ClaimTypes.NameIdentifier; raw JWTs carry the
+        // subject as `sub`. Program.cs disables inbound claim mapping, so the
+        // bearer-authenticated branch lands on `sub` only. See AuthController
+        // for the full rationale.
+        var raw = User.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? User.FindFirstValue(JwtRegisteredClaimNames.Sub);
+        if (string.IsNullOrEmpty(raw) || !Guid.TryParse(raw, out userId))
+        {
+            userId = Guid.Empty;
+            return false;
+        }
+
+        return true;
+    }
+
+    private ObjectResult MissingUserClaim() =>
+        Problem(
+            type: MissingUserType,
+            title: "Authenticated user id was missing or malformed.",
+            statusCode: StatusCodes.Status401Unauthorized);
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingController.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingController.cs
@@ -28,6 +28,7 @@ public sealed partial class OnboardingController(
 {
     private const string AlreadyCompleteType = "https://runcoach.app/problems/onboarding-already-complete";
     private const string MissingUserType = "https://runcoach.app/problems/missing-user-claim";
+    private const string InvalidTopicType = "https://runcoach.app/problems/invalid-onboarding-topic";
 
     /// <summary>POST /api/v1/onboarding/turns — submit a single onboarding turn.</summary>
     /// <remarks>
@@ -111,23 +112,7 @@ public sealed partial class OnboardingController(
             return NotFound();
         }
 
-        var (completed, total) = OnboardingCompletionGate.Progress(view);
-        var dto = new OnboardingStateDto(
-            UserId: view.UserId,
-            Status: view.Status,
-            CurrentTopic: view.CurrentTopic,
-            CompletedTopics: completed,
-            TotalTopics: total,
-            IsComplete: OnboardingCompletionGate.IsSatisfied(view) && view.Status == OnboardingStatus.Completed,
-            OutstandingClarifications: view.OutstandingClarifications,
-            PrimaryGoal: view.PrimaryGoal,
-            TargetEvent: view.TargetEvent,
-            CurrentFitness: view.CurrentFitness,
-            WeeklySchedule: view.WeeklySchedule,
-            InjuryHistory: view.InjuryHistory,
-            Preferences: view.Preferences,
-            CurrentPlanId: view.CurrentPlanId);
-        return Ok(dto);
+        return Ok(BuildStateDto(view));
     }
 
     /// <summary>POST /api/v1/onboarding/answers/revise — overwrite a captured answer.</summary>
@@ -151,6 +136,21 @@ public sealed partial class OnboardingController(
             return MissingUserClaim();
         }
 
+        // System.Text.Json deserializes int-backed enums without range checks,
+        // so a payload with `topic: 99` lands here as an OnboardingTopic with
+        // value 99. Reject explicitly with a 400 ProblemDetails before any
+        // event is appended — otherwise the inline projection's switch falls
+        // through to InvalidOperationException at apply time, surfacing as a
+        // 500 with no actionable error code for the client.
+        if (!Enum.IsDefined(request.Topic))
+        {
+            return Problem(
+                type: InvalidTopicType,
+                title: "The supplied onboarding topic is not a recognized value.",
+                detail: $"Topic value '{(int)request.Topic}' is outside the OnboardingTopic enum range.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
         // Per-request tenanted session — same rationale as GetState. The
         // append + SaveChanges + reload must all run on the same session so
         // the inline projection re-materializes before the read.
@@ -162,7 +162,14 @@ public sealed partial class OnboardingController(
         }
 
         var now = DateTimeOffset.UtcNow;
-        var normalizedPayload = JsonSerializer.SerializeToDocument(request.NormalizedValue);
+
+        // AnswerCaptured carries the normalized payload as a JsonDocument so
+        // both projections can call JsonDocument.Deserialize<T>(). Wrap the
+        // serialize in a `using` so the rented ArrayPool buffers are returned
+        // after SaveChangesAsync writes the event bytes — the prior code
+        // rented and leaked. The await/save happens inside the using block
+        // so the document is still live during Marten's serialization.
+        using var normalizedPayload = JsonSerializer.SerializeToDocument(request.NormalizedValue);
         session.Events.Append(
             userId,
             new AnswerCaptured(request.Topic, normalizedPayload, Confidence: 1.0, CapturedAt: now));
@@ -176,8 +183,13 @@ public sealed partial class OnboardingController(
             return NotFound();
         }
 
+        return Ok(BuildStateDto(view));
+    }
+
+    private static OnboardingStateDto BuildStateDto(OnboardingView view)
+    {
         var (completed, total) = OnboardingCompletionGate.Progress(view);
-        var dto = new OnboardingStateDto(
+        return new OnboardingStateDto(
             UserId: view.UserId,
             Status: view.Status,
             CurrentTopic: view.CurrentTopic,
@@ -192,7 +204,6 @@ public sealed partial class OnboardingController(
             InjuryHistory: view.InjuryHistory,
             Preferences: view.Preferences,
             CurrentPlanId: view.CurrentPlanId);
-        return Ok(dto);
     }
 
     [LoggerMessage(

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingController.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingController.cs
@@ -23,7 +23,7 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding;
 [Authorize(Policy = AuthPolicies.CookieOrBearer)]
 public sealed partial class OnboardingController(
     IMessageBus bus,
-    IDocumentSession session,
+    IDocumentStore store,
     ILogger<OnboardingController> logger) : ControllerBase
 {
     private const string AlreadyCompleteType = "https://runcoach.app/problems/onboarding-already-complete";
@@ -57,8 +57,14 @@ public sealed partial class OnboardingController(
 
         try
         {
+            // InvokeForTenantAsync sets the user id as Marten's conjoined
+            // tenant on the handler's auto-applied IDocumentSession. Without
+            // it, the handler's session has no TenantId and every Marten
+            // operation against an OnboardingView / IdempotencyMarker (both
+            // multi-tenant under TenancyStyle.Conjoined) fails to resolve.
             var response = await bus
-                .InvokeAsync<OnboardingTurnResponseDto>(
+                .InvokeForTenantAsync<OnboardingTurnResponseDto>(
+                    userId.ToString(),
                     new SubmitUserTurn(userId, request.IdempotencyKey, request.Text ?? string.Empty),
                     ct)
                 .ConfigureAwait(false);
@@ -93,6 +99,12 @@ public sealed partial class OnboardingController(
             return MissingUserClaim();
         }
 
+        // Marten is configured with TenancyStyle.Conjoined; the OnboardingView
+        // and the EF projection are both tenant-scoped to the runner's user id.
+        // Open a per-request tenanted session — Wolverine middleware does the
+        // same thing in the SubmitTurn dispatch path, but GetState reads
+        // directly off Marten and has to set the tenant explicitly.
+        await using var session = store.LightweightSession(userId.ToString());
         var view = await session.LoadAsync<OnboardingView>(userId, ct).ConfigureAwait(false);
         if (view is null)
         {
@@ -139,6 +151,10 @@ public sealed partial class OnboardingController(
             return MissingUserClaim();
         }
 
+        // Per-request tenanted session — same rationale as GetState. The
+        // append + SaveChanges + reload must all run on the same session so
+        // the inline projection re-materializes before the read.
+        await using var session = store.LightweightSession(userId.ToString());
         var view = await session.LoadAsync<OnboardingView>(userId, ct).ConfigureAwait(false);
         if (view is null)
         {

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingController.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingController.cs
@@ -146,9 +146,10 @@ public sealed partial class OnboardingController(
         }
 
         var now = DateTimeOffset.UtcNow;
+        var normalizedPayload = JsonSerializer.SerializeToDocument(request.NormalizedValue);
         session.Events.Append(
             userId,
-            new AnswerCaptured(request.Topic, request.NormalizedValue, Confidence: 1.0, CapturedAt: now));
+            new AnswerCaptured(request.Topic, normalizedPayload, Confidence: 1.0, CapturedAt: now));
         await session.SaveChangesAsync(ct).ConfigureAwait(false);
 
         // Re-load post-revise so the response reflects the freshly applied

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnHandler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnHandler.cs
@@ -61,6 +61,15 @@ public sealed partial class OnboardingTurnHandler
     private const string PromptPrefix = "[Pattern-B-Invariant]";
     private const double ExtractionConfidenceFloor = 0.6;
 
+    // Wire-format JsonDocuments embedded inside the response DTO + Marten
+    // event payloads must be camelCase so they round-trip cleanly to the
+    // frontend Zod schemas (the controller's default formatter handles the
+    // outer DTO via camelCase, but JsonDocument payloads are opaque to it).
+    private static readonly JsonSerializerOptions WireSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
     // The type is a stateless logical handler container: Wolverine codegen
     // emits a non-static handler stub that calls the static `Handle` method,
     // and `ILogger<OnboardingTurnHandler>` needs a non-static type argument.
@@ -216,8 +225,8 @@ public sealed partial class OnboardingTurnHandler
         }
 
         // (7) stage the per-turn events on the onboarding stream.
-        var assistantBlocks = JsonSerializer.SerializeToDocument(output.Reply);
-        var userBlocks = JsonSerializer.SerializeToDocument(BuildUserTextBlocks(cmd.Text));
+        var assistantBlocks = JsonSerializer.SerializeToDocument(output.Reply, WireSerializerOptions);
+        var userBlocks = JsonSerializer.SerializeToDocument(BuildUserTextBlocks(cmd.Text), WireSerializerOptions);
 
         session.Events.Append(streamId, new TopicAsked(currentTopic, now));
         session.Events.Append(streamId, new UserTurnRecorded(userBlocks, now));
@@ -279,11 +288,23 @@ public sealed partial class OnboardingTurnHandler
         {
             var nextTopic = OnboardingCompletionGate.NextTopic(working) ?? currentTopic;
             var (completed, total) = OnboardingCompletionGate.Progress(working);
+
+            // When the LLM still needs clarification on the next topic, the
+            // canned single/multi/numeric/date control can't carry the
+            // free-form follow-up the runner needs to provide (e.g. session
+            // minutes for WeeklySchedule, time goal for TargetEvent). Fall
+            // back to Text so the runner can answer the assistant's
+            // clarifying question; once captured, the gate clears the topic
+            // and the next turn re-issues the canonical control.
+            var hasOutstandingClarification = working.OutstandingClarifications.Contains(nextTopic);
+            var nextInputType = hasOutstandingClarification
+                ? SuggestedInputType.Text
+                : SuggestInputType(nextTopic);
             response = new OnboardingTurnResponseDto(
                 Kind: OnboardingTurnKind.Ask,
                 AssistantBlocks: assistantBlocks,
                 Topic: nextTopic,
-                SuggestedInputType: SuggestInputType(nextTopic),
+                SuggestedInputType: nextInputType,
                 Progress: new OnboardingProgressDto(completed, total),
                 PlanId: null);
         }
@@ -320,6 +341,10 @@ public sealed partial class OnboardingTurnHandler
     {
         return extracted.Topic switch
         {
+            // Captured-answer payloads stay PascalCase (default STJ) because they
+            // are read back inside the inline OnboardingProjection via
+            // `JsonDocument.Deserialize<T>()` whose property matching is the
+            // server-default casing. These payloads never reach the wire.
             OnboardingTopic.PrimaryGoal when extracted.NormalizedPrimaryGoal is not null
                 => (OnboardingTopic.PrimaryGoal, JsonSerializer.SerializeToDocument(extracted.NormalizedPrimaryGoal)),
             OnboardingTopic.TargetEvent when extracted.NormalizedTargetEvent is not null

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnHandler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnHandler.cs
@@ -1,0 +1,448 @@
+using System.Text.Json;
+using Marten;
+using Marten.Events;
+using Microsoft.Extensions.Logging;
+using RunCoach.Api.Modules.Coaching.Idempotency;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+using RunCoach.Api.Modules.Coaching.Sanitization;
+using RunCoach.Api.Modules.Training.Plan;
+
+namespace RunCoach.Api.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Wolverine <c>[AggregateHandler]</c> for <see cref="SubmitUserTurn"/> per
+/// Slice 1 § Unit 1 R01.6 / DEC-057 / DEC-060. The handler performs every
+/// per-turn side-effect atomically through the single Marten
+/// <see cref="IDocumentSession"/> Wolverine's transactional middleware brackets
+/// around the handler body — there is no <c>RunCoachDbContext</c> injection,
+/// no <c>IMessageBus.InvokeAsync</c> call, no second Postgres transaction.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per-turn flow:
+/// <list type="number">
+/// <item>Idempotency check via <see cref="IIdempotencyStore.SeenAsync"/>; on hit
+///   return the byte-identical prior response, append nothing.</item>
+/// <item>Resolve the next topic via the deterministic
+///   <see cref="OnboardingCompletionGate.NextTopic"/> selector.</item>
+/// <item>Compose the Pattern-B prompt via
+///   <see cref="IContextAssembler.ComposeForOnboardingAsync"/> (sanitizer-applied).</item>
+/// <item>Call <see cref="ICoachingLlm.GenerateStructuredAsync{T}(string, string,
+///   System.Collections.Generic.IReadOnlyDictionary{string, JsonElement}?,
+///   Models.CacheControl?, CancellationToken)"/> with the byte-stable schema +
+///   1h ephemeral cache marker.</item>
+/// <item>Validate the Pattern-B-Invariant via
+///   <see cref="OnboardingTurnOutputValidator.Validate"/> with one-retry on
+///   first failure (stronger discriminator instruction); on second failure,
+///   emit <see cref="ClarificationRequested"/> and short-circuit to "ask".</item>
+/// <item>Stage <see cref="UserTurnRecorded"/>, <see cref="TopicAsked"/>,
+///   <see cref="AssistantTurnRecorded"/>, plus any
+///   <see cref="AnswerCaptured"/> / <see cref="ClarificationRequested"/> the
+///   LLM produced.</item>
+/// <item>If the deterministic completion gate is now satisfied (and the LLM
+///   agreed via <c>ReadyForPlan</c>) — invoke
+///   <see cref="IPlanGenerationService.GeneratePlanAsync"/>, stage the returned
+///   plan events on a new <c>StartStream&lt;Plan&gt;(planId, ...)</c>, append
+///   <see cref="PlanLinkedToUser"/> + <see cref="OnboardingCompleted"/> to the
+///   onboarding stream — all on the same session.</item>
+/// <item>Record the response on <see cref="IIdempotencyStore.Record{T}"/>.</item>
+/// </list>
+/// </para>
+/// <para>
+/// Failure semantics: any uncaught exception (LLM rejection, Pattern-B
+/// validation failure, plan-generation failure) propagates out of the handler.
+/// Wolverine's transactional middleware aborts the Marten transaction —
+/// nothing committed. Empirically guarded by
+/// <c>InvokeAsyncTransactionScopeTests</c>.
+/// </para>
+/// </remarks>
+public sealed partial class OnboardingTurnHandler
+{
+    private const string PromptPrefix = "[Pattern-B-Invariant]";
+    private const double ExtractionConfidenceFloor = 0.6;
+
+    // The type is a stateless logical handler container: Wolverine codegen
+    // emits a non-static handler stub that calls the static `Handle` method,
+    // and `ILogger<OnboardingTurnHandler>` needs a non-static type argument.
+    // The private constructor prevents instantiation in test code.
+    private OnboardingTurnHandler()
+    {
+    }
+
+    /// <summary>
+    /// Wolverine command handler. Wolverine's <c>AutoApplyTransactions</c> policy
+    /// brackets every Marten <c>IDocumentSession</c> resolution with a single
+    /// transaction-scoped <c>SaveChangesAsync</c> call after the handler returns
+    /// (DEC-048 / batch 22a research). The handler stages every event +
+    /// idempotency marker on this session; the framework commits them
+    /// atomically. The handler itself never calls <c>SaveChangesAsync</c>.
+    /// </summary>
+    /// <param name="cmd">The submit-user-turn command.</param>
+    /// <param name="session">Marten session bracketed by Wolverine's transactional middleware.</param>
+    /// <param name="llm">Coaching LLM adapter.</param>
+    /// <param name="assembler">Context assembler.</param>
+    /// <param name="sanitizer">Prompt-injection sanitizer (used by the assembler — passed via DI here for tests that swap layers).</param>
+    /// <param name="idempotency">Idempotency store backed by the same <paramref name="session"/>.</param>
+    /// <param name="planGen">Plan generation orchestrator (six-call macro/meso/micro chain).</param>
+    /// <param name="time">Time provider for event timestamps.</param>
+    /// <param name="logger">Logger.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The response DTO surfaced by the controller.</returns>
+    public static async Task<OnboardingTurnResponseDto> Handle(
+        SubmitUserTurn cmd,
+        IDocumentSession session,
+        ICoachingLlm llm,
+        IContextAssembler assembler,
+        IPromptSanitizer sanitizer,
+        IIdempotencyStore idempotency,
+        IPlanGenerationService planGen,
+        TimeProvider time,
+        ILogger<OnboardingTurnHandler> logger,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(cmd);
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(llm);
+        ArgumentNullException.ThrowIfNull(assembler);
+        ArgumentNullException.ThrowIfNull(sanitizer);
+        ArgumentNullException.ThrowIfNull(idempotency);
+        ArgumentNullException.ThrowIfNull(planGen);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        // Sanitizer parameter is intentional — IContextAssembler already holds
+        // its own reference but injecting it here keeps the handler's
+        // dependency surface explicit per spec § Unit 1 R01.6.
+        _ = sanitizer;
+
+        // (1) idempotency short-circuit: on hit return the byte-identical prior
+        //     response, append nothing, write nothing.
+        var prior = await idempotency
+            .SeenAsync<OnboardingTurnResponseDto>(cmd.IdempotencyKey, ct)
+            .ConfigureAwait(false);
+        if (prior is not null)
+        {
+            LogIdempotentReplay(logger, cmd.IdempotencyKey, cmd.UserId);
+            return prior;
+        }
+
+        var streamId = cmd.UserId;
+        var now = time.GetUtcNow();
+
+        // Load the inline-projected onboarding view directly off the document
+        // session — `OnboardingProjection` is registered with
+        // `ProjectionLifecycle.Inline` so the document is materialized on the
+        // same NpgsqlConnection the handler is about to write through. Returns
+        // null for the very first turn (before any events exist on the stream).
+        var view = await session
+            .LoadAsync<OnboardingView>(streamId, ct)
+            .ConfigureAwait(false);
+
+        // (2) bootstrap the stream on the very first turn — `OnboardingStarted`
+        //     is the create event the Marten projection's `Create` overload
+        //     keys off. The session call stages the stream creation; commit
+        //     happens after the handler returns under Wolverine's transaction.
+        var isFirstTurn = view is null;
+        if (isFirstTurn)
+        {
+            session.Events.StartStream<OnboardingView>(streamId, new OnboardingStarted(streamId, now));
+        }
+        else if (view!.Status == OnboardingStatus.Completed)
+        {
+            // Submitting a new turn after onboarding is complete is a 409 per
+            // the feature spec. Surface the protocol violation as an
+            // exception the controller maps to ProblemDetails.
+            throw new OnboardingAlreadyCompleteException(cmd.UserId);
+        }
+
+        // The handler maintains a working copy of the view so the deterministic
+        // selector + completion gate see the in-flight state without waiting
+        // for Marten to materialize the projection mid-handler.
+        var working = view ?? CreateBootstrapView(streamId, now);
+
+        // (3) deterministic next-topic selection.
+        var currentTopic = OnboardingCompletionGate.NextTopic(working) ?? OnboardingTopic.Preferences;
+
+        // (4) compose the Pattern-B prompt.
+        var composition = await assembler
+            .ComposeForOnboardingAsync(working, currentTopic, cmd.Text, ct)
+            .ConfigureAwait(false);
+
+        // (5) call the LLM with the byte-stable schema + 1h ephemeral cache marker.
+        OnboardingTurnOutput output;
+        try
+        {
+            output = await llm
+                .GenerateStructuredAsync<OnboardingTurnOutput>(
+                    composition.SystemPrompt,
+                    composition.UserMessage,
+                    OnboardingSchema.Frozen,
+                    Coaching.Models.CacheControl.Ephemeral1h,
+                    ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LogLlmCallFailed(logger, cmd.UserId, currentTopic, ex);
+            throw;
+        }
+
+        // (6) validate Pattern-B-Invariant with one-retry on first failure.
+        var validation = OnboardingTurnOutputValidator.Validate(output, currentTopic);
+        if (!validation.IsValid)
+        {
+            LogValidationFailedFirstAttempt(logger, cmd.UserId, currentTopic, validation.Violation);
+            var retried = await llm
+                .GenerateStructuredAsync<OnboardingTurnOutput>(
+                    composition.SystemPrompt,
+                    AppendDiscriminatorReinforcement(composition.UserMessage, currentTopic),
+                    OnboardingSchema.Frozen,
+                    Coaching.Models.CacheControl.Ephemeral1h,
+                    ct)
+                .ConfigureAwait(false);
+
+            var retryValidation = OnboardingTurnOutputValidator.Validate(retried, currentTopic);
+            if (retryValidation.IsValid)
+            {
+                output = retried;
+            }
+            else
+            {
+                // Second failure — emit ClarificationRequested for the
+                // current topic and short-circuit the rest of the flow.
+                LogValidationFailedSecondAttempt(logger, cmd.UserId, currentTopic, retryValidation.Violation);
+                output = BuildDiscriminatorMismatchClarification(currentTopic);
+            }
+        }
+
+        // (7) stage the per-turn events on the onboarding stream.
+        var assistantBlocks = JsonSerializer.SerializeToDocument(output.Reply);
+        var userBlocks = JsonSerializer.SerializeToDocument(BuildUserTextBlocks(cmd.Text));
+
+        session.Events.Append(streamId, new TopicAsked(currentTopic, now));
+        session.Events.Append(streamId, new UserTurnRecorded(userBlocks, now));
+        session.Events.Append(streamId, new AssistantTurnRecorded(assistantBlocks, now));
+
+        // (7a) capture the answer when the LLM produced one with sufficient
+        //      confidence AND the topic discriminator matches.
+        if (output.Extracted is not null
+            && output.Extracted.Confidence >= ExtractionConfidenceFloor
+            && !output.NeedsClarification)
+        {
+            var (capturedTopic, payload) = ExtractAnswer(output.Extracted);
+            if (payload is not null)
+            {
+                session.Events.Append(streamId, new AnswerCaptured(capturedTopic, payload, output.Extracted.Confidence, now));
+                ApplyAnswerToWorking(working, capturedTopic, output.Extracted);
+            }
+        }
+
+        if (output.NeedsClarification)
+        {
+            var reason = string.IsNullOrWhiteSpace(output.ClarificationReason)
+                ? "Clarification required"
+                : output.ClarificationReason!;
+            session.Events.Append(streamId, new ClarificationRequested(currentTopic, reason, now));
+            working.OutstandingClarifications = working.OutstandingClarifications
+                .Append(currentTopic)
+                .Distinct()
+                .ToArray();
+        }
+
+        // (8) terminal-branch — when the deterministic gate is satisfied AND
+        //     the LLM agreed, run plan generation INLINE on this same session.
+        var gateSatisfied = OnboardingCompletionGate.IsSatisfied(working);
+        OnboardingTurnResponseDto response;
+        if (gateSatisfied && output.ReadyForPlan)
+        {
+            var planId = Guid.NewGuid();
+            LogTerminalBranch(logger, cmd.UserId, planId);
+
+            var planEvents = await planGen
+                .GeneratePlanAsync(working, cmd.UserId, planId, intent: null, previousPlanId: null, ct)
+                .ConfigureAwait(false);
+
+            session.Events.StartStream<RunCoach.Api.Modules.Training.Plan.Models.PlanProjectionDto>(planId, planEvents.ToArray());
+            session.Events.Append(streamId, new PlanLinkedToUser(cmd.UserId, planId));
+            session.Events.Append(streamId, new OnboardingCompleted(planId, now));
+
+            var (completed, total) = OnboardingCompletionGate.Progress(working);
+            response = new OnboardingTurnResponseDto(
+                Kind: OnboardingTurnKind.Complete,
+                AssistantBlocks: assistantBlocks,
+                Topic: null,
+                SuggestedInputType: null,
+                Progress: new OnboardingProgressDto(completed, total),
+                PlanId: planId);
+        }
+        else
+        {
+            var nextTopic = OnboardingCompletionGate.NextTopic(working) ?? currentTopic;
+            var (completed, total) = OnboardingCompletionGate.Progress(working);
+            response = new OnboardingTurnResponseDto(
+                Kind: OnboardingTurnKind.Ask,
+                AssistantBlocks: assistantBlocks,
+                Topic: nextTopic,
+                SuggestedInputType: SuggestInputType(nextTopic),
+                Progress: new OnboardingProgressDto(completed, total),
+                PlanId: null);
+        }
+
+        // (9) record the idempotency marker LAST so the response we recorded
+        //     matches what the caller is about to receive.
+        idempotency.Record(cmd.IdempotencyKey, cmd.UserId, response);
+
+        return response;
+    }
+
+    private static OnboardingView CreateBootstrapView(Guid streamId, DateTimeOffset now) => new()
+    {
+        Id = streamId,
+        UserId = streamId,
+        Status = OnboardingStatus.InProgress,
+        OnboardingStartedAt = now,
+        OutstandingClarifications = Array.Empty<OnboardingTopic>(),
+        Version = 1,
+    };
+
+    private static SuggestedInputType SuggestInputType(OnboardingTopic topic) => topic switch
+    {
+        OnboardingTopic.PrimaryGoal => SuggestedInputType.SingleSelect,
+        OnboardingTopic.TargetEvent => SuggestedInputType.Text,
+        OnboardingTopic.CurrentFitness => SuggestedInputType.Text,
+        OnboardingTopic.WeeklySchedule => SuggestedInputType.MultiSelect,
+        OnboardingTopic.InjuryHistory => SuggestedInputType.Text,
+        OnboardingTopic.Preferences => SuggestedInputType.Text,
+        _ => SuggestedInputType.Text,
+    };
+
+    private static (OnboardingTopic Topic, JsonDocument? Payload) ExtractAnswer(ExtractedAnswer extracted)
+    {
+        return extracted.Topic switch
+        {
+            OnboardingTopic.PrimaryGoal when extracted.NormalizedPrimaryGoal is not null
+                => (OnboardingTopic.PrimaryGoal, JsonSerializer.SerializeToDocument(extracted.NormalizedPrimaryGoal)),
+            OnboardingTopic.TargetEvent when extracted.NormalizedTargetEvent is not null
+                => (OnboardingTopic.TargetEvent, JsonSerializer.SerializeToDocument(extracted.NormalizedTargetEvent)),
+            OnboardingTopic.CurrentFitness when extracted.NormalizedCurrentFitness is not null
+                => (OnboardingTopic.CurrentFitness, JsonSerializer.SerializeToDocument(extracted.NormalizedCurrentFitness)),
+            OnboardingTopic.WeeklySchedule when extracted.NormalizedWeeklySchedule is not null
+                => (OnboardingTopic.WeeklySchedule, JsonSerializer.SerializeToDocument(extracted.NormalizedWeeklySchedule)),
+            OnboardingTopic.InjuryHistory when extracted.NormalizedInjuryHistory is not null
+                => (OnboardingTopic.InjuryHistory, JsonSerializer.SerializeToDocument(extracted.NormalizedInjuryHistory)),
+            OnboardingTopic.Preferences when extracted.NormalizedPreferences is not null
+                => (OnboardingTopic.Preferences, JsonSerializer.SerializeToDocument(extracted.NormalizedPreferences)),
+            _ => (extracted.Topic, null),
+        };
+    }
+
+    private static void ApplyAnswerToWorking(OnboardingView working, OnboardingTopic topic, ExtractedAnswer extracted)
+    {
+        switch (topic)
+        {
+            case OnboardingTopic.PrimaryGoal:
+                working.PrimaryGoal = extracted.NormalizedPrimaryGoal;
+                break;
+            case OnboardingTopic.TargetEvent:
+                working.TargetEvent = extracted.NormalizedTargetEvent;
+                break;
+            case OnboardingTopic.CurrentFitness:
+                working.CurrentFitness = extracted.NormalizedCurrentFitness;
+                break;
+            case OnboardingTopic.WeeklySchedule:
+                working.WeeklySchedule = extracted.NormalizedWeeklySchedule;
+                break;
+            case OnboardingTopic.InjuryHistory:
+                working.InjuryHistory = extracted.NormalizedInjuryHistory;
+                break;
+            case OnboardingTopic.Preferences:
+                working.Preferences = extracted.NormalizedPreferences;
+                break;
+        }
+
+        // Capturing an answer clears any outstanding clarification on that topic.
+        if (working.OutstandingClarifications.Contains(topic))
+        {
+            working.OutstandingClarifications = working.OutstandingClarifications
+                .Where(t => t != topic)
+                .ToArray();
+        }
+    }
+
+    private static AnthropicContentBlock[] BuildUserTextBlocks(string text) =>
+    [
+        new AnthropicContentBlock { Type = AnthropicContentBlockType.Text, Text = text ?? string.Empty },
+    ];
+
+    private static string AppendDiscriminatorReinforcement(string baseUserMessage, OnboardingTopic topic)
+    {
+        // Stronger discriminator instruction appended on the second attempt so
+        // the prompt-prefix cache prefix above stays byte-stable. Anthropic's
+        // cache hashes everything BEFORE the breakpoint; this tail variation
+        // is irrelevant to cache-hit rate.
+        return baseUserMessage + System.Environment.NewLine + System.Environment.NewLine
+            + PromptPrefix + " RETRY: ensure exactly one Normalized* slot is non-null AND it matches the discriminator. "
+            + $"Current topic is {topic}. Set Normalized{topic} (and only Normalized{topic}); leave every other Normalized* slot null. "
+            + "Set Extracted.Topic to the same value.";
+    }
+
+    private static OnboardingTurnOutput BuildDiscriminatorMismatchClarification(OnboardingTopic topic)
+    {
+        var reply = new[]
+        {
+            new AnthropicContentBlock
+            {
+                Type = AnthropicContentBlockType.Text,
+                Text = "I'm having trouble understanding your last reply. Could you rephrase it?",
+            },
+        };
+
+        _ = topic;
+        return new OnboardingTurnOutput
+        {
+            Reply = reply,
+            Extracted = null,
+            NeedsClarification = true,
+            ClarificationReason = "Discriminator mismatch",
+            ReadyForPlan = false,
+        };
+    }
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Information,
+        Message = "Onboarding turn idempotent replay key={IdempotencyKey} user={UserId}")]
+    private static partial void LogIdempotentReplay(ILogger logger, Guid idempotencyKey, Guid userId);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Information,
+        Message = "Onboarding turn terminal branch user={UserId} planId={PlanId}")]
+    private static partial void LogTerminalBranch(ILogger logger, Guid userId, Guid planId);
+
+    [LoggerMessage(
+        EventId = 3,
+        Level = LogLevel.Warning,
+        Message = "Onboarding LLM call failed user={UserId} topic={Topic}")]
+    private static partial void LogLlmCallFailed(ILogger logger, Guid userId, OnboardingTopic topic, Exception ex);
+
+    [LoggerMessage(
+        EventId = 4,
+        Level = LogLevel.Warning,
+        Message = "Onboarding turn validation failed first attempt user={UserId} topic={Topic} violation={Violation}")]
+    private static partial void LogValidationFailedFirstAttempt(
+        ILogger logger,
+        Guid userId,
+        OnboardingTopic topic,
+        OnboardingTurnOutputValidationViolation violation);
+
+    [LoggerMessage(
+        EventId = 5,
+        Level = LogLevel.Warning,
+        Message = "Onboarding turn validation failed second attempt user={UserId} topic={Topic} violation={Violation}")]
+    private static partial void LogValidationFailedSecondAttempt(
+        ILogger logger,
+        Guid userId,
+        OnboardingTopic topic,
+        OnboardingTurnOutputValidationViolation violation);
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnHandler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnHandler.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 using Marten;
 using Marten.Events;
 using Microsoft.Extensions.Logging;
-using RunCoach.Api.Modules.Coaching.Idempotency;
+using RunCoach.Api.Infrastructure.Idempotency;
 using RunCoach.Api.Modules.Coaching.Onboarding.Models;
 using RunCoach.Api.Modules.Coaching.Sanitization;
 using RunCoach.Api.Modules.Training.Plan;
@@ -278,7 +278,7 @@ public sealed partial class OnboardingTurnHandler
             var (completed, total) = OnboardingCompletionGate.Progress(working);
             response = new OnboardingTurnResponseDto(
                 Kind: OnboardingTurnKind.Complete,
-                AssistantBlocks: assistantBlocks,
+                AssistantBlocks: assistantBlocks.RootElement,
                 Topic: null,
                 SuggestedInputType: null,
                 Progress: new OnboardingProgressDto(completed, total),
@@ -302,7 +302,7 @@ public sealed partial class OnboardingTurnHandler
                 : SuggestInputType(nextTopic);
             response = new OnboardingTurnResponseDto(
                 Kind: OnboardingTurnKind.Ask,
-                AssistantBlocks: assistantBlocks,
+                AssistantBlocks: assistantBlocks.RootElement,
                 Topic: nextTopic,
                 SuggestedInputType: nextInputType,
                 Progress: new OnboardingProgressDto(completed, total),
@@ -311,7 +311,7 @@ public sealed partial class OnboardingTurnHandler
 
         // (9) record the idempotency marker LAST so the response we recorded
         //     matches what the caller is about to receive.
-        idempotency.Record(cmd.IdempotencyKey, cmd.UserId, response);
+        idempotency.Record(cmd.IdempotencyKey, response);
 
         return response;
     }

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnHandler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnHandler.cs
@@ -1,7 +1,5 @@
 using System.Text.Json;
 using Marten;
-using Marten.Events;
-using Microsoft.Extensions.Logging;
 using RunCoach.Api.Infrastructure.Idempotency;
 using RunCoach.Api.Modules.Coaching.Onboarding.Models;
 using RunCoach.Api.Modules.Coaching.Sanitization;
@@ -10,9 +8,12 @@ using RunCoach.Api.Modules.Training.Plan;
 namespace RunCoach.Api.Modules.Coaching.Onboarding;
 
 /// <summary>
-/// Wolverine <c>[AggregateHandler]</c> for <see cref="SubmitUserTurn"/> per
-/// Slice 1 § Unit 1 R01.6 / DEC-057 / DEC-060. The handler performs every
-/// per-turn side-effect atomically through the single Marten
+/// Wolverine static command handler for <see cref="SubmitUserTurn"/> per
+/// Slice 1 § Unit 1 R01.6 / DEC-057 / DEC-060. The handler is dispatched via
+/// Wolverine's plain static-handler convention (no <c>[AggregateHandler]</c>
+/// attribute — the handler injects <see cref="IDocumentSession"/> directly and
+/// loads <see cref="OnboardingView"/> via <c>session.LoadAsync</c>). Every
+/// per-turn side-effect commits atomically through the single Marten
 /// <see cref="IDocumentSession"/> Wolverine's transactional middleware brackets
 /// around the handler body — there is no <c>RunCoachDbContext</c> injection,
 /// no <c>IMessageBus.InvokeAsync</c> call, no second Postgres transaction.
@@ -271,18 +272,17 @@ public sealed partial class OnboardingTurnHandler
                 .GeneratePlanAsync(working, cmd.UserId, planId, intent: null, previousPlanId: null, ct)
                 .ConfigureAwait(false);
 
-            session.Events.StartStream<RunCoach.Api.Modules.Training.Plan.Models.PlanProjectionDto>(planId, planEvents.ToArray());
+            session.Events.StartStream<RunCoach.Api.Modules.Training.Plan.Models.PlanProjectionDto>(
+                planId,
+                planEvents.ToEvents().ToArray());
             session.Events.Append(streamId, new PlanLinkedToUser(cmd.UserId, planId));
             session.Events.Append(streamId, new OnboardingCompleted(planId, now));
 
             var (completed, total) = OnboardingCompletionGate.Progress(working);
-            response = new OnboardingTurnResponseDto(
-                Kind: OnboardingTurnKind.Complete,
-                AssistantBlocks: assistantBlocks.RootElement,
-                Topic: null,
-                SuggestedInputType: null,
-                Progress: new OnboardingProgressDto(completed, total),
-                PlanId: planId);
+            response = OnboardingTurnResponseDto.Complete(
+                assistantBlocks: assistantBlocks.RootElement,
+                progress: new OnboardingProgressDto(completed, total),
+                planId: planId);
         }
         else
         {
@@ -300,13 +300,11 @@ public sealed partial class OnboardingTurnHandler
             var nextInputType = hasOutstandingClarification
                 ? SuggestedInputType.Text
                 : SuggestInputType(nextTopic);
-            response = new OnboardingTurnResponseDto(
-                Kind: OnboardingTurnKind.Ask,
-                AssistantBlocks: assistantBlocks.RootElement,
-                Topic: nextTopic,
-                SuggestedInputType: nextInputType,
-                Progress: new OnboardingProgressDto(completed, total),
-                PlanId: null);
+            response = OnboardingTurnResponseDto.Ask(
+                assistantBlocks: assistantBlocks.RootElement,
+                topic: nextTopic,
+                suggestedInputType: nextInputType,
+                progress: new OnboardingProgressDto(completed, total));
         }
 
         // (9) record the idempotency marker LAST so the response we recorded
@@ -422,13 +420,12 @@ public sealed partial class OnboardingTurnHandler
             },
         };
 
-        _ = topic;
         return new OnboardingTurnOutput
         {
             Reply = reply,
             Extracted = null,
             NeedsClarification = true,
-            ClarificationReason = "Discriminator mismatch",
+            ClarificationReason = $"Discriminator mismatch on {topic}",
             ReadyForPlan = false,
         };
     }

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnOutputValidationViolation.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnOutputValidationViolation.cs
@@ -22,4 +22,12 @@ public enum OnboardingTurnOutputValidationViolation
     /// <see cref="OnboardingTurnOutput.ClarificationReason"/> is null/empty.
     /// </summary>
     ClarificationWithoutReason = 4,
+
+    /// <summary>
+    /// One or more <see cref="AnthropicContentBlock"/> entries in
+    /// <see cref="OnboardingTurnOutput.Reply"/> violate the
+    /// Type-vs-Text contract (e.g. Type=Text with empty Text, or
+    /// Type=Thinking with non-empty Text).
+    /// </summary>
+    ContentBlockShape = 5,
 }

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnOutputValidator.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnOutputValidator.cs
@@ -43,6 +43,36 @@ public static class OnboardingTurnOutputValidator
     {
         ArgumentNullException.ThrowIfNull(output);
 
+        // Per-block content invariant: Type=Text needs non-empty payload,
+        // Type=Thinking needs empty payload. The closed-shape schema cannot
+        // express this dependency (DEC-058), so the validator enforces it
+        // at the .NET boundary before any further structural checks.
+        if (output.Reply is not null)
+        {
+            foreach (var block in output.Reply)
+            {
+                if (block is null)
+                {
+                    return new OnboardingTurnOutputValidationResult(
+                        IsValid: false,
+                        Violation: OnboardingTurnOutputValidationViolation.ContentBlockShape,
+                        NonNullSlotCount: 0);
+                }
+
+                try
+                {
+                    block.Validate();
+                }
+                catch (InvalidOperationException)
+                {
+                    return new OnboardingTurnOutputValidationResult(
+                        IsValid: false,
+                        Violation: OnboardingTurnOutputValidationViolation.ContentBlockShape,
+                        NonNullSlotCount: 0);
+                }
+            }
+        }
+
         // Clarification consistency check is independent of Extracted.
         if (output.NeedsClarification && string.IsNullOrWhiteSpace(output.ClarificationReason))
         {

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitUserTurn.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitUserTurn.cs
@@ -1,0 +1,26 @@
+namespace RunCoach.Api.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Wolverine command dispatched by <c>OnboardingController.SubmitTurn</c> for every
+/// inbound POST /api/v1/onboarding/turns request. Carries the authenticated user's
+/// id (the per-user onboarding stream identity), the client-supplied idempotency
+/// key, and the runner's free-text input. Per Slice 1 § Unit 1 / DEC-057 / DEC-060
+/// the matching handler is <see cref="OnboardingTurnHandler"/> — a Wolverine
+/// <c>[AggregateHandler]</c> that performs the per-turn work atomically through a
+/// single Marten <c>IDocumentSession</c>: idempotency check + event emission +
+/// (terminal branch only) inline plan generation + onboarding-completion events.
+/// </summary>
+/// <param name="UserId">
+/// The authenticated runner's id; doubles as the onboarding aggregate stream id
+/// (one onboarding stream per user — DEC-047).
+/// </param>
+/// <param name="IdempotencyKey">
+/// Client-generated idempotency key — typically a <c>crypto.randomUUID()</c> the
+/// frontend re-sends on retry. The handler's first action is to short-circuit
+/// duplicate submissions via <c>IIdempotencyStore.SeenAsync</c>.
+/// </param>
+/// <param name="Text">The runner's raw free-text input for the current turn.</param>
+public sealed record SubmitUserTurn(
+    Guid UserId,
+    Guid IdempotencyKey,
+    string Text);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitUserTurn.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitUserTurn.cs
@@ -5,10 +5,11 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding;
 /// inbound POST /api/v1/onboarding/turns request. Carries the authenticated user's
 /// id (the per-user onboarding stream identity), the client-supplied idempotency
 /// key, and the runner's free-text input. Per Slice 1 § Unit 1 / DEC-057 / DEC-060
-/// the matching handler is <see cref="OnboardingTurnHandler"/> — a Wolverine
-/// <c>[AggregateHandler]</c> that performs the per-turn work atomically through a
-/// single Marten <c>IDocumentSession</c>: idempotency check + event emission +
-/// (terminal branch only) inline plan generation + onboarding-completion events.
+/// the matching handler is <see cref="OnboardingTurnHandler"/> — a static Wolverine
+/// handler (plain handler-discovery convention; no <c>[AggregateHandler]</c>
+/// attribute) that performs the per-turn work atomically through a single Marten
+/// <c>IDocumentSession</c>: idempotency check + event emission + (terminal branch
+/// only) inline plan generation + onboarding-completion events.
 /// </summary>
 /// <param name="UserId">
 /// The authenticated runner's id; doubles as the onboarding aggregate stream id

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/IPlanGenerationService.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/IPlanGenerationService.cs
@@ -1,0 +1,87 @@
+using RunCoach.Api.Modules.Coaching.Models;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+
+namespace RunCoach.Api.Modules.Training.Plan;
+
+/// <summary>
+/// Plain DI service that orchestrates the tiered macro/meso/micro structured-output
+/// chain to generate a training plan from a captured onboarding profile snapshot.
+/// Per Slice 1 § Unit 2 R02.4-R02.6 / DEC-057 / R-066 this is intentionally NOT a
+/// Wolverine handler and NOT a Wolverine command — it is invoked inline by the
+/// caller's <c>[AggregateHandler]</c> body so the returned events commit on the
+/// caller's <c>IDocumentSession</c> inside one Marten transaction (no
+/// <c>IMessageBus.InvokeAsync</c> opening a second session).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The service is pure orchestration: it composes the LLM prompt via
+/// <c>IContextAssembler.ComposeForPlanGenerationAsync</c>, calls
+/// <c>ICoachingLlm.GenerateStructuredAsync</c> exactly six times (1 macro + 4 meso +
+/// 1 micro), and returns the resulting events as a list. It does NOT touch
+/// <c>IDocumentSession</c>, does NOT call <c>SaveChangesAsync</c>, and does NOT
+/// stage events on any stream — the caller (Slice 1 § Unit 1's
+/// <c>OnboardingTurnHandler</c> on the terminal turn, or Slice 1 § Unit 5's
+/// <c>RegeneratePlanHandler</c>) is responsible for invoking
+/// <c>session.Events.StartStream&lt;Plan&gt;(planId, events)</c> on its own session.
+/// </para>
+/// <para>
+/// Failure semantics: the Anthropic SDK's <c>MaxRetries</c> (3 by default) covers
+/// transient errors (429, 5xx, network). An unrecoverable failure on any tier
+/// (macro, any of the four meso calls, or micro) propagates as an exception — the
+/// caller's transactional middleware then rolls back the entire Marten transaction
+/// so no partial Plan stream is persisted, no <c>OnboardingCompleted</c> /
+/// <c>PlanLinkedToUser</c> events are appended, and the EF projection's
+/// <c>UserProfile.CurrentPlanId</c> stays at its prior value.
+/// </para>
+/// </remarks>
+public interface IPlanGenerationService
+{
+    /// <summary>
+    /// Generates the per-user plan event sequence from a captured onboarding
+    /// profile snapshot. Runs the six-call structured-output chain (macro → 4
+    /// meso → micro) with Anthropic prompt-cache breakpoints set to the 1-hour
+    /// ephemeral tier so calls 2-6 hit the prefix cache.
+    /// </summary>
+    /// <param name="profileSnapshot">
+    /// The completed <see cref="OnboardingView"/> projection — the captured
+    /// answers across the six DEC-047 topics serve as the profile for plan
+    /// generation. The snapshot is read directly; the chain does NOT replay
+    /// the onboarding event stream on each macro/meso/micro call.
+    /// </param>
+    /// <param name="userId">The runner's user id; threaded onto the returned <see cref="PlanGenerated"/> event.</param>
+    /// <param name="planId">
+    /// The new Plan stream's id (the caller passes
+    /// <c>CombGuidIdGeneration.NewGuid()</c>); also doubles as the per-user-plan
+    /// stream id when the caller calls <c>session.Events.StartStream&lt;Plan&gt;(planId, events)</c>.
+    /// </param>
+    /// <param name="intent">
+    /// Optional regeneration intent free-text supplied by the runner via
+    /// Settings → Plan (Slice 1 § Unit 5). When non-null it is appended at the
+    /// END of the plan-generation user message under the stable label
+    /// <c>[Regeneration intent provided by user]</c> so the prefix above it
+    /// stays byte-identical to the initial-generation prompt. The free-text
+    /// MUST already be sanitized by the caller via
+    /// <c>IPromptSanitizer.SanitizeAsync(intent.FreeText, PromptSection.RegenerationIntentFreeText, ct)</c>.
+    /// </param>
+    /// <param name="previousPlanId">
+    /// The prior plan id when this generation came from the regenerate-from-settings
+    /// flow, or <see langword="null"/> for the initial onboarding-driven generation.
+    /// Threaded onto the returned <see cref="PlanGenerated"/> event so the
+    /// projection retains audit linkage to the prior plan without a schema bump.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// An ordered list of events:
+    /// <c>[PlanGenerated, MesoCycleCreated×4, FirstMicroCycleCreated]</c> in
+    /// exactly that sequence. The caller stages this list onto its own
+    /// <c>IDocumentSession</c> via
+    /// <c>session.Events.StartStream&lt;Plan&gt;(planId, events)</c>.
+    /// </returns>
+    Task<IReadOnlyList<object>> GeneratePlanAsync(
+        OnboardingView profileSnapshot,
+        Guid userId,
+        Guid planId,
+        RegenerationIntent? intent,
+        Guid? previousPlanId,
+        CancellationToken ct);
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/IPlanGenerationService.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/IPlanGenerationService.cs
@@ -8,8 +8,8 @@ namespace RunCoach.Api.Modules.Training.Plan;
 /// chain to generate a training plan from a captured onboarding profile snapshot.
 /// Per Slice 1 § Unit 2 R02.4-R02.6 / DEC-057 / R-066 this is intentionally NOT a
 /// Wolverine handler and NOT a Wolverine command — it is invoked inline by the
-/// caller's <c>[AggregateHandler]</c> body so the returned events commit on the
-/// caller's <c>IDocumentSession</c> inside one Marten transaction (no
+/// caller's static handler body so the returned events commit on the caller's
+/// <c>IDocumentSession</c> inside one Marten transaction (no
 /// <c>IMessageBus.InvokeAsync</c> opening a second session).
 /// </summary>
 /// <remarks>
@@ -17,12 +17,13 @@ namespace RunCoach.Api.Modules.Training.Plan;
 /// The service is pure orchestration: it composes the LLM prompt via
 /// <c>IContextAssembler.ComposeForPlanGenerationAsync</c>, calls
 /// <c>ICoachingLlm.GenerateStructuredAsync</c> exactly six times (1 macro + 4 meso +
-/// 1 micro), and returns the resulting events as a list. It does NOT touch
-/// <c>IDocumentSession</c>, does NOT call <c>SaveChangesAsync</c>, and does NOT
-/// stage events on any stream — the caller (Slice 1 § Unit 1's
+/// 1 micro), and returns the resulting events as a <see cref="PlanEventSequence"/>.
+/// It does NOT touch <c>IDocumentSession</c>, does NOT call <c>SaveChangesAsync</c>,
+/// and does NOT stage events on any stream — the caller (Slice 1 § Unit 1's
 /// <c>OnboardingTurnHandler</c> on the terminal turn, or Slice 1 § Unit 5's
 /// <c>RegeneratePlanHandler</c>) is responsible for invoking
-/// <c>session.Events.StartStream&lt;Plan&gt;(planId, events)</c> on its own session.
+/// <c>session.Events.StartStream&lt;PlanProjectionDto&gt;(planId, planEvents.ToEvents())</c>
+/// on its own session.
 /// </para>
 /// <para>
 /// Failure semantics: the Anthropic SDK's <c>MaxRetries</c> (3 by default) covers
@@ -52,7 +53,8 @@ public interface IPlanGenerationService
     /// <param name="planId">
     /// The new Plan stream's id (the caller passes
     /// <c>CombGuidIdGeneration.NewGuid()</c>); also doubles as the per-user-plan
-    /// stream id when the caller calls <c>session.Events.StartStream&lt;Plan&gt;(planId, events)</c>.
+    /// stream id when the caller calls
+    /// <c>session.Events.StartStream&lt;PlanProjectionDto&gt;(planId, planEvents.ToEvents())</c>.
     /// </param>
     /// <param name="intent">
     /// Optional regeneration intent free-text supplied by the runner via
@@ -71,13 +73,13 @@ public interface IPlanGenerationService
     /// </param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>
-    /// An ordered list of events:
-    /// <c>[PlanGenerated, MesoCycleCreated×4, FirstMicroCycleCreated]</c> in
-    /// exactly that sequence. The caller stages this list onto its own
-    /// <c>IDocumentSession</c> via
-    /// <c>session.Events.StartStream&lt;Plan&gt;(planId, events)</c>.
+    /// A strongly-typed <see cref="PlanEventSequence"/> wrapping the
+    /// <c>[PlanGenerated, MesoCycleCreated×4, FirstMicroCycleCreated]</c>
+    /// sequence. Call <see cref="PlanEventSequence.ToEvents"/> to flatten to
+    /// the <c>IReadOnlyList&lt;object&gt;</c> shape Marten's
+    /// <c>session.Events.StartStream</c> expects.
     /// </returns>
-    Task<IReadOnlyList<object>> GeneratePlanAsync(
+    Task<PlanEventSequence> GeneratePlanAsync(
         OnboardingView profileSnapshot,
         Guid userId,
         Guid planId,

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanEventSequence.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanEventSequence.cs
@@ -1,0 +1,78 @@
+namespace RunCoach.Api.Modules.Training.Plan;
+
+/// <summary>
+/// Strongly-typed wrapper around the canonical Slice 1 plan event sequence
+/// returned by <see cref="IPlanGenerationService.GeneratePlanAsync"/>. Encodes
+/// the documented shape <c>[PlanGenerated, MesoCycleCreated×4, FirstMicroCycleCreated]</c>
+/// in the type system so callers cannot accidentally drop, reorder, or
+/// mismatch element types when staging the events on a Marten session.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Construction validates <c>Mesos.Count == <see cref="ExpectedMesoCount"/></c>
+/// (Slice 1 generates weeks 1-4) and that all three fields are non-null.
+/// <see cref="ToEvents"/> flattens the wrapper back to the
+/// <c>IReadOnlyList&lt;object&gt;</c> shape that <c>session.Events.StartStream</c>
+/// expects.
+/// </para>
+/// </remarks>
+/// <param name="Macro">The plan-generation event carrying the macro plan.</param>
+/// <param name="Mesos">
+/// The four meso-cycle events for weeks 1..4, in order. Must contain exactly
+/// <see cref="ExpectedMesoCount"/> entries.
+/// </param>
+/// <param name="Micro">The first-micro-cycle event with detailed week-1 workouts.</param>
+public sealed record PlanEventSequence(
+    PlanGenerated Macro,
+    IReadOnlyList<MesoCycleCreated> Mesos,
+    FirstMicroCycleCreated Micro)
+{
+    /// <summary>
+    /// The required number of meso events per the Slice 1 contract.
+    /// </summary>
+    public const int ExpectedMesoCount = 4;
+
+    /// <summary>
+    /// Gets the plan-generation event carrying the macro plan.
+    /// </summary>
+    public PlanGenerated Macro { get; init; } = Macro ?? throw new ArgumentNullException(nameof(Macro));
+
+    /// <summary>
+    /// Gets the four meso-cycle events for weeks 1..4, in order.
+    /// </summary>
+    public IReadOnlyList<MesoCycleCreated> Mesos { get; init; } = ValidateMesos(Mesos);
+
+    /// <summary>
+    /// Gets the first-micro-cycle event with detailed week-1 workouts.
+    /// </summary>
+    public FirstMicroCycleCreated Micro { get; init; } = Micro ?? throw new ArgumentNullException(nameof(Micro));
+
+    /// <summary>
+    /// Flattens the wrapper into the ordered <c>IReadOnlyList&lt;object&gt;</c>
+    /// expected by Marten's <c>session.Events.StartStream</c>.
+    /// </summary>
+    /// <returns>
+    /// The events in canonical order:
+    /// <c>[PlanGenerated, MesoCycleCreated×4, FirstMicroCycleCreated]</c>.
+    /// </returns>
+    public IReadOnlyList<object> ToEvents()
+    {
+        var events = new List<object>(2 + Mesos.Count) { Macro };
+        events.AddRange(Mesos);
+        events.Add(Micro);
+        return events;
+    }
+
+    private static IReadOnlyList<MesoCycleCreated> ValidateMesos(IReadOnlyList<MesoCycleCreated> mesos)
+    {
+        ArgumentNullException.ThrowIfNull(mesos);
+        if (mesos.Count != ExpectedMesoCount)
+        {
+            throw new ArgumentException(
+                $"Expected {ExpectedMesoCount} meso events, got {mesos.Count}.",
+                nameof(mesos));
+        }
+
+        return mesos;
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanEventSequence.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanEventSequence.cs
@@ -73,6 +73,22 @@ public sealed record PlanEventSequence(
                 nameof(mesos));
         }
 
+        // Each entry must carry the canonical 1-based week index for its
+        // position so ToEvents() emits weeks 1..ExpectedMesoCount in order.
+        // A reordered or duplicated meso list would otherwise flatten through
+        // ToEvents() and quietly violate the wrapper's contract.
+        for (var index = 0; index < mesos.Count; index++)
+        {
+            var expectedWeek = index + 1;
+            if (mesos[index].WeekIndex != expectedWeek)
+            {
+                throw new ArgumentException(
+                    $"Meso events must be ordered for weeks 1..{ExpectedMesoCount}; " +
+                    $"position {index} carried WeekIndex={mesos[index].WeekIndex}, expected {expectedWeek}.",
+                    nameof(mesos));
+            }
+        }
+
         return mesos;
     }
 }

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanGenerationService.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanGenerationService.cs
@@ -1,0 +1,344 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RunCoach.Api.Modules.Coaching;
+using RunCoach.Api.Modules.Coaching.Models;
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+using RunCoach.Api.Modules.Coaching.Prompts;
+
+namespace RunCoach.Api.Modules.Training.Plan;
+
+/// <summary>
+/// Plain DI service implementing the six-call macro/meso/micro structured-output
+/// chain per Slice 1 § Unit 2 R02.4-R02.6 (DEC-057 / R-066). Returns the resulting
+/// events as a list — the caller stages them on its own <c>IDocumentSession</c>
+/// inside one Marten transaction so the entire plan + onboarding-completion writes
+/// commit atomically (R-069 / DEC-060).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The service does NOT inject <c>IDocumentSession</c>, does NOT call
+/// <c>SaveChangesAsync</c>, and does NOT touch any aggregate or projection. It is
+/// pure orchestration over <see cref="IContextAssembler"/> and
+/// <see cref="ICoachingLlm"/> calls, returning <c>IReadOnlyList&lt;object&gt;</c> for
+/// the caller to pass straight to <c>session.Events.StartStream&lt;Plan&gt;</c>.
+/// </para>
+/// <para>
+/// Per-tier prompt suffix: the base user message (cacheable prefix) comes from
+/// <see cref="IContextAssembler.ComposeForPlanGenerationAsync"/>; the service
+/// appends a tier-specific suffix (macro / meso week-N / micro) AFTER that base.
+/// Anthropic prompt-prefix caching with <see cref="CacheControl.Ephemeral1h"/>
+/// hashes everything before the breakpoint, so the suffix's variability across
+/// the six calls only affects the post-cache tail tokens.
+/// </para>
+/// </remarks>
+public sealed partial class PlanGenerationService : IPlanGenerationService
+{
+    /// <summary>
+    /// Marker label that begins the macro-tier suffix. The label string is part
+    /// of the wire bytes — held in a constant so tests can locate it.
+    /// </summary>
+    internal const string MacroTierLabel = "[TIER: MACRO PLAN]";
+
+    /// <summary>
+    /// Marker label that begins the meso-tier suffix. The week number, phase,
+    /// and deload-candidate hint are appended on the lines following this label.
+    /// </summary>
+    internal const string MesoTierLabel = "[TIER: MESO WEEK]";
+
+    /// <summary>
+    /// Marker label that begins the micro-tier suffix. The macro context and
+    /// week-1 meso template are recapped under this label so the LLM sees the
+    /// same shape across the chain.
+    /// </summary>
+    internal const string MicroTierLabel = "[TIER: MICRO WORKOUTS]";
+
+    /// <summary>
+    /// Number of meso weeks Slice 1 generates (weeks 1-4). Constant rather than
+    /// a setting so the projection's expected event sequence stays stable.
+    /// </summary>
+    internal const int MesoWeekCount = 4;
+
+    private readonly IContextAssembler _assembler;
+    private readonly ICoachingLlm _llm;
+    private readonly IPromptStore _promptStore;
+    private readonly CoachingLlmSettings _settings;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<PlanGenerationService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlanGenerationService"/> class.
+    /// </summary>
+    /// <param name="assembler">Context assembler used to compose the cacheable prompt prefix.</param>
+    /// <param name="llm">Coaching LLM adapter used to invoke the structured-output chain.</param>
+    /// <param name="promptStore">Prompt store consulted to record the active prompt version on <see cref="PlanGenerated"/>.</param>
+    /// <param name="settings">Coaching LLM settings — supplies the model id stamped on <see cref="PlanGenerated"/>.</param>
+    /// <param name="timeProvider">Time provider for the <see cref="PlanGenerated.GeneratedAt"/> stamp.</param>
+    /// <param name="logger">Logger.</param>
+    public PlanGenerationService(
+        IContextAssembler assembler,
+        ICoachingLlm llm,
+        IPromptStore promptStore,
+        IOptions<CoachingLlmSettings> settings,
+        TimeProvider timeProvider,
+        ILogger<PlanGenerationService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(assembler);
+        ArgumentNullException.ThrowIfNull(llm);
+        ArgumentNullException.ThrowIfNull(promptStore);
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _assembler = assembler;
+        _llm = llm;
+        _promptStore = promptStore;
+        _settings = settings.Value;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<object>> GeneratePlanAsync(
+        OnboardingView profileSnapshot,
+        Guid userId,
+        Guid planId,
+        RegenerationIntent? intent,
+        Guid? previousPlanId,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(profileSnapshot);
+        ct.ThrowIfCancellationRequested();
+
+        // Compose the cacheable prefix — same bytes for all six calls.
+        var composition = await _assembler
+            .ComposeForPlanGenerationAsync(profileSnapshot, intent, ct)
+            .ConfigureAwait(false);
+
+        var systemPrompt = composition.SystemPrompt;
+        var basePrompt = composition.UserMessage;
+
+        LogChainStart(_logger, planId, userId, previousPlanId);
+
+        // Tier 1 — macro plan.
+        var macro = await _llm
+            .GenerateStructuredAsync<MacroPlanOutput>(
+                systemPrompt,
+                BuildMacroUserMessage(basePrompt),
+                schema: null,
+                cacheControl: CacheControl.Ephemeral1h,
+                ct)
+            .ConfigureAwait(false);
+
+        // Tier 2 — four meso weeks (1..4). Each call carries a per-week context
+        // suffix derived from the macro plan's phase list so the LLM knows
+        // which phase boundary the week sits inside without re-reading macro.
+        var mesoEvents = new List<MesoCycleCreated>(MesoWeekCount);
+        for (var week = 1; week <= MesoWeekCount; week++)
+        {
+            var weekContext = WeekContext.FromMacro(macro, week);
+            var meso = await _llm
+                .GenerateStructuredAsync<MesoWeekOutput>(
+                    systemPrompt,
+                    BuildMesoUserMessage(basePrompt, macro, weekContext),
+                    schema: null,
+                    cacheControl: CacheControl.Ephemeral1h,
+                    ct)
+                .ConfigureAwait(false);
+
+            mesoEvents.Add(new MesoCycleCreated(week, meso));
+        }
+
+        // Tier 3 — micro week-1 detail. The user message recaps the macro plan
+        // and the week-1 meso so the model has both contexts. The system block
+        // remains the cacheable prefix shared with calls 1-5.
+        var weekOneMeso = mesoEvents[0].Meso;
+        var micro = await _llm
+            .GenerateStructuredAsync<MicroWorkoutListOutput>(
+                systemPrompt,
+                BuildMicroUserMessage(basePrompt, macro, weekOneMeso),
+                schema: null,
+                cacheControl: CacheControl.Ephemeral1h,
+                ct)
+            .ConfigureAwait(false);
+
+        var promptVersion = _promptStore.GetActiveVersion(ContextAssembler.CoachingPromptId);
+
+        // Assemble the canonical Slice 1 plan event sequence.
+        var planGenerated = new PlanGenerated(
+            PlanId: planId,
+            UserId: userId,
+            Macro: macro,
+            GeneratedAt: _timeProvider.GetUtcNow(),
+            PromptVersion: promptVersion,
+            ModelId: _settings.ModelId,
+            PreviousPlanId: previousPlanId);
+
+        var events = new List<object>(1 + MesoWeekCount + 1)
+        {
+            planGenerated,
+        };
+        events.AddRange(mesoEvents);
+        events.Add(new FirstMicroCycleCreated(micro));
+
+        LogChainComplete(_logger, planId, events.Count);
+
+        return events;
+    }
+
+    /// <summary>
+    /// Appends the macro-tier suffix on the cacheable base prompt. Layout: a
+    /// blank line, the tier label, and a brief instruction line telling the
+    /// LLM which structured output is expected.
+    /// </summary>
+    private static string BuildMacroUserMessage(string basePrompt)
+    {
+        var sb = new StringBuilder(basePrompt.Length + 128);
+        sb.Append(basePrompt);
+        sb.AppendLine();
+        sb.AppendLine();
+        sb.AppendLine(MacroTierLabel);
+        sb.AppendLine("Generate the periodized macro plan covering the full training horizon.");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Appends the meso-tier suffix on the cacheable base prompt. The macro
+    /// plan is serialized into a compact recap so the LLM sees the periodized
+    /// targets it just produced; the per-week <see cref="WeekContext"/>
+    /// follows so call N uses week N's phase + deload hint.
+    /// </summary>
+    private static string BuildMesoUserMessage(string basePrompt, MacroPlanOutput macro, WeekContext weekContext)
+    {
+        var sb = new StringBuilder(basePrompt.Length + 256);
+        sb.Append(basePrompt);
+        sb.AppendLine();
+        sb.AppendLine();
+        sb.AppendLine(MesoTierLabel);
+        AppendMacroRecap(sb, macro);
+        sb.AppendLine(CultureInfo.InvariantCulture, $"WeekIndex: {weekContext.WeekIndex}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"PhaseType: {weekContext.PhaseType}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"IsDeloadCandidate: {(weekContext.IsDeloadCandidate ? "true" : "false")}");
+        sb.AppendLine(
+            CultureInfo.InvariantCulture,
+            $"Generate the week template for week {weekContext.WeekIndex}.");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Appends the micro-tier suffix on the cacheable base prompt. Recaps both
+    /// the macro plan and the week-1 meso template so the LLM has the
+    /// progression context it needs to lay out detailed workouts.
+    /// </summary>
+    private static string BuildMicroUserMessage(
+        string basePrompt,
+        MacroPlanOutput macro,
+        MesoWeekOutput weekOneMeso)
+    {
+        var sb = new StringBuilder(basePrompt.Length + 512);
+        sb.Append(basePrompt);
+        sb.AppendLine();
+        sb.AppendLine();
+        sb.AppendLine(MicroTierLabel);
+        AppendMacroRecap(sb, macro);
+        sb.AppendLine(CultureInfo.InvariantCulture, $"Week 1 phase: {weekOneMeso.PhaseType}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"Week 1 weekly target km: {weekOneMeso.WeeklyTargetKm}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"Week 1 is deload: {(weekOneMeso.IsDeloadWeek ? "true" : "false")}");
+        sb.AppendLine("Generate the detailed workouts for week 1, one per scheduled run day.");
+        return sb.ToString();
+    }
+
+    private static void AppendMacroRecap(StringBuilder sb, MacroPlanOutput macro)
+    {
+        sb.AppendLine(CultureInfo.InvariantCulture, $"Macro goal: {macro.GoalDescription}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"Macro total weeks: {macro.TotalWeeks}");
+        sb.AppendLine("Phases:");
+        foreach (var phase in macro.Phases)
+        {
+            sb.AppendLine(
+                CultureInfo.InvariantCulture,
+                $"  - {phase.PhaseType}: {phase.Weeks} weeks ({phase.WeeklyDistanceStartKm}-{phase.WeeklyDistanceEndKm} km/wk, {phase.IntensityDistribution})");
+        }
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Plan generation chain start: PlanId={PlanId} UserId={UserId} PreviousPlanId={PreviousPlanId}")]
+    private static partial void LogChainStart(
+        ILogger logger,
+        Guid planId,
+        Guid userId,
+        Guid? previousPlanId);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Plan generation chain complete: PlanId={PlanId} EventCount={EventCount}")]
+    private static partial void LogChainComplete(
+        ILogger logger,
+        Guid planId,
+        int eventCount);
+
+    /// <summary>
+    /// Per-week context derived from the macro plan's phase list. Tells the
+    /// meso-tier LLM call which phase the week sits in and whether it is the
+    /// last week of a phase chunk that includes a deload week (the candidate
+    /// week for volume reduction).
+    /// </summary>
+    /// <param name="WeekIndex">1-based week number within the plan (1..4 in Slice 1).</param>
+    /// <param name="PhaseType">The periodization phase this week sits inside.</param>
+    /// <param name="IsDeloadCandidate">
+    /// Whether this week is the last week of a phase chunk that includes a
+    /// deload week — a hint to the LLM that this week may be the deload. The
+    /// LLM ultimately decides whether to flag the week with
+    /// <c>MesoWeekOutput.IsDeloadWeek = true</c>.
+    /// </param>
+    internal sealed record WeekContext(int WeekIndex, PhaseType PhaseType, bool IsDeloadCandidate)
+    {
+        /// <summary>
+        /// Derives the <see cref="WeekContext"/> for the given 1-based
+        /// <paramref name="weekIndex"/> from the macro plan. Walks the phase
+        /// list summing each phase's <c>Weeks</c> and returns the phase that
+        /// owns the requested week. If the requested week falls past the last
+        /// declared phase (defensive: macro might under-declare in pathological
+        /// LLM outputs), the last phase is returned.
+        /// </summary>
+        public static WeekContext FromMacro(MacroPlanOutput macro, int weekIndex)
+        {
+            ArgumentNullException.ThrowIfNull(macro);
+            if (weekIndex < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(weekIndex), weekIndex, "Week index is 1-based.");
+            }
+
+            if (macro.Phases.Length == 0)
+            {
+                // No phases declared — emit a defensive Base/no-deload context
+                // so the meso call still proceeds. The macro itself will fail
+                // downstream validation if this happens; logging is the
+                // caller's responsibility via the analyzer pipeline.
+                return new WeekContext(weekIndex, PhaseType.Base, IsDeloadCandidate: false);
+            }
+
+            var cumulative = 0;
+            foreach (var phase in macro.Phases)
+            {
+                var phaseEnd = cumulative + phase.Weeks;
+                if (weekIndex <= phaseEnd)
+                {
+                    var isLastWeekOfPhase = weekIndex == phaseEnd;
+                    return new WeekContext(
+                        weekIndex,
+                        phase.PhaseType,
+                        IsDeloadCandidate: phase.IncludesDeload && isLastWeekOfPhase);
+                }
+
+                cumulative = phaseEnd;
+            }
+
+            var lastPhase = macro.Phases[^1];
+            return new WeekContext(weekIndex, lastPhase.PhaseType, IsDeloadCandidate: false);
+        }
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanGenerationService.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanGenerationService.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.Text;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RunCoach.Api.Modules.Coaching;
 using RunCoach.Api.Modules.Coaching.Models;
@@ -101,7 +100,7 @@ public sealed partial class PlanGenerationService : IPlanGenerationService
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<object>> GeneratePlanAsync(
+    public async Task<PlanEventSequence> GeneratePlanAsync(
         OnboardingView profileSnapshot,
         Guid userId,
         Guid planId,
@@ -176,16 +175,14 @@ public sealed partial class PlanGenerationService : IPlanGenerationService
             ModelId: _settings.ModelId,
             PreviousPlanId: previousPlanId);
 
-        var events = new List<object>(1 + MesoWeekCount + 1)
-        {
-            planGenerated,
-        };
-        events.AddRange(mesoEvents);
-        events.Add(new FirstMicroCycleCreated(micro));
+        var sequence = new PlanEventSequence(
+            Macro: planGenerated,
+            Mesos: mesoEvents,
+            Micro: new FirstMicroCycleCreated(micro));
 
-        LogChainComplete(_logger, planId, events.Count);
+        LogChainComplete(_logger, planId, expectedEventCount: 1 + mesoEvents.Count + 1);
 
-        return events;
+        return sequence;
     }
 
     /// <summary>
@@ -274,71 +271,9 @@ public sealed partial class PlanGenerationService : IPlanGenerationService
 
     [LoggerMessage(
         Level = LogLevel.Information,
-        Message = "Plan generation chain complete: PlanId={PlanId} EventCount={EventCount}")]
+        Message = "Plan generation chain complete: PlanId={PlanId} EventCount={ExpectedEventCount}")]
     private static partial void LogChainComplete(
         ILogger logger,
         Guid planId,
-        int eventCount);
-
-    /// <summary>
-    /// Per-week context derived from the macro plan's phase list. Tells the
-    /// meso-tier LLM call which phase the week sits in and whether it is the
-    /// last week of a phase chunk that includes a deload week (the candidate
-    /// week for volume reduction).
-    /// </summary>
-    /// <param name="WeekIndex">1-based week number within the plan (1..4 in Slice 1).</param>
-    /// <param name="PhaseType">The periodization phase this week sits inside.</param>
-    /// <param name="IsDeloadCandidate">
-    /// Whether this week is the last week of a phase chunk that includes a
-    /// deload week — a hint to the LLM that this week may be the deload. The
-    /// LLM ultimately decides whether to flag the week with
-    /// <c>MesoWeekOutput.IsDeloadWeek = true</c>.
-    /// </param>
-    internal sealed record WeekContext(int WeekIndex, PhaseType PhaseType, bool IsDeloadCandidate)
-    {
-        /// <summary>
-        /// Derives the <see cref="WeekContext"/> for the given 1-based
-        /// <paramref name="weekIndex"/> from the macro plan. Walks the phase
-        /// list summing each phase's <c>Weeks</c> and returns the phase that
-        /// owns the requested week. If the requested week falls past the last
-        /// declared phase (defensive: macro might under-declare in pathological
-        /// LLM outputs), the last phase is returned.
-        /// </summary>
-        public static WeekContext FromMacro(MacroPlanOutput macro, int weekIndex)
-        {
-            ArgumentNullException.ThrowIfNull(macro);
-            if (weekIndex < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(weekIndex), weekIndex, "Week index is 1-based.");
-            }
-
-            if (macro.Phases.Length == 0)
-            {
-                // No phases declared — emit a defensive Base/no-deload context
-                // so the meso call still proceeds. The macro itself will fail
-                // downstream validation if this happens; logging is the
-                // caller's responsibility via the analyzer pipeline.
-                return new WeekContext(weekIndex, PhaseType.Base, IsDeloadCandidate: false);
-            }
-
-            var cumulative = 0;
-            foreach (var phase in macro.Phases)
-            {
-                var phaseEnd = cumulative + phase.Weeks;
-                if (weekIndex <= phaseEnd)
-                {
-                    var isLastWeekOfPhase = weekIndex == phaseEnd;
-                    return new WeekContext(
-                        weekIndex,
-                        phase.PhaseType,
-                        IsDeloadCandidate: phase.IncludesDeload && isLastWeekOfPhase);
-                }
-
-                cumulative = phaseEnd;
-            }
-
-            var lastPhase = macro.Phases[^1];
-            return new WeekContext(weekIndex, lastPhase.PhaseType, IsDeloadCandidate: false);
-        }
-    }
+        int expectedEventCount);
 }

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanGenerationService.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanGenerationService.cs
@@ -226,15 +226,17 @@ public sealed partial class PlanGenerationService : IPlanGenerationService
 
     /// <summary>
     /// Appends the micro-tier suffix on the cacheable base prompt. Recaps both
-    /// the macro plan and the week-1 meso template so the LLM has the
-    /// progression context it needs to lay out detailed workouts.
+    /// the macro plan and the full week-1 meso template (phase / target km /
+    /// deload flag plus the day-by-day slot map) so the micro tier elaborates
+    /// the exact week the meso call laid out, instead of inventing day slots
+    /// from a 3-field summary.
     /// </summary>
     private static string BuildMicroUserMessage(
         string basePrompt,
         MacroPlanOutput macro,
         MesoWeekOutput weekOneMeso)
     {
-        var sb = new StringBuilder(basePrompt.Length + 512);
+        var sb = new StringBuilder(basePrompt.Length + 768);
         sb.Append(basePrompt);
         sb.AppendLine();
         sb.AppendLine();
@@ -243,8 +245,32 @@ public sealed partial class PlanGenerationService : IPlanGenerationService
         sb.AppendLine(CultureInfo.InvariantCulture, $"Week 1 phase: {weekOneMeso.PhaseType}");
         sb.AppendLine(CultureInfo.InvariantCulture, $"Week 1 weekly target km: {weekOneMeso.WeeklyTargetKm}");
         sb.AppendLine(CultureInfo.InvariantCulture, $"Week 1 is deload: {(weekOneMeso.IsDeloadWeek ? "true" : "false")}");
+        AppendWeekOneMesoTemplate(sb, weekOneMeso);
         sb.AppendLine("Generate the detailed workouts for week 1, one per scheduled run day.");
         return sb.ToString();
+    }
+
+    private static void AppendWeekOneMesoTemplate(StringBuilder sb, MesoWeekOutput weekOneMeso)
+    {
+        sb.AppendLine("Week 1 meso template (day-by-day):");
+        AppendMesoSlot(sb, "Sunday", weekOneMeso.Sunday);
+        AppendMesoSlot(sb, "Monday", weekOneMeso.Monday);
+        AppendMesoSlot(sb, "Tuesday", weekOneMeso.Tuesday);
+        AppendMesoSlot(sb, "Wednesday", weekOneMeso.Wednesday);
+        AppendMesoSlot(sb, "Thursday", weekOneMeso.Thursday);
+        AppendMesoSlot(sb, "Friday", weekOneMeso.Friday);
+        AppendMesoSlot(sb, "Saturday", weekOneMeso.Saturday);
+        if (!string.IsNullOrWhiteSpace(weekOneMeso.WeekSummary))
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture, $"Week 1 summary: {weekOneMeso.WeekSummary}");
+        }
+    }
+
+    private static void AppendMesoSlot(StringBuilder sb, string day, MesoDaySlotOutput slot)
+    {
+        var workoutType = slot.WorkoutType?.ToString() ?? "(none)";
+        var notes = string.IsNullOrWhiteSpace(slot.Notes) ? string.Empty : $" — {slot.Notes}";
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  - {day}: {slot.SlotType} / {workoutType}{notes}");
     }
 
     private static void AppendMacroRecap(StringBuilder sb, MacroPlanOutput macro)

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/WeekContext.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/WeekContext.cs
@@ -1,0 +1,68 @@
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+
+namespace RunCoach.Api.Modules.Training.Plan;
+
+/// <summary>
+/// Per-week context derived from the macro plan's phase list. Tells the
+/// meso-tier LLM call which phase the week sits in and whether it is the
+/// last week of a phase chunk that includes a deload week (the candidate
+/// week for volume reduction).
+/// </summary>
+/// <param name="WeekIndex">1-based week number within the plan (1..4 in Slice 1).</param>
+/// <param name="PhaseType">The periodization phase this week sits inside.</param>
+/// <param name="IsDeloadCandidate">
+/// Whether this week is the last week of a phase chunk that includes a
+/// deload week — a hint to the LLM that this week may be the deload. The
+/// LLM ultimately decides whether to flag the week with
+/// <c>MesoWeekOutput.IsDeloadWeek = true</c>.
+/// </param>
+internal sealed record WeekContext(int WeekIndex, PhaseType PhaseType, bool IsDeloadCandidate)
+{
+    /// <summary>
+    /// Derives the <see cref="WeekContext"/> for the given 1-based
+    /// <paramref name="weekIndex"/> from the macro plan. Walks the phase
+    /// list summing each phase's <c>Weeks</c> and returns the phase that
+    /// owns the requested week. If the requested week falls past the last
+    /// declared phase (defensive: macro might under-declare in pathological
+    /// LLM outputs), the last phase is returned.
+    /// </summary>
+    /// <param name="macro">The macro plan output to derive context from.</param>
+    /// <param name="weekIndex">1-based week index.</param>
+    /// <returns>The week context.</returns>
+    public static WeekContext FromMacro(MacroPlanOutput macro, int weekIndex)
+    {
+        ArgumentNullException.ThrowIfNull(macro);
+        if (weekIndex < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(weekIndex), weekIndex, "Week index is 1-based.");
+        }
+
+        if (macro.Phases.Length == 0)
+        {
+            // No phases declared — emit a defensive Base/no-deload context
+            // so the meso call still proceeds. The macro itself will fail
+            // downstream validation if this happens; logging is the
+            // caller's responsibility via the analyzer pipeline.
+            return new WeekContext(weekIndex, PhaseType.Base, IsDeloadCandidate: false);
+        }
+
+        var cumulative = 0;
+        foreach (var phase in macro.Phases)
+        {
+            var phaseEnd = cumulative + phase.Weeks;
+            if (weekIndex <= phaseEnd)
+            {
+                var isLastWeekOfPhase = weekIndex == phaseEnd;
+                return new WeekContext(
+                    weekIndex,
+                    phase.PhaseType,
+                    IsDeloadCandidate: phase.IncludesDeload && isLastWeekOfPhase);
+            }
+
+            cumulative = phaseEnd;
+        }
+
+        var lastPhase = macro.Phases[^1];
+        return new WeekContext(weekIndex, lastPhase.PhaseType, IsDeloadCandidate: false);
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Infrastructure/DeterministicGuidTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Infrastructure/DeterministicGuidTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using RunCoach.Api.Infrastructure;
+
+namespace RunCoach.Api.Tests.Infrastructure;
+
+/// <summary>
+/// Unit tests for <see cref="DeterministicGuid.From"/> covering the UUID-v5
+/// shape (version + variant bits), determinism, and input validation.
+/// </summary>
+public sealed class DeterministicGuidTests
+{
+    private static readonly Guid SampleUserId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    [Fact]
+    public void From_ReturnsSameGuidForSameInputs()
+    {
+        // Arrange / Act
+        var first = DeterministicGuid.From(SampleUserId, "onboarding");
+        var second = DeterministicGuid.From(SampleUserId, "onboarding");
+
+        // Assert
+        first.Should().Be(second, because: "deterministic derivation must be repeatable");
+    }
+
+    [Fact]
+    public void From_DifferentStreamPurpose_ProducesDifferentGuid()
+    {
+        // Arrange / Act
+        var onboarding = DeterministicGuid.From(SampleUserId, "onboarding");
+        var plan = DeterministicGuid.From(SampleUserId, "plan");
+
+        // Assert
+        onboarding.Should().NotBe(plan, because: "stream purpose must namespace the derivation");
+    }
+
+    [Fact]
+    public void From_DifferentUserId_ProducesDifferentGuid()
+    {
+        // Arrange
+        var otherUser = Guid.Parse("99999999-8888-7777-6666-555555555555");
+
+        // Act
+        var a = DeterministicGuid.From(SampleUserId, "onboarding");
+        var b = DeterministicGuid.From(otherUser, "onboarding");
+
+        // Assert
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void From_SetsUuidV5VersionAndIetfVariantBits()
+    {
+        // Act
+        var actual = DeterministicGuid.From(SampleUserId, "onboarding");
+
+        // Assert — RFC 4122 §4.3: the version nibble must be 0x5 and the
+        // variant high bits must be 10xx (0x80..0xBF when masked with 0xC0).
+        // Use ToByteArray(bigEndian: true) so byte[6] / byte[8] map to the
+        // canonical version and variant positions per the spec.
+        var bytes = actual.ToByteArray(bigEndian: true);
+
+        ((bytes[6] & 0xF0) >> 4).Should().Be(0x5, because: "UUID v5 sets the version nibble to 5");
+        (bytes[8] & 0xC0).Should().Be(0x80, because: "RFC 4122 IETF variant bits must be 10xx");
+
+        // Sanity: the canonical string also surfaces the version digit at the
+        // start of the third hyphen-separated group.
+        actual.ToString("D")[14].Should().Be('5');
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void From_ThrowsWhenStreamPurposeIsNullOrWhitespace(string streamPurpose)
+    {
+        // Act
+        var act = () => DeterministicGuid.From(SampleUserId, streamPurpose);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithParameterName(nameof(streamPurpose));
+    }
+
+    [Fact]
+    public void From_ThrowsWhenStreamPurposeIsNull()
+    {
+        // Act
+        var act = () => DeterministicGuid.From(SampleUserId, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithParameterName("streamPurpose");
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/AnthropicContentBlockTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/AnthropicContentBlockTests.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Unit tests for <see cref="AnthropicContentBlock.Validate"/> covering the
+/// Type vs Text contract that the closed-shape grammar (DEC-058) cannot
+/// enforce at the schema level.
+/// </summary>
+public sealed class AnthropicContentBlockTests
+{
+    [Fact]
+    public void Validate_TextWithNonEmptyText_DoesNotThrow()
+    {
+        // Arrange
+        var block = new AnthropicContentBlock
+        {
+            Type = AnthropicContentBlockType.Text,
+            Text = "Hello, runner.",
+        };
+
+        // Act
+        var act = () => block.Validate();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Validate_ThinkingWithEmptyText_DoesNotThrow()
+    {
+        // Arrange
+        var block = new AnthropicContentBlock
+        {
+            Type = AnthropicContentBlockType.Thinking,
+            Text = string.Empty,
+        };
+
+        // Act
+        var act = () => block.Validate();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Validate_TextWithEmptyOrNullText_Throws(string? text)
+    {
+        // Arrange
+        var block = new AnthropicContentBlock
+        {
+            Type = AnthropicContentBlockType.Text,
+            Text = text!,
+        };
+
+        // Act
+        var act = () => block.Validate();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Type=Text must carry a non-empty Text payload*");
+    }
+
+    [Fact]
+    public void Validate_ThinkingWithNonEmptyText_Throws()
+    {
+        // Arrange
+        var block = new AnthropicContentBlock
+        {
+            Type = AnthropicContentBlockType.Thinking,
+            Text = "should be empty for thinking blocks",
+        };
+
+        // Act
+        var act = () => block.Validate();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Type=Thinking must carry an empty Text payload*");
+    }
+
+    [Fact]
+    public void Validate_UnknownType_Throws()
+    {
+        // Arrange — out-of-range enum cast to simulate a malformed payload.
+        var block = new AnthropicContentBlock
+        {
+            Type = (AnthropicContentBlockType)999,
+            Text = string.Empty,
+        };
+
+        // Act
+        var act = () => block.Validate();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Unknown AnthropicContentBlockType*");
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/InvokeAsyncTransactionScopeTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/InvokeAsyncTransactionScopeTests.cs
@@ -1,0 +1,180 @@
+using System.Text.Json;
+using FluentAssertions;
+using Marten;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using RunCoach.Api.Modules.Coaching;
+using RunCoach.Api.Modules.Coaching.Idempotency;
+using RunCoach.Api.Modules.Coaching.Models;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+using RunCoach.Api.Modules.Coaching.Sanitization;
+using RunCoach.Api.Modules.Training.Plan;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// R-066 + R-069 atomicity regression test (spec 13 § Unit 1 Verification).
+/// Stubs <see cref="IPlanGenerationService"/> to throw on the terminal-branch
+/// invocation; asserts the handler's response generation never reached the
+/// idempotency-record call AND no <see cref="OnboardingCompleted"/> event was
+/// staged on the session — Wolverine's transactional middleware would then
+/// rollback every staged change including the staged plan-stream creation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the unit-level guarantee: the handler itself never calls
+/// <c>SaveChangesAsync</c>, so when <see cref="IPlanGenerationService.GeneratePlanAsync"/>
+/// throws, the in-flight session has every appended event still pending and
+/// the framework will discard them. The companion integration test
+/// (<c>OnboardingFlowIntegrationTests</c>) drives a full HTTP request through
+/// the live Marten + Wolverine stack to confirm the rollback observably leaves
+/// no Plan stream and no <c>OnboardingCompleted</c> event in the database.
+/// </para>
+/// <para>
+/// Per DEC-060 / R-069 the dual-write atomicity claim — that exactly one
+/// Postgres transaction (and one <c>backend_xid</c>) covers the entire handler
+/// — is upheld by Marten's <c>UseEntityFrameworkCoreTransactionParticipant</c>
+/// wiring established in <c>MartenConfiguration</c>. That single-transaction
+/// property is asserted via the framework-level test
+/// <c>UserProfileFromOnboardingProjection</c> integration coverage rather
+/// than a separate <c>pg_stat_activity.backend_xid</c> observer probe; the
+/// observer probe is deferred per the cw-execute proof file.
+/// </para>
+/// </remarks>
+public class InvokeAsyncTransactionScopeTests
+{
+    [Fact]
+    public async Task Handle_When_PlanGeneration_Throws_Handler_Throws_And_Idempotency_Is_Not_Recorded()
+    {
+        // Arrange — bring the runner to the terminal branch with all six
+        // required slots already filled, then make plan generation explode.
+        var session = Substitute.For<IDocumentSession>();
+        var llm = Substitute.For<ICoachingLlm>();
+        var assembler = Substitute.For<IContextAssembler>();
+        var sanitizer = Substitute.For<IPromptSanitizer>();
+        var idempotency = Substitute.For<IIdempotencyStore>();
+        var planGen = Substitute.For<IPlanGenerationService>();
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero));
+        var userId = Guid.NewGuid();
+        var idempotencyKey = Guid.NewGuid();
+
+        // Pre-populate the view so the deterministic gate is satisfied.
+        var view = BuildFullView(userId);
+        session.LoadAsync<OnboardingView>(userId, Arg.Any<CancellationToken>()).Returns(view);
+        idempotency
+            .SeenAsync<OnboardingTurnResponseDto>(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((OnboardingTurnResponseDto?)null);
+        assembler
+            .ComposeForOnboardingAsync(
+                Arg.Any<OnboardingView>(),
+                Arg.Any<OnboardingTopic>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new OnboardingPromptComposition(
+                "system",
+                "user",
+                System.Collections.Immutable.ImmutableArray<SanitizationFinding>.Empty,
+                false));
+        llm
+            .GenerateStructuredAsync<OnboardingTurnOutput>(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, JsonElement>>(),
+                Arg.Any<CacheControl?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(BuildReadyForPlanOutput());
+        planGen
+            .GeneratePlanAsync(
+                Arg.Any<OnboardingView>(),
+                Arg.Any<Guid>(),
+                Arg.Any<Guid>(),
+                Arg.Any<RegenerationIntent?>(),
+                Arg.Any<Guid?>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsyncForAnyArgs(new InvalidOperationException("simulated plan-generation failure on the 4th meso call"));
+
+        // Act
+        var act = async () => await OnboardingTurnHandler.Handle(
+            new SubmitUserTurn(userId, idempotencyKey, "ok"),
+            session,
+            llm,
+            assembler,
+            sanitizer,
+            idempotency,
+            planGen,
+            time,
+            NullLogger<OnboardingTurnHandler>.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert — handler propagates the exception so Wolverine's transactional
+        //   middleware rolls back the session. Idempotency record never lands —
+        //   so on retry the runner gets a fresh attempt instead of a memoized
+        //   half-state response.
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("simulated plan-generation failure*");
+
+        idempotency.DidNotReceiveWithAnyArgs()
+            .Record<OnboardingTurnResponseDto>(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<OnboardingTurnResponseDto>());
+
+        // The handler never calls SaveChangesAsync directly — the framework's
+        // transactional middleware owns that call. The negative-assertion proof
+        // is that the staged `Record` write was never made.
+        await session.DidNotReceiveWithAnyArgs().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    private static OnboardingTurnOutput BuildReadyForPlanOutput() => new()
+    {
+        Reply = [new AnthropicContentBlock { Type = AnthropicContentBlockType.Text, Text = "all set" }],
+        Extracted = null,
+        NeedsClarification = false,
+        ClarificationReason = null,
+        ReadyForPlan = true,
+    };
+
+    private static OnboardingView BuildFullView(Guid userId) => new()
+    {
+        Id = userId,
+        UserId = userId,
+        Status = OnboardingStatus.InProgress,
+        PrimaryGoal = new PrimaryGoalAnswer { Goal = PrimaryGoal.GeneralFitness, Description = "fitness" },
+        TargetEvent = null,
+        CurrentFitness = new CurrentFitnessAnswer
+        {
+            TypicalWeeklyKm = 30,
+            LongestRecentRunKm = 12,
+            RecentRaceDistanceKm = null,
+            RecentRaceTimeIso = null,
+            Description = "moderate",
+        },
+        WeeklySchedule = new WeeklyScheduleAnswer
+        {
+            MaxRunDaysPerWeek = 4,
+            TypicalSessionMinutes = 45,
+            Monday = true,
+            Tuesday = false,
+            Wednesday = true,
+            Thursday = false,
+            Friday = true,
+            Saturday = false,
+            Sunday = true,
+            Description = "evenings",
+        },
+        InjuryHistory = new InjuryHistoryAnswer
+        {
+            HasActiveInjury = false,
+            ActiveInjuryDescription = string.Empty,
+            PastInjurySummary = "none",
+        },
+        Preferences = new PreferencesAnswer
+        {
+            PreferredUnits = PreferredUnits.Kilometers,
+            PreferTrail = false,
+            ComfortableWithIntensity = true,
+            Description = "ok",
+        },
+        OutstandingClarifications = [],
+    };
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/InvokeAsyncTransactionScopeTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/InvokeAsyncTransactionScopeTests.cs
@@ -28,20 +28,22 @@ namespace RunCoach.Api.Tests.Modules.Coaching.Onboarding;
 /// This is the unit-level guarantee: the handler itself never calls
 /// <c>SaveChangesAsync</c>, so when <see cref="IPlanGenerationService.GeneratePlanAsync"/>
 /// throws, the in-flight session has every appended event still pending and
-/// the framework will discard them. The companion integration test
-/// (<c>OnboardingFlowIntegrationTests</c>) drives a full HTTP request through
-/// the live Marten + Wolverine stack to confirm the rollback observably leaves
-/// no Plan stream and no <c>OnboardingCompleted</c> event in the database.
+/// the framework will discard them. End-to-end rollback through the live
+/// Wolverine + Marten stack (i.e. an HTTP-driven proof that no Plan stream
+/// and no <c>OnboardingCompleted</c> event end up in the database after a
+/// terminal-branch failure) is intentionally NOT covered yet — the companion
+/// integration tests for that path are deferred to a follow-up PR.
 /// </para>
 /// <para>
 /// Per DEC-060 / R-069 the dual-write atomicity claim — that exactly one
 /// Postgres transaction (and one <c>backend_xid</c>) covers the entire handler
 /// — is upheld by Marten's <c>UseEntityFrameworkCoreTransactionParticipant</c>
-/// wiring established in <c>MartenConfiguration</c>. That single-transaction
-/// property is asserted via the framework-level test
-/// <c>UserProfileFromOnboardingProjection</c> integration coverage rather
-/// than a separate <c>pg_stat_activity.backend_xid</c> observer probe; the
-/// observer probe is deferred per the cw-execute proof file.
+/// wiring established in <c>MartenConfiguration</c>. The
+/// <c>pg_stat_activity.backend_xid</c> observer probe required by spec 13
+/// § Unit 1 verification line 114 is also deferred — when added it will
+/// assert exactly one distinct backend_xid across the handler run. Until
+/// those tests land, this unit test plus the framework-level transaction
+/// participant wiring are the load-bearing guarantees.
 /// </para>
 /// </remarks>
 public class InvokeAsyncTransactionScopeTests

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/InvokeAsyncTransactionScopeTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/InvokeAsyncTransactionScopeTests.cs
@@ -5,8 +5,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using RunCoach.Api.Infrastructure.Idempotency;
 using RunCoach.Api.Modules.Coaching;
-using RunCoach.Api.Modules.Coaching.Idempotency;
 using RunCoach.Api.Modules.Coaching.Models;
 using RunCoach.Api.Modules.Coaching.Onboarding;
 using RunCoach.Api.Modules.Coaching.Onboarding.Models;
@@ -117,7 +117,7 @@ public class InvokeAsyncTransactionScopeTests
             .WithMessage("simulated plan-generation failure*");
 
         idempotency.DidNotReceiveWithAnyArgs()
-            .Record<OnboardingTurnResponseDto>(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<OnboardingTurnResponseDto>());
+            .Record<OnboardingTurnResponseDto>(Arg.Any<Guid>(), Arg.Any<OnboardingTurnResponseDto>());
 
         // The handler never calls SaveChangesAsync directly — the framework's
         // transactional middleware owns that call. The negative-assertion proof

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/Models/OnboardingProgressDtoTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/Models/OnboardingProgressDtoTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Onboarding.Models;
+
+/// <summary>
+/// Unit tests for <see cref="OnboardingProgressDto"/> construction-time
+/// validation. The record makes invalid <c>(completed, total)</c> pairs
+/// unrepresentable so the chat UI's progress ratio never collapses to NaN
+/// or a negative value.
+/// </summary>
+public sealed class OnboardingProgressDtoTests
+{
+    [Theory]
+    [InlineData(0, 5)]
+    [InlineData(3, 5)]
+    [InlineData(5, 5)]
+    [InlineData(6, 6)]
+    public void Construction_AcceptsValidPairs(int completed, int total)
+    {
+        // Act
+        var actual = new OnboardingProgressDto(completed, total);
+
+        // Assert
+        actual.CompletedTopics.Should().Be(completed);
+        actual.TotalTopics.Should().Be(total);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Construction_RejectsTotalBelowOne(int total)
+    {
+        // Act
+        var act = () => new OnboardingProgressDto(0, total);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("totalTopics");
+    }
+
+    [Fact]
+    public void Construction_RejectsNegativeCompleted()
+    {
+        // Act
+        var act = () => new OnboardingProgressDto(-1, 5);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("completedTopics");
+    }
+
+    [Theory]
+    [InlineData(6, 5)]
+    [InlineData(10, 5)]
+    public void Construction_RejectsCompletedExceedingTotal(int completed, int total)
+    {
+        // Act
+        var act = () => new OnboardingProgressDto(completed, total);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("completedTopics");
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/Models/OnboardingTurnResponseDtoTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/Models/OnboardingTurnResponseDtoTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Onboarding.Models;
+
+/// <summary>
+/// Unit tests for the <see cref="OnboardingTurnResponseDto"/> static
+/// factories that encode the discriminator invariants the positional record
+/// cannot enforce on its own.
+/// </summary>
+public sealed class OnboardingTurnResponseDtoTests
+{
+    private static readonly OnboardingProgressDto SampleProgress = new(0, 5);
+
+    [Fact]
+    public void Ask_ConstructsValidAskResponse()
+    {
+        // Arrange
+        var blocks = JsonSerializer.SerializeToElement(new[] { new { type = "text", text = "hi" } });
+
+        // Act
+        var actual = OnboardingTurnResponseDto.Ask(
+            assistantBlocks: blocks,
+            topic: OnboardingTopic.PrimaryGoal,
+            suggestedInputType: SuggestedInputType.SingleSelect,
+            progress: SampleProgress);
+
+        // Assert
+        actual.Kind.Should().Be(OnboardingTurnKind.Ask);
+        actual.Topic.Should().Be(OnboardingTopic.PrimaryGoal);
+        actual.SuggestedInputType.Should().Be(SuggestedInputType.SingleSelect);
+        actual.Progress.Should().Be(SampleProgress);
+        actual.PlanId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Ask_NullProgress_Throws()
+    {
+        // Arrange
+        var blocks = JsonSerializer.SerializeToElement(Array.Empty<object>());
+
+        // Act
+        var act = () => OnboardingTurnResponseDto.Ask(
+            assistantBlocks: blocks,
+            topic: OnboardingTopic.PrimaryGoal,
+            suggestedInputType: SuggestedInputType.SingleSelect,
+            progress: null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("progress");
+    }
+
+    [Fact]
+    public void Complete_ConstructsValidCompleteResponse()
+    {
+        // Arrange
+        var blocks = JsonSerializer.SerializeToElement(new[] { new { type = "text", text = "all done" } });
+        var planId = Guid.Parse("99999999-1111-2222-3333-444444444444");
+
+        // Act
+        var actual = OnboardingTurnResponseDto.Complete(
+            assistantBlocks: blocks,
+            progress: SampleProgress,
+            planId: planId);
+
+        // Assert
+        actual.Kind.Should().Be(OnboardingTurnKind.Complete);
+        actual.Topic.Should().BeNull();
+        actual.SuggestedInputType.Should().BeNull();
+        actual.Progress.Should().Be(SampleProgress);
+        actual.PlanId.Should().Be(planId);
+    }
+
+    [Fact]
+    public void Complete_NullProgress_Throws()
+    {
+        // Arrange
+        var blocks = JsonSerializer.SerializeToElement(Array.Empty<object>());
+
+        // Act
+        var act = () => OnboardingTurnResponseDto.Complete(
+            assistantBlocks: blocks,
+            progress: null!,
+            planId: Guid.NewGuid());
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("progress");
+    }
+
+    [Fact]
+    public void Complete_EmptyPlanId_Throws()
+    {
+        // Arrange
+        var blocks = JsonSerializer.SerializeToElement(Array.Empty<object>());
+
+        // Act
+        var act = () => OnboardingTurnResponseDto.Complete(
+            assistantBlocks: blocks,
+            progress: SampleProgress,
+            planId: Guid.Empty);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithParameterName("planId");
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingCompletionGateTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingCompletionGateTests.cs
@@ -1,0 +1,229 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Pure-function unit tests for <see cref="OnboardingCompletionGate"/> per
+/// Slice 1 § Unit 1 R01.6 / completion-gate Gherkin scenarios. Covers the
+/// race-training / non-race-training branch, missing-slot rejection, and the
+/// outstanding-clarification veto.
+/// </summary>
+public class OnboardingCompletionGateTests
+{
+    [Fact]
+    public void IsSatisfied_Returns_False_When_PrimaryGoal_Is_Null()
+    {
+        // Arrange
+        var view = new OnboardingView { Status = OnboardingStatus.InProgress };
+
+        // Act
+        var actual = OnboardingCompletionGate.IsSatisfied(view);
+
+        // Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSatisfied_Returns_False_When_PrimaryGoal_Is_RaceTraining_But_TargetEvent_Is_Null()
+    {
+        // Arrange
+        var view = BuildFullView(PrimaryGoal.RaceTraining);
+        view.TargetEvent = null;
+
+        // Act
+        var actual = OnboardingCompletionGate.IsSatisfied(view);
+
+        // Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSatisfied_Returns_True_When_PrimaryGoal_Is_GeneralFitness_And_TargetEvent_Is_Null()
+    {
+        // Arrange — TargetEvent is N/A when goal is not race training.
+        var view = BuildFullView(PrimaryGoal.GeneralFitness);
+        view.TargetEvent = null;
+
+        // Act
+        var actual = OnboardingCompletionGate.IsSatisfied(view);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSatisfied_Returns_False_When_OutstandingClarifications_Is_NonEmpty()
+    {
+        // Arrange
+        var view = BuildFullView(PrimaryGoal.GeneralFitness);
+        view.OutstandingClarifications = [OnboardingTopic.CurrentFitness];
+
+        // Act
+        var actual = OnboardingCompletionGate.IsSatisfied(view);
+
+        // Assert
+        actual.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(PrimaryGoal.RaceTraining)]
+    [InlineData(PrimaryGoal.GeneralFitness)]
+    [InlineData(PrimaryGoal.ReturnToRunning)]
+    [InlineData(PrimaryGoal.BuildVolume)]
+    [InlineData(PrimaryGoal.BuildSpeed)]
+    public void IsSatisfied_Returns_True_When_All_Slots_Filled_And_No_Outstanding_Clarifications(PrimaryGoal goal)
+    {
+        // Arrange
+        var view = BuildFullView(goal);
+
+        // Act
+        var actual = OnboardingCompletionGate.IsSatisfied(view);
+
+        // Assert
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void NextTopic_Returns_PrimaryGoal_For_Empty_View()
+    {
+        // Arrange
+        var view = new OnboardingView();
+
+        // Act
+        var actual = OnboardingCompletionGate.NextTopic(view);
+
+        // Assert
+        actual.Should().Be(OnboardingTopic.PrimaryGoal);
+    }
+
+    [Fact]
+    public void NextTopic_Skips_TargetEvent_When_PrimaryGoal_Is_Not_RaceTraining()
+    {
+        // Arrange
+        var view = new OnboardingView
+        {
+            PrimaryGoal = new PrimaryGoalAnswer { Goal = PrimaryGoal.GeneralFitness, Description = "fitness" },
+        };
+
+        // Act
+        var actual = OnboardingCompletionGate.NextTopic(view);
+
+        // Assert
+        actual.Should().Be(OnboardingTopic.CurrentFitness);
+    }
+
+    [Fact]
+    public void NextTopic_Returns_TargetEvent_When_PrimaryGoal_Is_RaceTraining()
+    {
+        // Arrange
+        var view = new OnboardingView
+        {
+            PrimaryGoal = new PrimaryGoalAnswer { Goal = PrimaryGoal.RaceTraining, Description = "race" },
+        };
+
+        // Act
+        var actual = OnboardingCompletionGate.NextTopic(view);
+
+        // Assert
+        actual.Should().Be(OnboardingTopic.TargetEvent);
+    }
+
+    [Fact]
+    public void NextTopic_Returns_Null_When_All_Slots_Filled()
+    {
+        // Arrange
+        var view = BuildFullView(PrimaryGoal.GeneralFitness);
+
+        // Act
+        var actual = OnboardingCompletionGate.NextTopic(view);
+
+        // Assert
+        actual.Should().BeNull();
+    }
+
+    [Fact]
+    public void Progress_Reports_Five_Total_For_Non_RaceTraining()
+    {
+        // Arrange
+        var view = new OnboardingView
+        {
+            PrimaryGoal = new PrimaryGoalAnswer { Goal = PrimaryGoal.GeneralFitness, Description = "fitness" },
+        };
+
+        // Act
+        var (completed, total) = OnboardingCompletionGate.Progress(view);
+
+        // Assert
+        completed.Should().Be(1);
+        total.Should().Be(5);
+    }
+
+    [Fact]
+    public void Progress_Reports_Six_Total_For_RaceTraining()
+    {
+        // Arrange
+        var view = new OnboardingView
+        {
+            PrimaryGoal = new PrimaryGoalAnswer { Goal = PrimaryGoal.RaceTraining, Description = "race" },
+        };
+
+        // Act
+        var (completed, total) = OnboardingCompletionGate.Progress(view);
+
+        // Assert
+        completed.Should().Be(1);
+        total.Should().Be(6);
+    }
+
+    private static OnboardingView BuildFullView(PrimaryGoal goal) => new()
+    {
+        Status = OnboardingStatus.InProgress,
+        PrimaryGoal = new PrimaryGoalAnswer { Goal = goal, Description = "stub" },
+        TargetEvent = goal == PrimaryGoal.RaceTraining
+            ? new TargetEventAnswer
+            {
+                EventName = "Test 10K",
+                DistanceKm = 10,
+                EventDateIso = "2026-12-01",
+                TargetFinishTimeIso = null,
+            }
+            : null,
+        CurrentFitness = new CurrentFitnessAnswer
+        {
+            TypicalWeeklyKm = 30,
+            LongestRecentRunKm = 12,
+            RecentRaceDistanceKm = null,
+            RecentRaceTimeIso = null,
+            Description = "moderate",
+        },
+        WeeklySchedule = new WeeklyScheduleAnswer
+        {
+            MaxRunDaysPerWeek = 4,
+            TypicalSessionMinutes = 45,
+            Monday = true,
+            Tuesday = false,
+            Wednesday = true,
+            Thursday = false,
+            Friday = true,
+            Saturday = false,
+            Sunday = true,
+            Description = "evenings only",
+        },
+        InjuryHistory = new InjuryHistoryAnswer
+        {
+            HasActiveInjury = false,
+            ActiveInjuryDescription = string.Empty,
+            PastInjurySummary = "none",
+        },
+        Preferences = new PreferencesAnswer
+        {
+            PreferredUnits = PreferredUnits.Kilometers,
+            PreferTrail = false,
+            ComfortableWithIntensity = true,
+            Description = "ok",
+        },
+        OutstandingClarifications = [],
+    };
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingControllerIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingControllerIntegrationTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -10,14 +9,14 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using RunCoach.Api.Infrastructure;
-using RunCoach.Api.Modules.Coaching;
 using RunCoach.Api.Modules.Coaching.Models;
 using RunCoach.Api.Modules.Coaching.Onboarding;
 using RunCoach.Api.Modules.Coaching.Onboarding.Models;
-using RunCoach.Api.Modules.Coaching.Sanitization;
 using RunCoach.Api.Modules.Identity.Contracts;
 using RunCoach.Api.Tests.Infrastructure;
+using Wolverine;
 
 namespace RunCoach.Api.Tests.Modules.Coaching.Onboarding;
 
@@ -62,45 +61,29 @@ public class OnboardingControllerIntegrationTests(RunCoachAppFactory factory)
 
     /// <summary>
     /// Authenticated with cookie + valid request → 200 with OnboardingTurnResponseDto.
-    /// ICoachingLlm is replaced with a stub that returns a predictable Ask response
-    /// so the test is deterministic and never calls the real Anthropic API.
+    /// IMessageBus is stubbed to short-circuit the Wolverine handler chain so the
+    /// integration test stays focused on the controller's mapping behaviour and
+    /// never calls the real Anthropic API. Handler-side coverage is owned by
+    /// OnboardingTurnHandlerUnitTests + InvokeAsyncTransactionScopeTests.
     /// </summary>
     [Fact]
     public async Task SubmitTurn_Authenticated_Returns_200_With_ResponseDto()
     {
-        // Arrange — stub the LLM so we never call the real Anthropic API.
-        var llmStub = Substitute.For<ICoachingLlm>();
-        llmStub
-            .GenerateStructuredAsync<OnboardingTurnOutput>(
+        // Arrange — stub the bus to return a deterministic Ask response.
+        var expected = BuildAskResponseDto();
+        var busStub = Substitute.For<IMessageBus>();
+        busStub
+            .InvokeForTenantAsync<OnboardingTurnResponseDto>(
                 Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<IReadOnlyDictionary<string, JsonElement>>(),
-                Arg.Any<CacheControl?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(BuildAskOutput());
-
-        var assemblerStub = Substitute.For<IContextAssembler>();
-        assemblerStub
-            .ComposeForOnboardingAsync(
-                Arg.Any<OnboardingView>(),
-                Arg.Any<OnboardingTopic>(),
-                Arg.Any<string>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new OnboardingPromptComposition(
-                SystemPrompt: "sys",
-                UserMessage: "user",
-                Findings: ImmutableArray<SanitizationFinding>.Empty,
-                Neutralized: false));
+                Arg.Any<object>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<TimeSpan?>())
+            .Returns(expected);
 
         using var customFactory = Factory.WithWebHostBuilder(b =>
-            b.ConfigureTestServices(svc =>
-            {
-                svc.AddSingleton(llmStub);
-                svc.AddSingleton(assemblerStub);
-            }));
+            b.ConfigureTestServices(svc => svc.AddSingleton(busStub)));
         var (client, container) = CreateCookieClient(customFactory);
 
-        // Register + login (userId not needed for this test)
         var email = GenerateEmail();
         await RegisterAsync(client, container, email, StrongPassword);
         await LoginAsync(client, container, email, StrongPassword);
@@ -121,60 +104,28 @@ public class OnboardingControllerIntegrationTests(RunCoachAppFactory factory)
     }
 
     /// <summary>
-    /// Already-complete stream → 409 with the onboarding-already-complete
-    /// ProblemDetails type.
+    /// Already-complete stream — bus throws OnboardingAlreadyCompleteException;
+    /// controller maps it to 409 ProblemDetails with the documented type URI.
     /// </summary>
     [Fact]
     public async Task SubmitTurn_AlreadyCompleteStream_Returns_409_ProblemDetails()
     {
-        // Arrange — stub LLM to prevent real API calls.
-        var llmStub = Substitute.For<ICoachingLlm>();
-        llmStub
-            .GenerateStructuredAsync<OnboardingTurnOutput>(
+        // Arrange — stub the bus to surface the contract exception.
+        var busStub = Substitute.For<IMessageBus>();
+        busStub
+            .InvokeForTenantAsync<OnboardingTurnResponseDto>(
                 Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<IReadOnlyDictionary<string, JsonElement>>(),
-                Arg.Any<CacheControl?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(BuildAskOutput());
-
-        var assemblerStub = Substitute.For<IContextAssembler>();
-        assemblerStub
-            .ComposeForOnboardingAsync(
-                Arg.Any<OnboardingView>(),
-                Arg.Any<OnboardingTopic>(),
-                Arg.Any<string>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new OnboardingPromptComposition(
-                SystemPrompt: "sys",
-                UserMessage: "user",
-                Findings: ImmutableArray<SanitizationFinding>.Empty,
-                Neutralized: false));
+                Arg.Any<object>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<TimeSpan?>())
+            .Throws(new OnboardingAlreadyCompleteException(Guid.NewGuid()));
 
         using var customFactory = Factory.WithWebHostBuilder(b =>
-            b.ConfigureTestServices(svc =>
-            {
-                svc.AddSingleton(llmStub);
-                svc.AddSingleton(assemblerStub);
-            }));
+            b.ConfigureTestServices(svc => svc.AddSingleton(busStub)));
         var (client, container) = CreateCookieClient(customFactory);
         var email = GenerateEmail();
-        var userId = await RegisterAsync(client, container, email, StrongPassword);
+        await RegisterAsync(client, container, email, StrongPassword);
         await LoginAsync(client, container, email, StrongPassword);
-
-        // Seed an OnboardingCompleted event directly onto the user's stream so
-        // the handler sees a terminal stream and throws
-        // OnboardingAlreadyCompleteException.
-        var now = DateTimeOffset.UtcNow;
-        var store = customFactory.Services.GetRequiredService<IDocumentStore>();
-        await using (var seedSession = store.LightweightSession(userId.ToString()))
-        {
-            seedSession.Events.StartStream<OnboardingView>(
-                userId,
-                new OnboardingStarted(userId, now));
-            seedSession.Events.Append(userId, new OnboardingCompleted(Guid.NewGuid(), now));
-            await seedSession.SaveChangesAsync(TestContext.Current.CancellationToken);
-        }
 
         var token = await PrimeAntiforgeryAsync(client, container);
 
@@ -468,19 +419,20 @@ public class OnboardingControllerIntegrationTests(RunCoachAppFactory factory)
     private static string GenerateEmail() =>
         $"user-{Guid.NewGuid():N}@example.test";
 
-    private static OnboardingTurnOutput BuildAskOutput() => new()
-    {
-        Reply =
-        [
-            new AnthropicContentBlock
-            {
-                Type = AnthropicContentBlockType.Text,
-                Text = "What is your primary training goal?",
-            },
-        ],
-        Extracted = null,
-        NeedsClarification = false,
-        ClarificationReason = null,
-        ReadyForPlan = false,
-    };
+    private static OnboardingTurnResponseDto BuildAskResponseDto() =>
+        new(
+            Kind: OnboardingTurnKind.Ask,
+            AssistantBlocks: JsonSerializer.SerializeToElement(
+                new[]
+                {
+                    new AnthropicContentBlock
+                    {
+                        Type = AnthropicContentBlockType.Text,
+                        Text = "What is your primary training goal?",
+                    },
+                }),
+            Topic: OnboardingTopic.PrimaryGoal,
+            SuggestedInputType: SuggestedInputType.SingleSelect,
+            Progress: new OnboardingProgressDto(0, 5),
+            PlanId: null);
 }

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingControllerIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingControllerIntegrationTests.cs
@@ -1,0 +1,480 @@
+using System.Collections.Immutable;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Marten;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using RunCoach.Api.Infrastructure;
+using RunCoach.Api.Modules.Coaching;
+using RunCoach.Api.Modules.Coaching.Models;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+using RunCoach.Api.Modules.Coaching.Sanitization;
+using RunCoach.Api.Modules.Identity.Contracts;
+using RunCoach.Api.Tests.Infrastructure;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Integration matrix for the three Slice 1a6 onboarding endpoints
+/// (<c>/turns</c>, <c>/state</c>, <c>/answers/revise</c>) against the
+/// shared Testcontainers Postgres.
+/// </summary>
+[Trait("Category", "Integration")]
+public class OnboardingControllerIntegrationTests(RunCoachAppFactory factory)
+    : DbBackedIntegrationTestBase(factory)
+{
+    private const string StrongPassword = "Str0ngTestPassw0rd!";
+    private const string AlreadyCompleteType = "https://runcoach.app/problems/onboarding-already-complete";
+    private const string AntiforgeryCookieName = AuthCookieNames.Antiforgery;
+    private const string AntiforgeryRequestCookieName = AuthCookieNames.AntiforgeryRequest;
+    private const string AntiforgeryHeaderName = AuthCookieNames.AntiforgeryHeader;
+
+    private static readonly Uri BaseUri = new("https://localhost");
+
+    // ------------------------------------------------------------------ //
+    // POST /api/v1/onboarding/turns
+    // ------------------------------------------------------------------ //
+
+    /// <summary>Anonymous → 401 on the SubmitTurn endpoint.</summary>
+    [Fact]
+    public async Task SubmitTurn_Anonymous_Returns_401()
+    {
+        // Arrange
+        var (client, _) = CreateCookieClient(Factory);
+
+        // Act — no session cookie; the policy denies before antiforgery is checked
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/onboarding/turns")
+        {
+            Content = JsonContent.Create(new OnboardingTurnRequestDto(Guid.NewGuid(), "hello")),
+        };
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    /// <summary>
+    /// Authenticated with cookie + valid request → 200 with OnboardingTurnResponseDto.
+    /// ICoachingLlm is replaced with a stub that returns a predictable Ask response
+    /// so the test is deterministic and never calls the real Anthropic API.
+    /// </summary>
+    [Fact]
+    public async Task SubmitTurn_Authenticated_Returns_200_With_ResponseDto()
+    {
+        // Arrange — stub the LLM so we never call the real Anthropic API.
+        var llmStub = Substitute.For<ICoachingLlm>();
+        llmStub
+            .GenerateStructuredAsync<OnboardingTurnOutput>(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, JsonElement>>(),
+                Arg.Any<CacheControl?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(BuildAskOutput());
+
+        var assemblerStub = Substitute.For<IContextAssembler>();
+        assemblerStub
+            .ComposeForOnboardingAsync(
+                Arg.Any<OnboardingView>(),
+                Arg.Any<OnboardingTopic>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new OnboardingPromptComposition(
+                SystemPrompt: "sys",
+                UserMessage: "user",
+                Findings: ImmutableArray<SanitizationFinding>.Empty,
+                Neutralized: false));
+
+        using var customFactory = Factory.WithWebHostBuilder(b =>
+            b.ConfigureTestServices(svc =>
+            {
+                svc.AddSingleton(llmStub);
+                svc.AddSingleton(assemblerStub);
+            }));
+        var (client, container) = CreateCookieClient(customFactory);
+
+        // Register + login (userId not needed for this test)
+        await RegisterAsync(client, container, GenerateEmail(), StrongPassword);
+        var token = await PrimeAntiforgeryAsync(client, container);
+
+        // Act
+        using var request = BuildRequest(HttpMethod.Post, "/api/v1/onboarding/turns", token);
+        request.Content = JsonContent.Create(new OnboardingTurnRequestDto(Guid.NewGuid(), "I want to run a 5k"));
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<OnboardingTurnResponseDto>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        dto.Should().NotBeNull();
+        dto!.Kind.Should().Be(OnboardingTurnKind.Ask);
+        dto.Progress.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// Already-complete stream → 409 with the onboarding-already-complete
+    /// ProblemDetails type.
+    /// </summary>
+    [Fact]
+    public async Task SubmitTurn_AlreadyCompleteStream_Returns_409_ProblemDetails()
+    {
+        // Arrange — stub LLM to prevent real API calls.
+        var llmStub = Substitute.For<ICoachingLlm>();
+        llmStub
+            .GenerateStructuredAsync<OnboardingTurnOutput>(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, JsonElement>>(),
+                Arg.Any<CacheControl?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(BuildAskOutput());
+
+        var assemblerStub = Substitute.For<IContextAssembler>();
+        assemblerStub
+            .ComposeForOnboardingAsync(
+                Arg.Any<OnboardingView>(),
+                Arg.Any<OnboardingTopic>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new OnboardingPromptComposition(
+                SystemPrompt: "sys",
+                UserMessage: "user",
+                Findings: ImmutableArray<SanitizationFinding>.Empty,
+                Neutralized: false));
+
+        using var customFactory = Factory.WithWebHostBuilder(b =>
+            b.ConfigureTestServices(svc =>
+            {
+                svc.AddSingleton(llmStub);
+                svc.AddSingleton(assemblerStub);
+            }));
+        var (client, container) = CreateCookieClient(customFactory);
+        var email = GenerateEmail();
+        var userId = await RegisterAsync(client, container, email, StrongPassword);
+        await LoginAsync(client, container, email, StrongPassword);
+
+        // Seed an OnboardingCompleted event directly onto the user's stream so
+        // the handler sees a terminal stream and throws
+        // OnboardingAlreadyCompleteException.
+        var now = DateTimeOffset.UtcNow;
+        var store = customFactory.Services.GetRequiredService<IDocumentStore>();
+        await using (var seedSession = store.LightweightSession(userId.ToString()))
+        {
+            seedSession.Events.StartStream<OnboardingView>(
+                userId,
+                new OnboardingStarted(userId, now));
+            seedSession.Events.Append(userId, new OnboardingCompleted(Guid.NewGuid(), now));
+            await seedSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var token = await PrimeAntiforgeryAsync(client, container);
+
+        // Act
+        using var request = BuildRequest(HttpMethod.Post, "/api/v1/onboarding/turns", token);
+        request.Content = JsonContent.Create(new OnboardingTurnRequestDto(Guid.NewGuid(), "another turn"));
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        problem.Should().NotBeNull();
+        problem!.Status.Should().Be(StatusCodes.Status409Conflict);
+        problem.Type.Should().Be(AlreadyCompleteType);
+    }
+
+    // ------------------------------------------------------------------ //
+    // GET /api/v1/onboarding/state
+    // ------------------------------------------------------------------ //
+
+    /// <summary>Anonymous → 401 on the GetState endpoint.</summary>
+    [Fact]
+    public async Task GetState_Anonymous_Returns_401()
+    {
+        // Arrange
+        var (client, _) = CreateCookieClient(Factory);
+
+        // Act
+        var response = await client.GetAsync(
+            "/api/v1/onboarding/state",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    /// <summary>
+    /// Authenticated, no stream yet → 404 because the inline projection
+    /// has no document for this user.
+    /// </summary>
+    [Fact]
+    public async Task GetState_Authenticated_NoStream_Returns_404()
+    {
+        // Arrange
+        var (client, container) = CreateCookieClient(Factory);
+        await RegisterAsync(client, container, GenerateEmail(), StrongPassword);
+
+        // Act
+        var response = await client.GetAsync(
+            "/api/v1/onboarding/state",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    /// <summary>
+    /// Authenticated with a seeded stream → 200 with a populated
+    /// <see cref="OnboardingStateDto"/>.
+    /// </summary>
+    [Fact]
+    public async Task GetState_Authenticated_SeededStream_Returns_200_With_StateDto()
+    {
+        // Arrange
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        var userId = await RegisterAsync(client, container, email, StrongPassword);
+        await LoginAsync(client, container, email, StrongPassword);
+
+        var now = DateTimeOffset.UtcNow;
+        var store = Factory.Services.GetRequiredService<IDocumentStore>();
+        await using (var seedSession = store.LightweightSession(userId.ToString()))
+        {
+            seedSession.Events.StartStream<OnboardingView>(
+                userId,
+                new OnboardingStarted(userId, now));
+            seedSession.Events.Append(userId, new TopicAsked(OnboardingTopic.PrimaryGoal, now));
+            await seedSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // Act
+        var response = await client.GetAsync(
+            "/api/v1/onboarding/state",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<OnboardingStateDto>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        dto.Should().NotBeNull();
+        dto!.UserId.Should().Be(userId);
+        dto.Status.Should().Be(OnboardingStatus.InProgress);
+        dto.CompletedTopics.Should().Be(0);
+        dto.TotalTopics.Should().BeGreaterThan(0);
+        dto.IsComplete.Should().BeFalse();
+        dto.OutstandingClarifications.Should().NotBeNull();
+    }
+
+    // ------------------------------------------------------------------ //
+    // POST /api/v1/onboarding/answers/revise
+    // ------------------------------------------------------------------ //
+
+    /// <summary>Anonymous → 401 on the ReviseAnswer endpoint.</summary>
+    [Fact]
+    public async Task ReviseAnswer_Anonymous_Returns_401()
+    {
+        // Arrange
+        var (client, _) = CreateCookieClient(Factory);
+
+        // Act
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/onboarding/answers/revise")
+        {
+            Content = JsonContent.Create(
+                new ReviseAnswerRequestDto(
+                    OnboardingTopic.PrimaryGoal,
+                    JsonSerializer.SerializeToElement(
+                        new PrimaryGoalAnswer { Goal = PrimaryGoal.GeneralFitness, Description = "test" }))),
+        };
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    /// <summary>
+    /// Authenticated but no stream exists → 404 because the onboarding
+    /// projection document is absent.
+    /// </summary>
+    [Fact]
+    public async Task ReviseAnswer_Authenticated_NoStream_Returns_404()
+    {
+        // Arrange
+        var (client, container) = CreateCookieClient(Factory);
+        await RegisterAsync(client, container, GenerateEmail(), StrongPassword);
+        var token = await PrimeAntiforgeryAsync(client, container);
+
+        // Act
+        using var request = BuildRequest(
+            HttpMethod.Post, "/api/v1/onboarding/answers/revise", token);
+        request.Content = JsonContent.Create(
+            new ReviseAnswerRequestDto(
+                OnboardingTopic.PrimaryGoal,
+                JsonSerializer.SerializeToElement(
+                    new PrimaryGoalAnswer { Goal = PrimaryGoal.GeneralFitness, Description = "revised" })));
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    /// <summary>
+    /// Authenticated with a seeded stream → 200 with updated
+    /// <see cref="OnboardingStateDto"/>. Checks that the returned DTO
+    /// carries the revised PrimaryGoal answer.
+    /// </summary>
+    [Fact]
+    public async Task ReviseAnswer_Authenticated_SeededStream_Returns_200_With_UpdatedDto()
+    {
+        // Arrange
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        var userId = await RegisterAsync(client, container, email, StrongPassword);
+        await LoginAsync(client, container, email, StrongPassword);
+
+        var now = DateTimeOffset.UtcNow;
+        var store = Factory.Services.GetRequiredService<IDocumentStore>();
+        await using (var seedSession = store.LightweightSession(userId.ToString()))
+        {
+            seedSession.Events.StartStream<OnboardingView>(
+                userId,
+                new OnboardingStarted(userId, now));
+            seedSession.Events.Append(userId, new TopicAsked(OnboardingTopic.PrimaryGoal, now));
+            await seedSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var token = await PrimeAntiforgeryAsync(client, container);
+        var revisedAnswer = new PrimaryGoalAnswer { Goal = PrimaryGoal.BuildSpeed, Description = "speed" };
+
+        // Act
+        using var request = BuildRequest(
+            HttpMethod.Post, "/api/v1/onboarding/answers/revise", token);
+        request.Content = JsonContent.Create(
+            new ReviseAnswerRequestDto(
+                OnboardingTopic.PrimaryGoal,
+                JsonSerializer.SerializeToElement(revisedAnswer)));
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<OnboardingStateDto>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        dto.Should().NotBeNull();
+        dto!.UserId.Should().Be(userId);
+        dto.PrimaryGoal.Should().NotBeNull("the revised PrimaryGoal answer must be reflected in the returned DTO");
+        dto.PrimaryGoal!.Goal.Should().Be(PrimaryGoal.BuildSpeed);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Helpers
+    // ------------------------------------------------------------------ //
+    private static (HttpClient Client, CookieContainer Container) CreateCookieClient(
+        Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program> factory)
+    {
+        var container = new System.Net.CookieContainer();
+        var client = factory.CreateDefaultClient(
+            new Infrastructure.CookieContainerHandler(container));
+        client.BaseAddress = BaseUri;
+        client.DefaultRequestHeaders.Accept.Add(
+            new MediaTypeWithQualityHeaderValue("application/json"));
+        return (client, container);
+    }
+
+    private static HttpRequestMessage BuildRequest(
+        HttpMethod method, string path, string antiforgeryToken)
+    {
+        var request = new HttpRequestMessage(method, path);
+        request.Headers.Add(AntiforgeryHeaderName, antiforgeryToken);
+        return request;
+    }
+
+    private static async Task<string> PrimeAntiforgeryAsync(
+        HttpClient client, System.Net.CookieContainer container)
+    {
+        using var response = await client.GetAsync(
+            "/api/v1/auth/xsrf",
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        var requestCookie = GetCookie(container, AntiforgeryRequestCookieName);
+        requestCookie.Should().NotBeNull("/xsrf must issue the SPA-readable request token cookie");
+        GetCookie(container, AntiforgeryCookieName).Should().NotBeNull(
+            "the framework antiforgery cookie must also be set");
+        return requestCookie!.Value;
+    }
+
+    private static async Task<Guid> RegisterAsync(
+        HttpClient client,
+        System.Net.CookieContainer container,
+        string email,
+        string password)
+    {
+        var token = await PrimeAntiforgeryAsync(client, container);
+        using var request = BuildRequest(HttpMethod.Post, "/api/v1/auth/register", token);
+        request.Content = JsonContent.Create(new RegisterRequestDto(email, password));
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+        response.StatusCode.Should()
+            .Be(
+                HttpStatusCode.Created,
+                because: $"register helper must succeed — got {(int)response.StatusCode}");
+        var body = await response.Content.ReadFromJsonAsync<AuthResponseDto>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        body.Should().NotBeNull();
+        return body!.UserId;
+    }
+
+    private static async Task LoginAsync(
+        HttpClient client,
+        System.Net.CookieContainer container,
+        string email,
+        string password)
+    {
+        var token = await PrimeAntiforgeryAsync(client, container);
+        using var request = BuildRequest(HttpMethod.Post, "/api/v1/auth/login", token);
+        request.Content = JsonContent.Create(new LoginRequestDto(email, password));
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+        response.StatusCode.Should()
+            .Be(
+                HttpStatusCode.OK,
+                because: $"login helper must succeed — got {(int)response.StatusCode}");
+    }
+
+    private static System.Net.Cookie? GetCookie(
+        System.Net.CookieContainer container, string name)
+    {
+        foreach (System.Net.Cookie c in container.GetCookies(BaseUri))
+        {
+            if (string.Equals(c.Name, name, StringComparison.Ordinal))
+            {
+                return c;
+            }
+        }
+
+        return null;
+    }
+
+    private static string GenerateEmail() =>
+        $"user-{Guid.NewGuid():N}@example.test";
+
+    private static OnboardingTurnOutput BuildAskOutput() => new()
+    {
+        Reply =
+        [
+            new AnthropicContentBlock
+            {
+                Type = AnthropicContentBlockType.Text,
+                Text = "What is your primary training goal?",
+            },
+        ],
+        Extracted = null,
+        NeedsClarification = false,
+        ClarificationReason = null,
+        ReadyForPlan = false,
+    };
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingControllerIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingControllerIntegrationTests.cs
@@ -60,6 +60,34 @@ public class OnboardingControllerIntegrationTests(RunCoachAppFactory factory)
     }
 
     /// <summary>
+    /// Authenticated but no antiforgery token → 400 ProblemDetails. Mirrors
+    /// the Auth pattern (Register_MissingAntiforgeryToken_Returns_400_ProblemDetails)
+    /// to make sure the [RequireAntiforgeryToken] attribute on /turns can't be
+    /// silently dropped without test failure.
+    /// </summary>
+    [Fact]
+    public async Task SubmitTurn_AuthenticatedNoAntiforgery_Returns_400_ProblemDetails()
+    {
+        // Arrange — register/login but skip PrimeAntiforgeryAsync so neither
+        // the cookie nor the header is attached on the POST.
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        await RegisterAsync(client, container, email, StrongPassword);
+        await LoginAsync(client, container, email, StrongPassword);
+
+        // Act
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/onboarding/turns")
+        {
+            Content = JsonContent.Create(new OnboardingTurnRequestDto(Guid.NewGuid(), "hello")),
+        };
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+    }
+
+    /// <summary>
     /// Authenticated with cookie + valid request → 200 with OnboardingTurnResponseDto.
     /// IMessageBus is stubbed to short-circuit the Wolverine handler chain so the
     /// integration test stays focused on the controller's mapping behaviour and
@@ -187,6 +215,48 @@ public class OnboardingControllerIntegrationTests(RunCoachAppFactory factory)
     }
 
     /// <summary>
+    /// Multi-tenant isolation: authenticated as user B, calling GET /state
+    /// must NOT expose user A's seeded stream — Marten conjoined-tenancy must
+    /// hold even if tests share the same Postgres container. Catches refactors
+    /// that drop the per-request <c>store.LightweightSession(userId.ToString())</c>
+    /// tenant scoping.
+    /// </summary>
+    [Fact]
+    public async Task GetState_AuthenticatedAsUserB_DoesNotSeeUserAStream()
+    {
+        // Arrange — seed user A's stream directly via a tenanted session.
+        var (clientA, containerA) = CreateCookieClient(Factory);
+        var emailA = GenerateEmail();
+        var userAId = await RegisterAsync(clientA, containerA, emailA, StrongPassword);
+        await LoginAsync(clientA, containerA, emailA, StrongPassword);
+
+        var now = DateTimeOffset.UtcNow;
+        var store = Factory.Services.GetRequiredService<IDocumentStore>();
+        await using (var seedSession = store.LightweightSession(userAId.ToString()))
+        {
+            seedSession.Events.StartStream<OnboardingView>(
+                userAId,
+                new OnboardingStarted(userAId, now));
+            seedSession.Events.Append(userAId, new TopicAsked(OnboardingTopic.PrimaryGoal, now));
+            await seedSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // User B logs in fresh — different identity, different tenant.
+        var (clientB, containerB) = CreateCookieClient(Factory);
+        var emailB = GenerateEmail();
+        await RegisterAsync(clientB, containerB, emailB, StrongPassword);
+        await LoginAsync(clientB, containerB, emailB, StrongPassword);
+
+        // Act
+        var response = await clientB.GetAsync(
+            "/api/v1/onboarding/state",
+            TestContext.Current.CancellationToken);
+
+        // Assert — user B sees no stream of their own and CANNOT see A's.
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    /// <summary>
     /// Authenticated with a seeded stream → 200 with a populated
     /// <see cref="OnboardingStateDto"/>.
     /// </summary>
@@ -252,6 +322,36 @@ public class OnboardingControllerIntegrationTests(RunCoachAppFactory factory)
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    /// <summary>
+    /// Authenticated but no antiforgery token → 400 ProblemDetails.
+    /// Mirrors the SubmitTurn antiforgery negative test for the second
+    /// state-changing POST endpoint.
+    /// </summary>
+    [Fact]
+    public async Task ReviseAnswer_AuthenticatedNoAntiforgery_Returns_400_ProblemDetails()
+    {
+        // Arrange — register/login but skip PrimeAntiforgeryAsync.
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        await RegisterAsync(client, container, email, StrongPassword);
+        await LoginAsync(client, container, email, StrongPassword);
+
+        // Act
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/onboarding/answers/revise")
+        {
+            Content = JsonContent.Create(
+                new ReviseAnswerRequestDto(
+                    OnboardingTopic.PrimaryGoal,
+                    JsonSerializer.SerializeToElement(
+                        new PrimaryGoalAnswer { Goal = PrimaryGoal.GeneralFitness, Description = "test" }))),
+        };
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
     }
 
     /// <summary>
@@ -327,6 +427,61 @@ public class OnboardingControllerIntegrationTests(RunCoachAppFactory factory)
         dto!.UserId.Should().Be(userId);
         dto.PrimaryGoal.Should().NotBeNull("the revised PrimaryGoal answer must be reflected in the returned DTO");
         dto.PrimaryGoal!.Goal.Should().Be(PrimaryGoal.BuildSpeed);
+    }
+
+    /// <summary>
+    /// Multi-tenant isolation: authenticated as user B, calling POST /answers/revise
+    /// must NOT mutate user A's seeded stream — Marten conjoined-tenancy
+    /// scoping must prevent the cross-tenant write. Asserts user B sees a 404
+    /// (their own stream does not exist) and user A's view remains untouched.
+    /// </summary>
+    [Fact]
+    public async Task ReviseAnswer_AuthenticatedAsUserB_CannotMutateUserAStream()
+    {
+        // Arrange — seed user A's stream via a tenanted session.
+        var (clientA, containerA) = CreateCookieClient(Factory);
+        var emailA = GenerateEmail();
+        var userAId = await RegisterAsync(clientA, containerA, emailA, StrongPassword);
+        await LoginAsync(clientA, containerA, emailA, StrongPassword);
+
+        var now = DateTimeOffset.UtcNow;
+        var store = Factory.Services.GetRequiredService<IDocumentStore>();
+        await using (var seedSession = store.LightweightSession(userAId.ToString()))
+        {
+            seedSession.Events.StartStream<OnboardingView>(
+                userAId,
+                new OnboardingStarted(userAId, now));
+            seedSession.Events.Append(userAId, new TopicAsked(OnboardingTopic.PrimaryGoal, now));
+            await seedSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // User B logs in fresh — different identity, different tenant.
+        var (clientB, containerB) = CreateCookieClient(Factory);
+        var emailB = GenerateEmail();
+        await RegisterAsync(clientB, containerB, emailB, StrongPassword);
+        await LoginAsync(clientB, containerB, emailB, StrongPassword);
+        var token = await PrimeAntiforgeryAsync(clientB, containerB);
+
+        // Act — user B attempts to revise; the controller's tenanted session
+        // scopes to userB.ToString() so user A's stream is NOT visible.
+        using var request = BuildRequest(
+            HttpMethod.Post, "/api/v1/onboarding/answers/revise", token);
+        request.Content = JsonContent.Create(
+            new ReviseAnswerRequestDto(
+                OnboardingTopic.PrimaryGoal,
+                JsonSerializer.SerializeToElement(
+                    new PrimaryGoalAnswer { Goal = PrimaryGoal.BuildSpeed, Description = "user-B intrusion" })));
+        var response = await clientB.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert — user B's tenant has no stream so they get 404.
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        // Verify user A's stream is unchanged (no AnswerCaptured event was appended).
+        await using var verifySession = store.LightweightSession(userAId.ToString());
+        var aEvents = await verifySession.Events.FetchStreamAsync(
+            userAId,
+            token: TestContext.Current.CancellationToken);
+        aEvents.Should().NotContain(e => e.Data is AnswerCaptured);
     }
 
     // ------------------------------------------------------------------ //

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingControllerIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingControllerIntegrationTests.cs
@@ -101,7 +101,9 @@ public class OnboardingControllerIntegrationTests(RunCoachAppFactory factory)
         var (client, container) = CreateCookieClient(customFactory);
 
         // Register + login (userId not needed for this test)
-        await RegisterAsync(client, container, GenerateEmail(), StrongPassword);
+        var email = GenerateEmail();
+        await RegisterAsync(client, container, email, StrongPassword);
+        await LoginAsync(client, container, email, StrongPassword);
         var token = await PrimeAntiforgeryAsync(client, container);
 
         // Act
@@ -220,7 +222,9 @@ public class OnboardingControllerIntegrationTests(RunCoachAppFactory factory)
     {
         // Arrange
         var (client, container) = CreateCookieClient(Factory);
-        await RegisterAsync(client, container, GenerateEmail(), StrongPassword);
+        var email = GenerateEmail();
+        await RegisterAsync(client, container, email, StrongPassword);
+        await LoginAsync(client, container, email, StrongPassword);
 
         // Act
         var response = await client.GetAsync(
@@ -308,7 +312,9 @@ public class OnboardingControllerIntegrationTests(RunCoachAppFactory factory)
     {
         // Arrange
         var (client, container) = CreateCookieClient(Factory);
-        await RegisterAsync(client, container, GenerateEmail(), StrongPassword);
+        var email = GenerateEmail();
+        await RegisterAsync(client, container, email, StrongPassword);
+        await LoginAsync(client, container, email, StrongPassword);
         var token = await PrimeAntiforgeryAsync(client, container);
 
         // Act

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnConcurrencyTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnConcurrencyTests.cs
@@ -1,0 +1,216 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using FluentAssertions;
+using Marten;
+using Marten.Exceptions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using RunCoach.Api.Modules.Coaching;
+using RunCoach.Api.Modules.Coaching.Idempotency;
+using RunCoach.Api.Modules.Coaching.Models;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+using RunCoach.Api.Modules.Coaching.Sanitization;
+using RunCoach.Api.Modules.Identity.Entities;
+using RunCoach.Api.Modules.Training.Plan;
+using RunCoach.Api.Tests.Infrastructure;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Regression guard for DEC-057's "single-handler / single-session / single-transaction"
+/// concurrency guarantee. Verifies that <c>EventAppendMode.Rich</c> enforces stream-version
+/// consistency so that N concurrent first-turn submissions for the same user result in
+/// exactly one successful commit and (N-1) stream-collision failures.
+///
+/// <para>
+/// Without <c>EventAppendMode.Rich</c> (i.e. under <c>Quick</c> mode), Marten skips
+/// the per-stream version check. All N concurrent sessions can race past
+/// <c>session.Events.StartStream&lt;OnboardingView&gt;(userId, …)</c> and succeed at
+/// <c>SaveChangesAsync</c>, producing N copies of the onboarding stream's first-event
+/// sequence — the exact silent data-corruption the <c>Rich</c> flip closes.
+/// </para>
+/// <para>
+/// The test calls <see cref="OnboardingTurnHandler.Handle"/> directly (bypassing the
+/// Wolverine message bus) so the <c>ExistingStreamIdCollisionException</c> propagates
+/// from <c>SaveChangesAsync</c> to the test harness rather than being routed to the
+/// dead-letter queue. This proves the underlying database-level guard fires, which is
+/// the precondition for Wolverine's <c>MoveToErrorQueue</c> policy to be meaningful.
+/// </para>
+/// </summary>
+[Trait("Category", "Integration")]
+public sealed class OnboardingTurnConcurrencyTests(RunCoachAppFactory factory)
+    : DbBackedIntegrationTestBase(factory)
+{
+    private const int ConcurrentSubmitCount = 5;
+    private const string StrongPassword = "Str0ngTestPassw0rd!";
+
+    /// <summary>
+    /// Five concurrent first-turn submissions for the same user stream must result in
+    /// exactly one successful <c>SaveChangesAsync</c> commit (the "winner") and four
+    /// <c>ExistingStreamIdCollisionException</c> failures (the "losers"). Each loser's
+    /// exception must be either <see cref="ExistingStreamIdCollisionException"/> or a
+    /// <see cref="MartenCommandException"/> wrapping a PostgreSQL unique-constraint
+    /// violation — both indicate Marten's Rich-mode version gate fired.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentFirstTurnSubmits_ExactlyOneSucceeds_RestThrowStreamCollision()
+    {
+        // Arrange — provision a real Identity row so Marten's conjoined-tenancy
+        // projection wiring has a valid FK target when the winner commits.
+        var userId = await SeedUserAsync();
+
+        var successCount = 0;
+        var failures = new List<Exception>();
+        var lockObj = new Lock();
+
+        // Act — fire N concurrent handler invocations, each in its own DI scope
+        // (mirroring the per-request scope Wolverine creates in production). All
+        // share the same userId so their StartStream calls target the same Marten
+        // stream. Each uses a distinct idempotencyKey so the idempotency short-
+        // circuit does NOT mask the race — the collision must happen at the DB
+        // layer, not inside the handler.
+        var tasks = Enumerable.Range(0, ConcurrentSubmitCount).Select(async _ =>
+        {
+            try
+            {
+                await InvokeFirstTurnAsync(userId, idempotencyKey: Guid.NewGuid());
+                lock (lockObj)
+                {
+                    successCount++;
+                }
+            }
+            catch (Exception ex)
+            {
+                lock (lockObj)
+                {
+                    failures.Add(ex);
+                }
+            }
+        });
+
+        await Task.WhenAll(tasks);
+
+        // Assert — exactly one winner; all losers carry a stream-collision signal.
+        successCount.Should().Be(
+            1,
+            because: "exactly one concurrent StartStream<OnboardingView> commit must win; all others must hit the stream-id unique constraint");
+
+        var expectedFailureCount = ConcurrentSubmitCount - 1;
+        failures.Should().HaveCount(
+            expectedFailureCount,
+            because: $"the remaining {expectedFailureCount} submits must fail with a stream-collision exception from Marten's Rich-mode version check");
+
+        // Each failure must be a Marten stream-collision indicator: either the typed
+        // ExistingStreamIdCollisionException (emitted directly by Marten when it
+        // detects the collision before issuing the SQL) or a MartenCommandException
+        // wrapping the PostgreSQL unique-constraint violation (emitted when the
+        // collision surfaces at the DB level inside SaveChangesAsync).
+        foreach (var ex in failures)
+        {
+            ex.Should().Match<Exception>(
+                e => e is ExistingStreamIdCollisionException || e is MartenCommandException,
+                because: "Rich-mode concurrent StartStream must throw ExistingStreamIdCollisionException or MartenCommandException — not silently succeed");
+        }
+    }
+
+    /// <inheritdoc/>
+    public override async ValueTask DisposeAsync()
+    {
+        // Marten event data lives in runcoach_events (not public schema).
+        // Reset both so no stream data leaks between tests.
+        await Factory.Services.ResetAllMartenDataAsync();
+        await base.DisposeAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    private static OnboardingTurnOutput BuildValidLlmOutput() => new()
+    {
+        Reply = [new AnthropicContentBlock { Type = AnthropicContentBlockType.Text, Text = "tell me about your goals" }],
+        Extracted = new ExtractedAnswer
+        {
+            Topic = OnboardingTopic.PrimaryGoal,
+            Confidence = 0.5,
+            NormalizedPrimaryGoal = null,
+            NormalizedTargetEvent = null,
+            NormalizedCurrentFitness = null,
+            NormalizedWeeklySchedule = null,
+            NormalizedInjuryHistory = null,
+            NormalizedPreferences = null,
+        },
+        NeedsClarification = true,
+        ClarificationReason = "Need more detail",
+        ReadyForPlan = false,
+    };
+
+    private async Task<Guid> SeedUserAsync()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var email = $"concurrency-{Guid.NewGuid():N}@example.test";
+        var user = new ApplicationUser { Email = email, UserName = email };
+        var result = await users.CreateAsync(user, StrongPassword);
+        result.Succeeded.Should()
+            .BeTrue(because: $"seed must succeed — got [{string.Join(", ", result.Errors.Select(e => e.Code))}]");
+        return user.Id;
+    }
+
+    /// <summary>
+    /// Invokes <see cref="OnboardingTurnHandler.Handle"/> in its own DI scope with a
+    /// real <see cref="IDocumentSession"/> and then commits via
+    /// <c>SaveChangesAsync</c> (standing in for Wolverine's transactional middleware).
+    /// All LLM-dependent collaborators are stubbed to return a minimal valid
+    /// <see cref="OnboardingTurnOutput"/> so the handler proceeds past the LLM call
+    /// and reaches the <c>StartStream</c> + <c>Append</c> path before commit.
+    /// </summary>
+    private async Task InvokeFirstTurnAsync(Guid userId, Guid idempotencyKey)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var session = scope.ServiceProvider.GetRequiredService<IDocumentSession>();
+
+        var llm = Substitute.For<ICoachingLlm>();
+        llm.GenerateStructuredAsync<OnboardingTurnOutput>(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, JsonElement>>(),
+                Arg.Any<CacheControl?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(BuildValidLlmOutput());
+
+        var assembler = Substitute.For<IContextAssembler>();
+        assembler.ComposeForOnboardingAsync(
+                Arg.Any<OnboardingView>(),
+                Arg.Any<OnboardingTopic>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new OnboardingPromptComposition(
+                SystemPrompt: "system",
+                UserMessage: "user",
+                Findings: ImmutableArray<SanitizationFinding>.Empty,
+                Neutralized: false));
+
+        var sanitizer = Substitute.For<IPromptSanitizer>();
+        var planGen = Substitute.For<IPlanGenerationService>();
+        var idempotency = new MartenIdempotencyStore(session);
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero));
+
+        await OnboardingTurnHandler.Handle(
+            new SubmitUserTurn(userId, idempotencyKey, "hello"),
+            session,
+            llm,
+            assembler,
+            sanitizer,
+            idempotency,
+            planGen,
+            time,
+            NullLogger<OnboardingTurnHandler>.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Stand in for Wolverine's transactional middleware. This is the commit
+        // where the stream-collision exception surfaces for the losing sessions.
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnConcurrencyTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnConcurrencyTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
+using Npgsql;
 using NSubstitute;
 using RunCoach.Api.Infrastructure.Idempotency;
 using RunCoach.Api.Modules.Coaching;
@@ -109,11 +110,16 @@ public sealed class OnboardingTurnConcurrencyTests(RunCoachAppFactory factory)
         // detects the collision before issuing the SQL) or a MartenCommandException
         // wrapping the PostgreSQL unique-constraint violation (emitted when the
         // collision surfaces at the DB level inside SaveChangesAsync).
+        //
+        // Per CodeRabbit feedback: a bare `is MartenCommandException` would also
+        // accept unrelated SQL errors (foreign-key, syntax, etc.). Verify the
+        // wrapped Postgres exception carries SqlState 23505 (unique_violation),
+        // which is the exact signal that Marten's Rich-mode version gate fired.
         foreach (var ex in failures)
         {
             ex.Should().Match<Exception>(
-                e => e is ExistingStreamIdCollisionException || e is MartenCommandException,
-                because: "Rich-mode concurrent StartStream must throw ExistingStreamIdCollisionException or MartenCommandException — not silently succeed");
+                e => e is ExistingStreamIdCollisionException || IsUniqueViolation(e),
+                because: "Rich-mode concurrent StartStream must throw ExistingStreamIdCollisionException or a MartenCommandException wrapping a Postgres unique_violation (SqlState 23505) — not silently succeed");
         }
     }
 
@@ -125,6 +131,33 @@ public sealed class OnboardingTurnConcurrencyTests(RunCoachAppFactory factory)
         await Factory.Services.ResetAllMartenDataAsync();
         await base.DisposeAsync();
         GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Walks an exception chain looking for a Postgres unique-constraint
+    /// violation (SqlState 23505). Marten typically wraps the Npgsql exception
+    /// inside a MartenCommandException, so we drill through InnerException
+    /// rather than relying on the outer type alone.
+    /// </summary>
+    private static bool IsUniqueViolation(Exception ex)
+    {
+        if (ex is not MartenCommandException)
+        {
+            return false;
+        }
+
+        var current = ex.InnerException;
+        while (current is not null)
+        {
+            if (current is PostgresException pg && string.Equals(pg.SqlState, "23505", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            current = current.InnerException;
+        }
+
+        return false;
     }
 
     private static OnboardingTurnOutput BuildValidLlmOutput() => new()

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnConcurrencyTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnConcurrencyTests.cs
@@ -8,8 +8,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
+using RunCoach.Api.Infrastructure.Idempotency;
 using RunCoach.Api.Modules.Coaching;
-using RunCoach.Api.Modules.Coaching.Idempotency;
 using RunCoach.Api.Modules.Coaching.Models;
 using RunCoach.Api.Modules.Coaching.Onboarding;
 using RunCoach.Api.Modules.Coaching.Onboarding.Models;
@@ -194,8 +194,11 @@ public sealed class OnboardingTurnConcurrencyTests(RunCoachAppFactory factory)
 
         var sanitizer = Substitute.For<IPromptSanitizer>();
         var planGen = Substitute.For<IPlanGenerationService>();
-        var idempotency = new MartenIdempotencyStore(session);
         var time = new FakeTimeProvider(new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero));
+        var idempotency = new MartenIdempotencyStore(
+            session,
+            time,
+            NullLogger<MartenIdempotencyStore>.Instance);
 
         await OnboardingTurnHandler.Handle(
             new SubmitUserTurn(userId, idempotencyKey, "hello"),

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnConcurrencyTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnConcurrencyTests.cs
@@ -169,7 +169,14 @@ public sealed class OnboardingTurnConcurrencyTests(RunCoachAppFactory factory)
     private async Task InvokeFirstTurnAsync(Guid userId, Guid idempotencyKey)
     {
         using var scope = Factory.Services.CreateScope();
-        var session = scope.ServiceProvider.GetRequiredService<IDocumentSession>();
+
+        // Marten is configured with TenancyStyle.Conjoined; the default DI
+        // session has no tenant assigned (in production, Wolverine middleware
+        // sets it from the message envelope). LightweightSession with the
+        // user id as tenant matches what the runtime would do for this
+        // command and lets MartenIdempotencyStore's tenant-scope guard pass.
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
 
         var llm = Substitute.For<ICoachingLlm>();
         llm.GenerateStructuredAsync<OnboardingTurnOutput>(

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnHandlerUnitTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnHandlerUnitTests.cs
@@ -1,0 +1,338 @@
+using System.Text.Json;
+using FluentAssertions;
+using Marten;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using RunCoach.Api.Modules.Coaching;
+using RunCoach.Api.Modules.Coaching.Idempotency;
+using RunCoach.Api.Modules.Coaching.Models;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+using RunCoach.Api.Modules.Coaching.Sanitization;
+using RunCoach.Api.Modules.Training.Plan;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Unit tests for <see cref="OnboardingTurnHandler.Handle"/> using NSubstitute
+/// fakes. Covers (1) idempotency replay short-circuit, (2) Pattern-B
+/// validation one-retry path, (3) clarification emission, (4) terminal-branch
+/// plan generation invocation, and (5) the all-or-nothing single-Marten-session
+/// guarantee — when <see cref="IPlanGenerationService"/> throws, the handler
+/// rethrows and never appends <see cref="OnboardingCompleted"/>.
+/// </summary>
+public class OnboardingTurnHandlerUnitTests
+{
+    private const string SystemPrompt = "system-bytes";
+    private const string UserMessage = "user-bytes";
+
+    [Fact]
+    public async Task Handle_When_IdempotencyKey_Already_Recorded_Returns_Prior_Response_Without_Side_Effects()
+    {
+        // Arrange
+        var deps = new Dependencies();
+        var prior = BuildAskResponseDto();
+        deps.Idempotency
+            .SeenAsync<OnboardingTurnResponseDto>(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(prior);
+
+        // Act
+        var actual = await OnboardingTurnHandler.Handle(
+            new SubmitUserTurn(deps.UserId, deps.IdempotencyKey, "hi"),
+            deps.Session,
+            deps.Llm,
+            deps.Assembler,
+            deps.Sanitizer,
+            deps.Idempotency,
+            deps.PlanGen,
+            deps.Time,
+            NullLogger<OnboardingTurnHandler>.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        actual.Should().BeSameAs(prior);
+        await deps.Llm.DidNotReceiveWithAnyArgs().GenerateStructuredAsync<OnboardingTurnOutput>(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, JsonElement>>(),
+            Arg.Any<CacheControl?>(),
+            Arg.Any<CancellationToken>());
+        deps.Idempotency.DidNotReceiveWithAnyArgs().Record<OnboardingTurnResponseDto>(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<OnboardingTurnResponseDto>());
+    }
+
+    [Fact]
+    public async Task Handle_Validation_Failure_Triggers_OneRetry_With_Discriminator_Reinforcement()
+    {
+        // Arrange
+        var deps = new Dependencies();
+        deps.AssemblerComposes(SystemPrompt, UserMessage);
+        deps.SeesNoIdempotencyHit();
+        deps.LlmReturnsSequence(
+            BuildInvalidOutput(), // first call: invalid (multiple slots)
+            BuildValidOutput(OnboardingTopic.PrimaryGoal, PrimaryGoal.GeneralFitness));
+
+        // Act
+        await OnboardingTurnHandler.Handle(
+            new SubmitUserTurn(deps.UserId, deps.IdempotencyKey, "general fitness"),
+            deps.Session,
+            deps.Llm,
+            deps.Assembler,
+            deps.Sanitizer,
+            deps.Idempotency,
+            deps.PlanGen,
+            deps.Time,
+            NullLogger<OnboardingTurnHandler>.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert — first call uses the base user message; second call adds the
+        //   discriminator-reinforcement suffix.
+        await deps.Llm.Received(1).GenerateStructuredAsync<OnboardingTurnOutput>(
+            SystemPrompt,
+            UserMessage,
+            Arg.Any<IReadOnlyDictionary<string, JsonElement>>(),
+            Arg.Any<CacheControl?>(),
+            Arg.Any<CancellationToken>());
+
+        await deps.Llm.Received(1).GenerateStructuredAsync<OnboardingTurnOutput>(
+            SystemPrompt,
+            Arg.Is<string>(m => m.Contains("[Pattern-B-Invariant] RETRY", StringComparison.Ordinal)),
+            Arg.Any<IReadOnlyDictionary<string, JsonElement>>(),
+            Arg.Any<CacheControl?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_Validation_Failure_On_Both_Attempts_Synthesizes_Discriminator_Mismatch_Clarification()
+    {
+        // Arrange
+        var deps = new Dependencies();
+        deps.AssemblerComposes(SystemPrompt, UserMessage);
+        deps.SeesNoIdempotencyHit();
+        deps.LlmReturnsSequence(BuildInvalidOutput(), BuildInvalidOutput());
+
+        // Act
+        var actual = await OnboardingTurnHandler.Handle(
+            new SubmitUserTurn(deps.UserId, deps.IdempotencyKey, "uh"),
+            deps.Session,
+            deps.Llm,
+            deps.Assembler,
+            deps.Sanitizer,
+            deps.Idempotency,
+            deps.PlanGen,
+            deps.Time,
+            NullLogger<OnboardingTurnHandler>.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert — handler short-circuits to ask, no terminal branch.
+        actual.Kind.Should().Be(OnboardingTurnKind.Ask);
+        actual.PlanId.Should().BeNull();
+        await deps.PlanGen.DidNotReceiveWithAnyArgs().GeneratePlanAsync(
+            Arg.Any<OnboardingView>(),
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<RegenerationIntent?>(),
+            Arg.Any<Guid?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_Throws_OnboardingAlreadyComplete_When_Stream_Is_Terminal()
+    {
+        // Arrange
+        var deps = new Dependencies();
+        var view = new OnboardingView
+        {
+            Id = deps.UserId,
+            UserId = deps.UserId,
+            Status = OnboardingStatus.Completed,
+        };
+        deps.Session
+            .LoadAsync<OnboardingView>(deps.UserId, Arg.Any<CancellationToken>())
+            .Returns(view);
+        deps.SeesNoIdempotencyHit();
+
+        // Act
+        var act = async () => await OnboardingTurnHandler.Handle(
+            new SubmitUserTurn(deps.UserId, deps.IdempotencyKey, "again"),
+            deps.Session,
+            deps.Llm,
+            deps.Assembler,
+            deps.Sanitizer,
+            deps.Idempotency,
+            deps.PlanGen,
+            deps.Time,
+            NullLogger<OnboardingTurnHandler>.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<OnboardingAlreadyCompleteException>()
+            .Where(ex => ex.UserId == deps.UserId);
+    }
+
+    [Fact]
+    public async Task Handle_Records_Idempotency_Marker_With_Final_Response()
+    {
+        // Arrange
+        var deps = new Dependencies();
+        deps.AssemblerComposes(SystemPrompt, UserMessage);
+        deps.SeesNoIdempotencyHit();
+        deps.LlmReturnsSequence(BuildValidOutput(OnboardingTopic.PrimaryGoal, PrimaryGoal.GeneralFitness));
+
+        // Act
+        var response = await OnboardingTurnHandler.Handle(
+            new SubmitUserTurn(deps.UserId, deps.IdempotencyKey, "fitness"),
+            deps.Session,
+            deps.Llm,
+            deps.Assembler,
+            deps.Sanitizer,
+            deps.Idempotency,
+            deps.PlanGen,
+            deps.Time,
+            NullLogger<OnboardingTurnHandler>.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert — record was called with the response we are about to return.
+        deps.Idempotency.Received(1).Record(deps.IdempotencyKey, deps.UserId, response);
+    }
+
+    private static OnboardingTurnResponseDto BuildAskResponseDto() => new(
+        Kind: OnboardingTurnKind.Ask,
+        AssistantBlocks: JsonSerializer.SerializeToDocument(Array.Empty<AnthropicContentBlock>()),
+        Topic: OnboardingTopic.PrimaryGoal,
+        SuggestedInputType: SuggestedInputType.SingleSelect,
+        Progress: new OnboardingProgressDto(0, 5),
+        PlanId: null);
+
+    private static OnboardingTurnOutput BuildValidOutput(OnboardingTopic topic, PrimaryGoal goal)
+    {
+        return new OnboardingTurnOutput
+        {
+            Reply = [new AnthropicContentBlock { Type = AnthropicContentBlockType.Text, Text = "ok" }],
+            Extracted = new ExtractedAnswer
+            {
+                Topic = topic,
+                Confidence = 0.9,
+                NormalizedPrimaryGoal = topic == OnboardingTopic.PrimaryGoal
+                    ? new PrimaryGoalAnswer { Goal = goal, Description = "test" }
+                    : null,
+                NormalizedTargetEvent = null,
+                NormalizedCurrentFitness = null,
+                NormalizedWeeklySchedule = null,
+                NormalizedInjuryHistory = null,
+                NormalizedPreferences = null,
+            },
+            NeedsClarification = false,
+            ClarificationReason = null,
+            ReadyForPlan = false,
+        };
+    }
+
+    private static OnboardingTurnOutput BuildInvalidOutput()
+    {
+        // Both PrimaryGoal AND TargetEvent slots populated — Pattern-B violation.
+        return new OnboardingTurnOutput
+        {
+            Reply = [new AnthropicContentBlock { Type = AnthropicContentBlockType.Text, Text = "..." }],
+            Extracted = new ExtractedAnswer
+            {
+                Topic = OnboardingTopic.PrimaryGoal,
+                Confidence = 0.9,
+                NormalizedPrimaryGoal = new PrimaryGoalAnswer { Goal = PrimaryGoal.GeneralFitness, Description = "x" },
+                NormalizedTargetEvent = new TargetEventAnswer
+                {
+                    EventName = "leak",
+                    DistanceKm = 5,
+                    EventDateIso = "2026-12-01",
+                    TargetFinishTimeIso = null,
+                },
+                NormalizedCurrentFitness = null,
+                NormalizedWeeklySchedule = null,
+                NormalizedInjuryHistory = null,
+                NormalizedPreferences = null,
+            },
+            NeedsClarification = false,
+            ClarificationReason = null,
+            ReadyForPlan = false,
+        };
+    }
+
+    private sealed class Dependencies
+    {
+        public Dependencies()
+        {
+            Session = Substitute.For<IDocumentSession>();
+            Llm = Substitute.For<ICoachingLlm>();
+            Assembler = Substitute.For<IContextAssembler>();
+            Sanitizer = Substitute.For<IPromptSanitizer>();
+            Idempotency = Substitute.For<IIdempotencyStore>();
+            PlanGen = Substitute.For<IPlanGenerationService>();
+            Time = new FakeTimeProvider(new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero));
+            UserId = Guid.NewGuid();
+            IdempotencyKey = Guid.NewGuid();
+
+            // NSubstitute auto-substitutes interface-typed properties on
+            // proxied interfaces, so `Session.Events.Append(...)` resolves to
+            // a no-op recursive substitute without an explicit stub.
+        }
+
+        public IDocumentSession Session { get; }
+
+        public ICoachingLlm Llm { get; }
+
+        public IContextAssembler Assembler { get; }
+
+        public IPromptSanitizer Sanitizer { get; }
+
+        public IIdempotencyStore Idempotency { get; }
+
+        public IPlanGenerationService PlanGen { get; }
+
+        public FakeTimeProvider Time { get; }
+
+        public Guid UserId { get; }
+
+        public Guid IdempotencyKey { get; }
+
+        public void SeesNoIdempotencyHit()
+        {
+            Idempotency
+                .SeenAsync<OnboardingTurnResponseDto>(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+                .Returns((OnboardingTurnResponseDto?)null);
+        }
+
+        public void AssemblerComposes(string systemPrompt, string userMessage)
+        {
+            Assembler
+                .ComposeForOnboardingAsync(
+                    Arg.Any<OnboardingView>(),
+                    Arg.Any<OnboardingTopic>(),
+                    Arg.Any<string>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(new OnboardingPromptComposition(
+                    SystemPrompt: systemPrompt,
+                    UserMessage: userMessage,
+                    Findings: System.Collections.Immutable.ImmutableArray<SanitizationFinding>.Empty,
+                    Neutralized: false));
+        }
+
+        public void LlmReturnsSequence(params OnboardingTurnOutput[] outputs)
+        {
+            ArgumentNullException.ThrowIfNull(outputs);
+            if (outputs.Length == 0)
+            {
+                throw new ArgumentException("Provide at least one output.", nameof(outputs));
+            }
+
+            var queue = new Queue<OnboardingTurnOutput>(outputs);
+            Llm
+                .GenerateStructuredAsync<OnboardingTurnOutput>(
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    Arg.Any<IReadOnlyDictionary<string, JsonElement>>(),
+                    Arg.Any<CacheControl?>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(_ => queue.Count > 0 ? queue.Dequeue() : outputs[^1]);
+        }
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnHandlerUnitTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnHandlerUnitTests.cs
@@ -134,6 +134,169 @@ public class OnboardingTurnHandlerUnitTests
             Arg.Any<RegenerationIntent?>(),
             Arg.Any<Guid?>(),
             Arg.Any<CancellationToken>());
+
+        // Audit trail: the handler must stage exactly one ClarificationRequested
+        // for the current topic with the reason carrying the topic name, and must
+        // NOT stage any AnswerCaptured (the synthesized fallback has no extraction).
+        var appended = CollectAppendedEvents(deps.Session);
+        var clarifications = appended.OfType<ClarificationRequested>().ToArray();
+        clarifications.Should().ContainSingle();
+        clarifications[0].Topic.Should().Be(OnboardingTopic.PrimaryGoal);
+        clarifications[0].Reason.Should().StartWith("Discriminator mismatch");
+        appended.OfType<AnswerCaptured>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_TerminalBranch_StagesPlanStreamAndCompletionEvents()
+    {
+        // Arrange — gate satisfied + LLM agrees ⇒ terminal branch fires.
+        var deps = new Dependencies();
+        var planId = Guid.Empty;
+        deps.AssemblerComposes(SystemPrompt, UserMessage);
+        deps.SeesNoIdempotencyHit();
+        deps.LlmReturnsSequence(BuildReadyForPlanOutput());
+
+        var fullView = BuildFullView(deps.UserId);
+        deps.Session.LoadAsync<OnboardingView>(deps.UserId, Arg.Any<CancellationToken>())
+            .Returns(fullView);
+
+        var fakeSequence = BuildFakePlanSequence(deps.UserId);
+        deps.PlanGen
+            .GeneratePlanAsync(
+                Arg.Any<OnboardingView>(),
+                Arg.Any<Guid>(),
+                Arg.Do<Guid>(id => planId = id),
+                Arg.Any<RegenerationIntent?>(),
+                Arg.Any<Guid?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(fakeSequence);
+
+        // Act
+        var response = await OnboardingTurnHandler.Handle(
+            new SubmitUserTurn(deps.UserId, deps.IdempotencyKey, "ready"),
+            deps.Session,
+            deps.Llm,
+            deps.Assembler,
+            deps.Sanitizer,
+            deps.Idempotency,
+            deps.PlanGen,
+            deps.Time,
+            NullLogger<OnboardingTurnHandler>.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        response.Kind.Should().Be(OnboardingTurnKind.Complete);
+        response.PlanId.Should().Be(planId);
+        response.PlanId.Should().NotBe(Guid.Empty);
+
+        // Plan stream creation goes through StartStream<PlanProjectionDto>.
+        var startCalls = deps.Session.Events.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == "StartStream"
+                && c.GetMethodInfo().IsGenericMethod
+                && c.GetMethodInfo().GetGenericArguments()[0] == typeof(RunCoach.Api.Modules.Training.Plan.Models.PlanProjectionDto))
+            .ToArray();
+        startCalls.Should().ContainSingle();
+        var startArgs = startCalls[0].GetArguments();
+        startArgs[0].Should().Be(planId);
+        var staged = (object[])startArgs[1]!;
+        staged.Should().HaveCount(6);
+        staged[0].Should().BeOfType<PlanGenerated>();
+
+        // PlanLinkedToUser + OnboardingCompleted are appended on the onboarding stream.
+        var appended = CollectAppendedEvents(deps.Session);
+        var links = appended.OfType<PlanLinkedToUser>().ToArray();
+        links.Should().ContainSingle();
+        links[0].UserId.Should().Be(deps.UserId);
+        links[0].PlanId.Should().Be(planId);
+
+        var completions = appended.OfType<OnboardingCompleted>().ToArray();
+        completions.Should().ContainSingle();
+        completions[0].PlanId.Should().Be(planId);
+    }
+
+    [Theory]
+    [InlineData(0.59, false, false)] // below floor → no AnswerCaptured
+    [InlineData(0.60, false, true)] // exact boundary → AnswerCaptured fires
+    [InlineData(0.95, true, false)] // NeedsClarification gates capture even with high confidence
+    public async Task Handle_AnswerCaptured_RespectsConfidenceFloorAndClarificationGate(
+        double confidence,
+        bool needsClarification,
+        bool expectAnswerCaptured)
+    {
+        // Arrange
+        var deps = new Dependencies();
+        deps.AssemblerComposes(SystemPrompt, UserMessage);
+        deps.SeesNoIdempotencyHit();
+        deps.LlmReturnsSequence(BuildOutputWithExtraction(
+            confidence: confidence,
+            needsClarification: needsClarification));
+
+        // Act
+        await OnboardingTurnHandler.Handle(
+            new SubmitUserTurn(deps.UserId, deps.IdempotencyKey, "fitness"),
+            deps.Session,
+            deps.Llm,
+            deps.Assembler,
+            deps.Sanitizer,
+            deps.Idempotency,
+            deps.PlanGen,
+            deps.Time,
+            NullLogger<OnboardingTurnHandler>.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var appended = CollectAppendedEvents(deps.Session);
+        var captures = appended.OfType<AnswerCaptured>().ToArray();
+        var expectedCaptureCount = expectAnswerCaptured ? 1 : 0;
+        captures.Should().HaveCount(expectedCaptureCount);
+
+        // When NeedsClarification=true the handler must still stage
+        // ClarificationRequested (the alternative audit-trail event).
+        if (needsClarification)
+        {
+            appended.OfType<ClarificationRequested>().Should().ContainSingle();
+        }
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_AssistantBlocks_UseCamelCasePropertyNames()
+    {
+        // Arrange — drive a happy-path Ask response through the WireSerializerOptions
+        // path (CamelCase). Asserts the serialized JsonDocument carries lowercase
+        // 'type' / 'text' so the SPA Zod schemas keep round-tripping.
+        var deps = new Dependencies();
+        deps.AssemblerComposes(SystemPrompt, UserMessage);
+        deps.SeesNoIdempotencyHit();
+        deps.LlmReturnsSequence(BuildValidOutput(OnboardingTopic.PrimaryGoal, PrimaryGoal.GeneralFitness));
+
+        // Act
+        var response = await OnboardingTurnHandler.Handle(
+            new SubmitUserTurn(deps.UserId, deps.IdempotencyKey, "fitness"),
+            deps.Session,
+            deps.Llm,
+            deps.Assembler,
+            deps.Sanitizer,
+            deps.Idempotency,
+            deps.PlanGen,
+            deps.Time,
+            NullLogger<OnboardingTurnHandler>.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Assert — the serialized assistant blocks must use camelCase keys.
+        response.AssistantBlocks.ValueKind.Should().Be(JsonValueKind.Array);
+        var firstBlock = response.AssistantBlocks.EnumerateArray().First();
+
+        // Camelcase keys present.
+        firstBlock.TryGetProperty("type", out _).Should()
+            .BeTrue(because: "WireSerializerOptions.CamelCase must produce lowercase 'type'");
+        firstBlock.TryGetProperty("text", out _).Should()
+            .BeTrue(because: "WireSerializerOptions.CamelCase must produce lowercase 'text'");
+
+        // PascalCase keys absent — would indicate the camelCase policy was dropped.
+        firstBlock.TryGetProperty("Type", out _).Should()
+            .BeFalse(because: "PascalCase 'Type' would indicate a regression in the wire format");
+        firstBlock.TryGetProperty("Text", out _).Should()
+            .BeFalse(because: "PascalCase 'Text' would indicate a regression in the wire format");
     }
 
     [Fact]
@@ -227,6 +390,170 @@ public class OnboardingTurnHandlerUnitTests
             ReadyForPlan = false,
         };
     }
+
+    /// <summary>
+    /// Walks every Append(streamId, params object[]) call recorded against the
+    /// session's Events substitute and flattens the appended events into one
+    /// list — lets per-test assertions filter via .OfType&lt;T&gt;() instead of
+    /// fighting NSubstitute's expression-tree limits.
+    /// </summary>
+    private static List<object> CollectAppendedEvents(Marten.IDocumentSession session)
+    {
+        var collected = new List<object>();
+        foreach (var call in session.Events.ReceivedCalls())
+        {
+            if (!string.Equals(call.GetMethodInfo().Name, "Append", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var args = call.GetArguments();
+            if (args.Length < 2 || args[1] is not object[] events)
+            {
+                continue;
+            }
+
+            collected.AddRange(events);
+        }
+
+        return collected;
+    }
+
+    private static OnboardingTurnOutput BuildOutputWithExtraction(
+        double confidence,
+        bool needsClarification)
+    {
+        return new OnboardingTurnOutput
+        {
+            Reply = [new AnthropicContentBlock { Type = AnthropicContentBlockType.Text, Text = "ok" }],
+            Extracted = new ExtractedAnswer
+            {
+                Topic = OnboardingTopic.PrimaryGoal,
+                Confidence = confidence,
+                NormalizedPrimaryGoal = new PrimaryGoalAnswer { Goal = PrimaryGoal.GeneralFitness, Description = "test" },
+                NormalizedTargetEvent = null,
+                NormalizedCurrentFitness = null,
+                NormalizedWeeklySchedule = null,
+                NormalizedInjuryHistory = null,
+                NormalizedPreferences = null,
+            },
+            NeedsClarification = needsClarification,
+            ClarificationReason = needsClarification ? "needs more detail" : null,
+            ReadyForPlan = false,
+        };
+    }
+
+    private static OnboardingTurnOutput BuildReadyForPlanOutput() => new()
+    {
+        Reply = [new AnthropicContentBlock { Type = AnthropicContentBlockType.Text, Text = "all set" }],
+        Extracted = null,
+        NeedsClarification = false,
+        ClarificationReason = null,
+        ReadyForPlan = true,
+    };
+
+    private static OnboardingView BuildFullView(Guid userId) => new()
+    {
+        Id = userId,
+        UserId = userId,
+        Status = OnboardingStatus.InProgress,
+        PrimaryGoal = new PrimaryGoalAnswer { Goal = PrimaryGoal.GeneralFitness, Description = "fitness" },
+        TargetEvent = null,
+        CurrentFitness = new CurrentFitnessAnswer
+        {
+            TypicalWeeklyKm = 30,
+            LongestRecentRunKm = 12,
+            RecentRaceDistanceKm = null,
+            RecentRaceTimeIso = null,
+            Description = "moderate",
+        },
+        WeeklySchedule = new WeeklyScheduleAnswer
+        {
+            MaxRunDaysPerWeek = 4,
+            TypicalSessionMinutes = 45,
+            Monday = true,
+            Tuesday = false,
+            Wednesday = true,
+            Thursday = false,
+            Friday = true,
+            Saturday = false,
+            Sunday = true,
+            Description = "evenings",
+        },
+        InjuryHistory = new InjuryHistoryAnswer
+        {
+            HasActiveInjury = false,
+            ActiveInjuryDescription = string.Empty,
+            PastInjurySummary = "none",
+        },
+        Preferences = new PreferencesAnswer
+        {
+            PreferredUnits = PreferredUnits.Kilometers,
+            PreferTrail = false,
+            ComfortableWithIntensity = true,
+            Description = "ok",
+        },
+        OutstandingClarifications = [],
+    };
+
+    private static PlanEventSequence BuildFakePlanSequence(Guid userId)
+    {
+        var generatedAt = new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+        var macro = new PlanGenerated(
+            PlanId: Guid.Parse("00000000-0000-0000-0000-000000000111"),
+            UserId: userId,
+            Macro: new RunCoach.Api.Modules.Coaching.Models.Structured.MacroPlanOutput
+            {
+                TotalWeeks = 4,
+                GoalDescription = "test",
+                Phases = Array.Empty<RunCoach.Api.Modules.Coaching.Models.Structured.PlanPhaseOutput>(),
+                Rationale = string.Empty,
+                Warnings = string.Empty,
+            },
+            GeneratedAt: generatedAt,
+            PromptVersion: "v1",
+            ModelId: "test-model",
+            PreviousPlanId: null);
+
+        var meso = new RunCoach.Api.Modules.Coaching.Models.Structured.MesoWeekOutput
+        {
+            WeekNumber = 1,
+            PhaseType = RunCoach.Api.Modules.Coaching.Models.Structured.PhaseType.Base,
+            WeeklyTargetKm = 20,
+            IsDeloadWeek = false,
+            Sunday = MesoRest(),
+            Monday = MesoRest(),
+            Tuesday = MesoRest(),
+            Wednesday = MesoRest(),
+            Thursday = MesoRest(),
+            Friday = MesoRest(),
+            Saturday = MesoRest(),
+            WeekSummary = "rest",
+        };
+
+        var mesos = new MesoCycleCreated[]
+        {
+            new(1, meso),
+            new(2, meso with { WeekNumber = 2 }),
+            new(3, meso with { WeekNumber = 3 }),
+            new(4, meso with { WeekNumber = 4 }),
+        };
+
+        var micro = new FirstMicroCycleCreated(
+            new RunCoach.Api.Modules.Coaching.Models.Structured.MicroWorkoutListOutput
+            {
+                Workouts = Array.Empty<RunCoach.Api.Modules.Coaching.Models.Structured.WorkoutOutput>(),
+            });
+
+        return new PlanEventSequence(macro, mesos, micro);
+    }
+
+    private static RunCoach.Api.Modules.Coaching.Models.Structured.MesoDaySlotOutput MesoRest() => new()
+    {
+        SlotType = RunCoach.Api.Modules.Coaching.Models.Structured.DaySlotType.Rest,
+        WorkoutType = null,
+        Notes = "rest",
+    };
 
     private static OnboardingTurnOutput BuildInvalidOutput()
     {

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnHandlerUnitTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnHandlerUnitTests.cs
@@ -4,8 +4,8 @@ using Marten;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
+using RunCoach.Api.Infrastructure.Idempotency;
 using RunCoach.Api.Modules.Coaching;
-using RunCoach.Api.Modules.Coaching.Idempotency;
 using RunCoach.Api.Modules.Coaching.Models;
 using RunCoach.Api.Modules.Coaching.Onboarding;
 using RunCoach.Api.Modules.Coaching.Onboarding.Models;
@@ -58,7 +58,7 @@ public class OnboardingTurnHandlerUnitTests
             Arg.Any<IReadOnlyDictionary<string, JsonElement>>(),
             Arg.Any<CacheControl?>(),
             Arg.Any<CancellationToken>());
-        deps.Idempotency.DidNotReceiveWithAnyArgs().Record<OnboardingTurnResponseDto>(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<OnboardingTurnResponseDto>());
+        deps.Idempotency.DidNotReceiveWithAnyArgs().Record<OnboardingTurnResponseDto>(Arg.Any<Guid>(), Arg.Any<OnboardingTurnResponseDto>());
     }
 
     [Fact]
@@ -193,12 +193,12 @@ public class OnboardingTurnHandlerUnitTests
             TestContext.Current.CancellationToken);
 
         // Assert — record was called with the response we are about to return.
-        deps.Idempotency.Received(1).Record(deps.IdempotencyKey, deps.UserId, response);
+        deps.Idempotency.Received(1).Record(deps.IdempotencyKey, response);
     }
 
     private static OnboardingTurnResponseDto BuildAskResponseDto() => new(
         Kind: OnboardingTurnKind.Ask,
-        AssistantBlocks: JsonSerializer.SerializeToDocument(Array.Empty<AnthropicContentBlock>()),
+        AssistantBlocks: JsonSerializer.SerializeToElement(Array.Empty<AnthropicContentBlock>()),
         Topic: OnboardingTopic.PrimaryGoal,
         SuggestedInputType: SuggestedInputType.SingleSelect,
         Progress: new OnboardingProgressDto(0, 5),

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnOutputShapeTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnOutputShapeTests.cs
@@ -274,7 +274,7 @@ public sealed class OnboardingTurnOutputShapeTests
         // Arrange — Ask branch: AssistantBlocks round-trips as JsonElement without disposal concerns.
         var blocksJson = """[{"type":"text","text":"What is your primary goal?"}]""";
         var blocksElement = JsonDocument.Parse(blocksJson).RootElement.Clone();
-        var progress = new OnboardingProgressDto(Completed: 0, Total: 6);
+        var progress = new OnboardingProgressDto(CompletedTopics: 0, TotalTopics: 6);
         var expected = new OnboardingTurnResponseDto(
             Kind: OnboardingTurnKind.Ask,
             AssistantBlocks: blocksElement,
@@ -302,7 +302,7 @@ public sealed class OnboardingTurnOutputShapeTests
         var blocksJson = """[{"type":"text","text":"Your plan is ready!"}]""";
         var blocksElement = JsonDocument.Parse(blocksJson).RootElement.Clone();
         var planId = Guid.NewGuid();
-        var progress = new OnboardingProgressDto(Completed: 6, Total: 6);
+        var progress = new OnboardingProgressDto(CompletedTopics: 6, TotalTopics: 6);
         var expected = new OnboardingTurnResponseDto(
             Kind: OnboardingTurnKind.Complete,
             AssistantBlocks: blocksElement,

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanEventSequenceTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanEventSequenceTests.cs
@@ -1,0 +1,188 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+using RunCoach.Api.Modules.Training.Plan;
+
+namespace RunCoach.Api.Tests.Modules.Training.Plan;
+
+/// <summary>
+/// Unit tests for <see cref="PlanEventSequence"/> construction invariants.
+/// The wrapper enforces the canonical Slice 1 shape so callers cannot
+/// accidentally drop, reorder, or mismatch element types.
+/// </summary>
+public sealed class PlanEventSequenceTests
+{
+    [Fact]
+    public void Constructor_ValidSequence_FlattensInCanonicalOrder()
+    {
+        // Arrange
+        var macro = BuildMacro();
+        var mesos = new[]
+        {
+            new MesoCycleCreated(1, BuildMeso(1)),
+            new MesoCycleCreated(2, BuildMeso(2)),
+            new MesoCycleCreated(3, BuildMeso(3)),
+            new MesoCycleCreated(4, BuildMeso(4)),
+        };
+        var micro = new FirstMicroCycleCreated(BuildMicro());
+
+        // Act
+        var sequence = new PlanEventSequence(macro, mesos, micro);
+        var events = sequence.ToEvents();
+
+        // Assert
+        events.Should().HaveCount(6);
+        events[0].Should().BeSameAs(macro);
+        events[1].Should().BeSameAs(mesos[0]);
+        events[2].Should().BeSameAs(mesos[1]);
+        events[3].Should().BeSameAs(mesos[2]);
+        events[4].Should().BeSameAs(mesos[3]);
+        events[5].Should().BeSameAs(micro);
+    }
+
+    [Fact]
+    public void Constructor_NullMacro_Throws()
+    {
+        // Act
+        var act = () => new PlanEventSequence(null!, BuildMesos(), new FirstMicroCycleCreated(BuildMicro()));
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("Macro");
+    }
+
+    [Fact]
+    public void Constructor_NullMicro_Throws()
+    {
+        // Act
+        var act = () => new PlanEventSequence(BuildMacro(), BuildMesos(), null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("Micro");
+    }
+
+    [Fact]
+    public void Constructor_NullMesos_Throws()
+    {
+        // Act
+        var act = () => new PlanEventSequence(BuildMacro(), null!, new FirstMicroCycleCreated(BuildMicro()));
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("mesos");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(3)]
+    [InlineData(5)]
+    public void Constructor_WrongMesoCount_Throws(int count)
+    {
+        // Arrange
+        var mesos = Enumerable.Range(1, count)
+            .Select(week => new MesoCycleCreated(week, BuildMeso(week)))
+            .ToArray();
+
+        // Act
+        var act = () => new PlanEventSequence(BuildMacro(), mesos, new FirstMicroCycleCreated(BuildMicro()));
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage($"*Expected {PlanEventSequence.ExpectedMesoCount} meso events*")
+            .Which.ParamName.Should().Be("mesos");
+    }
+
+    [Fact]
+    public void Constructor_OutOfOrderMesos_Throws()
+    {
+        // Arrange — week 1, 3, 2, 4 (out of canonical order)
+        var mesos = new[]
+        {
+            new MesoCycleCreated(1, BuildMeso(1)),
+            new MesoCycleCreated(3, BuildMeso(3)),
+            new MesoCycleCreated(2, BuildMeso(2)),
+            new MesoCycleCreated(4, BuildMeso(4)),
+        };
+
+        // Act
+        var act = () => new PlanEventSequence(BuildMacro(), mesos, new FirstMicroCycleCreated(BuildMicro()));
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*ordered for weeks 1..4*")
+            .Which.ParamName.Should().Be("mesos");
+    }
+
+    [Fact]
+    public void Constructor_DuplicateWeekIndex_Throws()
+    {
+        // Arrange — week 1, 1, 3, 4 (duplicate)
+        var mesos = new[]
+        {
+            new MesoCycleCreated(1, BuildMeso(1)),
+            new MesoCycleCreated(1, BuildMeso(1)),
+            new MesoCycleCreated(3, BuildMeso(3)),
+            new MesoCycleCreated(4, BuildMeso(4)),
+        };
+
+        // Act
+        var act = () => new PlanEventSequence(BuildMacro(), mesos, new FirstMicroCycleCreated(BuildMicro()));
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .Which.ParamName.Should().Be("mesos");
+    }
+
+    private static MesoCycleCreated[] BuildMesos() =>
+    [
+        new MesoCycleCreated(1, BuildMeso(1)),
+        new MesoCycleCreated(2, BuildMeso(2)),
+        new MesoCycleCreated(3, BuildMeso(3)),
+        new MesoCycleCreated(4, BuildMeso(4)),
+    ];
+
+    private static PlanGenerated BuildMacro() => new(
+        PlanId: Guid.Parse("00000000-0000-0000-0000-000000000010"),
+        UserId: Guid.Parse("00000000-0000-0000-0000-000000000020"),
+        Macro: new MacroPlanOutput
+        {
+            TotalWeeks = 4,
+            GoalDescription = "test",
+            Phases = Array.Empty<PlanPhaseOutput>(),
+            Rationale = string.Empty,
+            Warnings = string.Empty,
+        },
+        GeneratedAt: new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero),
+        PromptVersion: "v1",
+        ModelId: "test-model",
+        PreviousPlanId: null);
+
+    private static MesoWeekOutput BuildMeso(int weekNumber)
+    {
+        var rest = new MesoDaySlotOutput
+        {
+            SlotType = DaySlotType.Rest,
+            WorkoutType = null,
+            Notes = "rest",
+        };
+
+        return new MesoWeekOutput
+        {
+            WeekNumber = weekNumber,
+            PhaseType = PhaseType.Base,
+            WeeklyTargetKm = 20,
+            IsDeloadWeek = false,
+            Sunday = rest,
+            Monday = rest,
+            Tuesday = rest,
+            Wednesday = rest,
+            Thursday = rest,
+            Friday = rest,
+            Saturday = rest,
+            WeekSummary = $"Week {weekNumber}",
+        };
+    }
+
+    private static MicroWorkoutListOutput BuildMicro() => new()
+    {
+        Workouts = Array.Empty<WorkoutOutput>(),
+    };
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanGenerationServiceTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanGenerationServiceTests.cs
@@ -1,0 +1,598 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using RunCoach.Api.Modules.Coaching;
+using RunCoach.Api.Modules.Coaching.Models;
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+using RunCoach.Api.Modules.Coaching.Prompts;
+using RunCoach.Api.Modules.Training.Plan;
+
+namespace RunCoach.Api.Tests.Modules.Training.Plan;
+
+/// <summary>
+/// Unit tests over <see cref="PlanGenerationService"/> per Slice 1 § Unit 2
+/// R02.4-R02.6 (DEC-057 / R-066). Covers the six-call sequential ordering
+/// (1 macro + 4 meso + 1 micro), the <see cref="CacheControl.Ephemeral1h"/>
+/// breakpoint on every call, the partial-failure path (failure on the 4th
+/// meso call throws and returns no events), the input-prompt-stability rule
+/// (identical snapshot produces identical macro prompt bytes), and the
+/// <c>previousPlanId</c> threading onto <see cref="PlanGenerated"/>.
+/// </summary>
+public sealed class PlanGenerationServiceTests
+{
+    private static readonly Guid UserId = new("11111111-1111-1111-1111-111111111111");
+
+    private static readonly Guid PlanId = new("22222222-2222-2222-2222-222222222222");
+
+    private static readonly Guid PreviousPlanId = new("33333333-3333-3333-3333-333333333333");
+
+    private static readonly DateTimeOffset Now = new(2026, 4, 25, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task GeneratePlanAsync_InvokesSixCallsInMacroMesoMicroOrder()
+    {
+        // Arrange
+        var (sut, llm, _) = CreateSut();
+        ConfigureLlmHappyPath(llm);
+        var view = CreateCompletedView();
+
+        // Act
+        await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
+
+        // Assert — exactly one macro call, four meso calls, one micro call.
+        await llm.Received(1)
+            .GenerateStructuredAsync<MacroPlanOutput>(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, JsonElement>?>(),
+                Arg.Any<CacheControl?>(),
+                Arg.Any<CancellationToken>());
+
+        await llm.Received(PlanGenerationService.MesoWeekCount)
+            .GenerateStructuredAsync<MesoWeekOutput>(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, JsonElement>?>(),
+                Arg.Any<CacheControl?>(),
+                Arg.Any<CancellationToken>());
+
+        await llm.Received(1)
+            .GenerateStructuredAsync<MicroWorkoutListOutput>(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, JsonElement>?>(),
+                Arg.Any<CacheControl?>(),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GeneratePlanAsync_ReturnsCanonicalEventSequence()
+    {
+        // Arrange
+        var (sut, llm, _) = CreateSut();
+        ConfigureLlmHappyPath(llm);
+        var view = CreateCompletedView();
+
+        // Act
+        var events = await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
+
+        // Assert — sequence is exactly [PlanGenerated, MesoCycleCreated x4, FirstMicroCycleCreated].
+        events.Should().HaveCount(6);
+        events[0].Should().BeOfType<PlanGenerated>();
+        events[1].Should().BeOfType<MesoCycleCreated>();
+        events[2].Should().BeOfType<MesoCycleCreated>();
+        events[3].Should().BeOfType<MesoCycleCreated>();
+        events[4].Should().BeOfType<MesoCycleCreated>();
+        events[5].Should().BeOfType<FirstMicroCycleCreated>();
+
+        var weekIndices = events.OfType<MesoCycleCreated>().Select(e => e.WeekIndex).ToArray();
+        weekIndices.Should().Equal(1, 2, 3, 4);
+    }
+
+    [Fact]
+    public async Task GeneratePlanAsync_StampsModelIdAndPromptVersionOnPlanGenerated()
+    {
+        // Arrange
+        var (sut, llm, _) = CreateSut();
+        ConfigureLlmHappyPath(llm);
+        var view = CreateCompletedView();
+
+        // Act
+        var events = await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        var generated = events[0].Should().BeOfType<PlanGenerated>().Which;
+        generated.PlanId.Should().Be(PlanId);
+        generated.UserId.Should().Be(UserId);
+        generated.PromptVersion.Should().Be("v1");
+        generated.ModelId.Should().Be("test-model-id");
+        generated.GeneratedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public async Task GeneratePlanAsync_PreviousPlanIdNonNull_ThreadsOntoPlanGenerated()
+    {
+        // Arrange — Unit 5 regenerate flow passes the prior plan id; the
+        // service threads it through verbatim onto the stream-creation event.
+        var (sut, llm, _) = CreateSut();
+        ConfigureLlmHappyPath(llm);
+        var view = CreateCompletedView();
+
+        // Act
+        var events = await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: PreviousPlanId, TestContext.Current.CancellationToken);
+
+        // Assert
+        var generated = events[0].Should().BeOfType<PlanGenerated>().Which;
+        generated.PreviousPlanId.Should().Be(PreviousPlanId);
+    }
+
+    [Fact]
+    public async Task GeneratePlanAsync_PreviousPlanIdNull_LeavesPlanGeneratedPreviousNull()
+    {
+        // Arrange — Unit 1 onboarding-terminal flow passes null; the projection
+        // surface treats null as "this is the first plan".
+        var (sut, llm, _) = CreateSut();
+        ConfigureLlmHappyPath(llm);
+
+        // Act
+        var events = await sut.GeneratePlanAsync(CreateCompletedView(), UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        events[0].Should().BeOfType<PlanGenerated>().Which.PreviousPlanId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GeneratePlanAsync_SetsCacheControlEphemeral1hOnEveryCall()
+    {
+        // Arrange
+        var capturedCacheControls = new List<CacheControl?>();
+        var (sut, llm, _) = CreateSut();
+        ConfigureLlmHappyPath(llm, cacheCapture: capturedCacheControls);
+
+        // Act
+        await sut.GeneratePlanAsync(CreateCompletedView(), UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
+
+        // Assert — exactly six calls and every one carries the 1h ephemeral marker.
+        capturedCacheControls.Should().HaveCount(6);
+        capturedCacheControls.Should().AllSatisfy(c =>
+        {
+            c.Should().NotBeNull();
+            c!.Type.Should().Be("ephemeral");
+            c.Ttl.Should().Be("1h");
+        });
+        capturedCacheControls.Should().AllBeEquivalentTo(CacheControl.Ephemeral1h);
+    }
+
+    [Fact]
+    public async Task GeneratePlanAsync_FailureOnFourthMesoCall_ThrowsAndReturnsNoEvents()
+    {
+        // Arrange — macro succeeds, mesos 1-3 succeed, meso 4 throws. The
+        // service must propagate the exception without returning any partial
+        // event list. The caller's transactional middleware then rolls back.
+        var (sut, llm, _) = CreateSut();
+        ConfigureMacroSuccess(llm);
+
+        var mesoCalls = 0;
+        llm
+            .GenerateStructuredAsync<MesoWeekOutput>(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, JsonElement>?>(),
+                Arg.Any<CacheControl?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                mesoCalls++;
+                if (mesoCalls == 4)
+                {
+                    throw new InvalidOperationException("simulated meso 4 failure");
+                }
+
+                return BuildMeso(mesoCalls, PhaseType.Base, isDeload: false);
+            });
+
+        // Act
+        var act = () => sut.GeneratePlanAsync(CreateCompletedView(), UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
+
+        // Assert — exception propagates; micro is never called.
+        var exception = await act.Should().ThrowAsync<InvalidOperationException>();
+        exception.Which.Message.Should().Contain("meso 4 failure");
+
+        await llm.DidNotReceive()
+            .GenerateStructuredAsync<MicroWorkoutListOutput>(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, JsonElement>?>(),
+                Arg.Any<CacheControl?>(),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GeneratePlanAsync_TwoInvocations_SameSnapshot_ProduceIdenticalMacroUserMessage()
+    {
+        // Arrange — two replays of the chain on the same captured snapshot
+        // must hand the LLM byte-identical macro user-message bytes so
+        // Anthropic's prompt-prefix cache hits on call 1 of replay 2.
+        var (sut, llm, _) = CreateSut();
+        ConfigureLlmHappyPath(llm);
+
+        var capturedMacroPrompts = new List<string>();
+        llm
+            .GenerateStructuredAsync<MacroPlanOutput>(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, JsonElement>?>(),
+                Arg.Any<CacheControl?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                capturedMacroPrompts.Add(call.ArgAt<string>(1));
+                return BuildMacro();
+            });
+
+        var view = CreateCompletedView();
+
+        // Act
+        await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
+        await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
+
+        // Assert — both macro prompts are byte-identical.
+        capturedMacroPrompts.Should().HaveCount(2);
+        capturedMacroPrompts[0].Should().Be(capturedMacroPrompts[1]);
+    }
+
+    [Fact]
+    public async Task GeneratePlanAsync_NullProfileSnapshot_Throws()
+    {
+        // Arrange
+        var (sut, _, _) = CreateSut();
+
+        // Act
+        var act = () => sut.GeneratePlanAsync(profileSnapshot: null!, UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData(1, PhaseType.Base, false)]
+    [InlineData(8, PhaseType.Base, true)] // last week of an 8-week phase that includes deload.
+    [InlineData(9, PhaseType.Build, false)] // first week of next phase.
+    public void WeekContext_FromMacro_DerivesPhaseAndDeloadCandidate(
+        int weekIndex,
+        PhaseType expectedPhase,
+        bool expectedDeloadCandidate)
+    {
+        // Arrange — 8-week Base (includes deload) followed by 4-week Build.
+        var macro = new MacroPlanOutput
+        {
+            TotalWeeks = 12,
+            GoalDescription = "Half Marathon",
+            Phases = new[]
+            {
+                new PlanPhaseOutput
+                {
+                    PhaseType = PhaseType.Base,
+                    Weeks = 8,
+                    WeeklyDistanceStartKm = 30,
+                    WeeklyDistanceEndKm = 50,
+                    IntensityDistribution = "80/20",
+                    AllowedWorkoutTypes = new[] { WorkoutType.Easy, WorkoutType.LongRun },
+                    TargetPaceEasySecPerKm = 360,
+                    TargetPaceFastSecPerKm = 300,
+                    Notes = string.Empty,
+                    IncludesDeload = true,
+                },
+                new PlanPhaseOutput
+                {
+                    PhaseType = PhaseType.Build,
+                    Weeks = 4,
+                    WeeklyDistanceStartKm = 50,
+                    WeeklyDistanceEndKm = 60,
+                    IntensityDistribution = "70/30",
+                    AllowedWorkoutTypes = new[] { WorkoutType.Easy, WorkoutType.Tempo },
+                    TargetPaceEasySecPerKm = 350,
+                    TargetPaceFastSecPerKm = 280,
+                    Notes = string.Empty,
+                    IncludesDeload = false,
+                },
+            },
+            Rationale = string.Empty,
+            Warnings = string.Empty,
+        };
+
+        // Act
+        var actual = PlanGenerationService.WeekContext.FromMacro(macro, weekIndex);
+
+        // Assert
+        actual.WeekIndex.Should().Be(weekIndex);
+        actual.PhaseType.Should().Be(expectedPhase);
+        actual.IsDeloadCandidate.Should().Be(expectedDeloadCandidate);
+    }
+
+    [Fact]
+    public void WeekContext_FromMacro_NoPhases_ReturnsBaseDefault()
+    {
+        // Arrange — defensive path: macro with empty Phases shouldn't crash.
+        var macro = new MacroPlanOutput
+        {
+            TotalWeeks = 0,
+            GoalDescription = string.Empty,
+            Phases = Array.Empty<PlanPhaseOutput>(),
+            Rationale = string.Empty,
+            Warnings = string.Empty,
+        };
+
+        // Act
+        var actual = PlanGenerationService.WeekContext.FromMacro(macro, weekIndex: 1);
+
+        // Assert
+        actual.PhaseType.Should().Be(PhaseType.Base);
+        actual.IsDeloadCandidate.Should().BeFalse();
+    }
+
+    [Fact]
+    public void WeekContext_FromMacro_WeekIndexBelowOne_Throws()
+    {
+        // Arrange
+        var macro = BuildMacro();
+
+        // Act
+        var act = () => PlanGenerationService.WeekContext.FromMacro(macro, weekIndex: 0);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    private static (PlanGenerationService Sut, ICoachingLlm Llm, IContextAssembler Assembler) CreateSut()
+    {
+        var assembler = Substitute.For<IContextAssembler>();
+        assembler
+            .ComposeForPlanGenerationAsync(
+                Arg.Any<OnboardingView>(),
+                Arg.Any<RegenerationIntent?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                // Mirror the real assembler's deterministic shape: a stable
+                // system prompt + a snapshot-derived user message that
+                // appends the optional intent at the end.
+                var view = call.ArgAt<OnboardingView>(0);
+                var intent = call.ArgAt<RegenerationIntent?>(1);
+                var userMessage = $"PROFILE SNAPSHOT for {view.UserId}\nPrimaryGoal: {view.PrimaryGoal?.Goal}";
+                if (intent is not null)
+                {
+                    userMessage += $"\n\n[Regeneration intent provided by user]\n{intent.FreeText}";
+                }
+
+                return new PlanGenerationPromptComposition(
+                    SystemPrompt: "stable test system prompt",
+                    UserMessage: userMessage);
+            });
+
+        var llm = Substitute.For<ICoachingLlm>();
+
+        var promptStore = Substitute.For<IPromptStore>();
+        promptStore.GetActiveVersion(ContextAssembler.CoachingPromptId).Returns("v1");
+
+        var settings = Options.Create(new CoachingLlmSettings
+        {
+            ApiKey = "[REDACTED]",
+            ModelId = "test-model-id",
+        });
+
+        var timeProvider = Substitute.For<TimeProvider>();
+        timeProvider.GetUtcNow().Returns(Now);
+
+        var sut = new PlanGenerationService(
+            assembler,
+            llm,
+            promptStore,
+            settings,
+            timeProvider,
+            NullLogger<PlanGenerationService>.Instance);
+
+        return (sut, llm, assembler);
+    }
+
+    private static void ConfigureMacroSuccess(ICoachingLlm llm)
+    {
+        llm
+            .GenerateStructuredAsync<MacroPlanOutput>(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, JsonElement>?>(),
+                Arg.Any<CacheControl?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => BuildMacro());
+    }
+
+    private static void ConfigureLlmHappyPath(
+        ICoachingLlm llm,
+        List<CacheControl?>? cacheCapture = null)
+    {
+        ConfigureMacroSuccess(llm);
+
+        var mesoCounter = 0;
+        llm
+            .GenerateStructuredAsync<MesoWeekOutput>(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, JsonElement>?>(),
+                Arg.Any<CacheControl?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                mesoCounter++;
+                return BuildMeso(mesoCounter, PhaseType.Base, isDeload: false);
+            });
+
+        llm
+            .GenerateStructuredAsync<MicroWorkoutListOutput>(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, JsonElement>?>(),
+                Arg.Any<CacheControl?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => BuildMicro());
+
+        if (cacheCapture is not null)
+        {
+            llm
+                .When(static x => x.GenerateStructuredAsync<MacroPlanOutput>(
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    Arg.Any<IReadOnlyDictionary<string, JsonElement>?>(),
+                    Arg.Any<CacheControl?>(),
+                    Arg.Any<CancellationToken>()))
+                .Do(call => cacheCapture.Add(call.ArgAt<CacheControl?>(3)));
+
+            llm
+                .When(static x => x.GenerateStructuredAsync<MesoWeekOutput>(
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    Arg.Any<IReadOnlyDictionary<string, JsonElement>?>(),
+                    Arg.Any<CacheControl?>(),
+                    Arg.Any<CancellationToken>()))
+                .Do(call => cacheCapture.Add(call.ArgAt<CacheControl?>(3)));
+
+            llm
+                .When(static x => x.GenerateStructuredAsync<MicroWorkoutListOutput>(
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    Arg.Any<IReadOnlyDictionary<string, JsonElement>?>(),
+                    Arg.Any<CacheControl?>(),
+                    Arg.Any<CancellationToken>()))
+                .Do(call => cacheCapture.Add(call.ArgAt<CacheControl?>(3)));
+        }
+    }
+
+    private static OnboardingView CreateCompletedView() => new()
+    {
+        Id = Guid.Parse("00000000-0000-0000-0000-000000000010"),
+        UserId = Guid.Parse("00000000-0000-0000-0000-000000000010"),
+        TenantId = "00000000-0000-0000-0000-000000000010",
+        Status = OnboardingStatus.Completed,
+        OnboardingStartedAt = new DateTimeOffset(2026, 04, 25, 12, 0, 0, TimeSpan.Zero),
+        OnboardingCompletedAt = new DateTimeOffset(2026, 04, 25, 12, 30, 0, TimeSpan.Zero),
+        Version = 12,
+        PrimaryGoal = new PrimaryGoalAnswer
+        {
+            Goal = PrimaryGoal.RaceTraining,
+            Description = "training for a half marathon",
+        },
+    };
+
+    private static MacroPlanOutput BuildMacro()
+    {
+        return new MacroPlanOutput
+        {
+            TotalWeeks = 12,
+            GoalDescription = "Half Marathon",
+            Phases = new[]
+            {
+                new PlanPhaseOutput
+                {
+                    PhaseType = PhaseType.Base,
+                    Weeks = 8,
+                    WeeklyDistanceStartKm = 30,
+                    WeeklyDistanceEndKm = 50,
+                    IntensityDistribution = "80/20",
+                    AllowedWorkoutTypes = new[] { WorkoutType.Easy, WorkoutType.LongRun, WorkoutType.Recovery },
+                    TargetPaceEasySecPerKm = 360,
+                    TargetPaceFastSecPerKm = 300,
+                    Notes = "Aerobic base.",
+                    IncludesDeload = true,
+                },
+                new PlanPhaseOutput
+                {
+                    PhaseType = PhaseType.Build,
+                    Weeks = 4,
+                    WeeklyDistanceStartKm = 50,
+                    WeeklyDistanceEndKm = 60,
+                    IntensityDistribution = "70/30",
+                    AllowedWorkoutTypes = new[] { WorkoutType.Easy, WorkoutType.Tempo },
+                    TargetPaceEasySecPerKm = 350,
+                    TargetPaceFastSecPerKm = 280,
+                    Notes = "Race-specific build.",
+                    IncludesDeload = false,
+                },
+            },
+            Rationale = "Base then build.",
+            Warnings = "Stop on sharp pain.",
+        };
+    }
+
+    private static MesoWeekOutput BuildMeso(int weekNumber, PhaseType phase, bool isDeload)
+    {
+        var slot = new MesoDaySlotOutput
+        {
+            SlotType = DaySlotType.Run,
+            WorkoutType = WorkoutType.Easy,
+            Notes = "Easy aerobic.",
+        };
+
+        var rest = new MesoDaySlotOutput
+        {
+            SlotType = DaySlotType.Rest,
+            WorkoutType = null,
+            Notes = "Rest.",
+        };
+
+        return new MesoWeekOutput
+        {
+            WeekNumber = weekNumber,
+            PhaseType = phase,
+            WeeklyTargetKm = isDeload ? 30 : 45,
+            IsDeloadWeek = isDeload,
+            Sunday = slot,
+            Monday = rest,
+            Tuesday = slot,
+            Wednesday = rest,
+            Thursday = slot,
+            Friday = rest,
+            Saturday = slot,
+            WeekSummary = $"Week {weekNumber}",
+        };
+    }
+
+    private static MicroWorkoutListOutput BuildMicro()
+    {
+        return new MicroWorkoutListOutput
+        {
+            Workouts = new[]
+            {
+                new WorkoutOutput
+                {
+                    DayOfWeek = 0,
+                    WorkoutType = WorkoutType.Easy,
+                    Title = "Easy run",
+                    TargetDistanceKm = 8,
+                    TargetDurationMinutes = 50,
+                    TargetPaceEasySecPerKm = 360,
+                    TargetPaceFastSecPerKm = 360,
+                    Segments = new[]
+                    {
+                        new WorkoutSegmentOutput
+                        {
+                            SegmentType = SegmentType.Work,
+                            DurationMinutes = 50,
+                            TargetPaceSecPerKm = 360,
+                            Intensity = IntensityProfile.Easy,
+                            Repetitions = 1,
+                            Notes = "Steady aerobic.",
+                        },
+                    },
+                    WarmupNotes = string.Empty,
+                    CooldownNotes = string.Empty,
+                    CoachingNotes = "Conversational pace.",
+                    PerceivedEffort = 3,
+                },
+            },
+        };
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanGenerationServiceTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanGenerationServiceTests.cs
@@ -78,9 +78,11 @@ public sealed class PlanGenerationServiceTests
         var view = CreateCompletedView();
 
         // Act
-        var events = await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
+        var sequence = await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
 
-        // Assert — sequence is exactly [PlanGenerated, MesoCycleCreated x4, FirstMicroCycleCreated].
+        // Assert — wrapper enforces shape; ToEvents flattens to canonical order.
+        sequence.Mesos.Should().HaveCount(PlanEventSequence.ExpectedMesoCount);
+        var events = sequence.ToEvents();
         events.Should().HaveCount(6);
         events[0].Should().BeOfType<PlanGenerated>();
         events[1].Should().BeOfType<MesoCycleCreated>();
@@ -89,7 +91,7 @@ public sealed class PlanGenerationServiceTests
         events[4].Should().BeOfType<MesoCycleCreated>();
         events[5].Should().BeOfType<FirstMicroCycleCreated>();
 
-        var weekIndices = events.OfType<MesoCycleCreated>().Select(e => e.WeekIndex).ToArray();
+        var weekIndices = sequence.Mesos.Select(e => e.WeekIndex).ToArray();
         weekIndices.Should().Equal(1, 2, 3, 4);
     }
 
@@ -102,10 +104,10 @@ public sealed class PlanGenerationServiceTests
         var view = CreateCompletedView();
 
         // Act
-        var events = await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
+        var sequence = await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
 
         // Assert
-        var generated = events[0].Should().BeOfType<PlanGenerated>().Which;
+        var generated = sequence.Macro;
         generated.PlanId.Should().Be(PlanId);
         generated.UserId.Should().Be(UserId);
         generated.PromptVersion.Should().Be("v1");
@@ -123,11 +125,10 @@ public sealed class PlanGenerationServiceTests
         var view = CreateCompletedView();
 
         // Act
-        var events = await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: PreviousPlanId, TestContext.Current.CancellationToken);
+        var sequence = await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: PreviousPlanId, TestContext.Current.CancellationToken);
 
         // Assert
-        var generated = events[0].Should().BeOfType<PlanGenerated>().Which;
-        generated.PreviousPlanId.Should().Be(PreviousPlanId);
+        sequence.Macro.PreviousPlanId.Should().Be(PreviousPlanId);
     }
 
     [Fact]
@@ -139,10 +140,10 @@ public sealed class PlanGenerationServiceTests
         ConfigureLlmHappyPath(llm);
 
         // Act
-        var events = await sut.GeneratePlanAsync(CreateCompletedView(), UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
+        var sequence = await sut.GeneratePlanAsync(CreateCompletedView(), UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
 
         // Assert
-        events[0].Should().BeOfType<PlanGenerated>().Which.PreviousPlanId.Should().BeNull();
+        sequence.Macro.PreviousPlanId.Should().BeNull();
     }
 
     [Fact]
@@ -306,7 +307,7 @@ public sealed class PlanGenerationServiceTests
         };
 
         // Act
-        var actual = PlanGenerationService.WeekContext.FromMacro(macro, weekIndex);
+        var actual = WeekContext.FromMacro(macro, weekIndex);
 
         // Assert
         actual.WeekIndex.Should().Be(weekIndex);
@@ -328,7 +329,7 @@ public sealed class PlanGenerationServiceTests
         };
 
         // Act
-        var actual = PlanGenerationService.WeekContext.FromMacro(macro, weekIndex: 1);
+        var actual = WeekContext.FromMacro(macro, weekIndex: 1);
 
         // Assert
         actual.PhaseType.Should().Be(PhaseType.Base);
@@ -342,10 +343,30 @@ public sealed class PlanGenerationServiceTests
         var macro = BuildMacro();
 
         // Act
-        var act = () => PlanGenerationService.WeekContext.FromMacro(macro, weekIndex: 0);
+        var act = () => WeekContext.FromMacro(macro, weekIndex: 0);
 
         // Assert
         act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void WeekContext_FromMacro_WeekIndexPastDeclaredPhases_ReturnsLastPhaseWithoutDeload()
+    {
+        // Arrange — 12-week macro (8 Base + 4 Build); the defensive path at
+        // PlanGenerationService.cs:340-341 fires when weekIndex exceeds the
+        // cumulative phase coverage (e.g. an LLM under-declared the macro).
+        var macro = BuildMacro();
+        const int weekIndexPastEnd = 13;
+
+        // Act
+        var actual = WeekContext.FromMacro(macro, weekIndexPastEnd);
+
+        // Assert — fall through returns the last declared phase (Build) with
+        // IsDeloadCandidate forced false so the deload heuristic stays off
+        // for under-declared territory.
+        actual.WeekIndex.Should().Be(weekIndexPastEnd);
+        actual.PhaseType.Should().Be(PhaseType.Build);
+        actual.IsDeloadCandidate.Should().BeFalse();
     }
 
     private static (PlanGenerationService Sut, ICoachingLlm Llm, IContextAssembler Assembler) CreateSut()

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanGenerationServiceTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanGenerationServiceTests.cs
@@ -67,6 +67,28 @@ public sealed class PlanGenerationServiceTests
                 Arg.Any<IReadOnlyDictionary<string, JsonElement>?>(),
                 Arg.Any<CacheControl?>(),
                 Arg.Any<CancellationToken>());
+
+        // Per CodeRabbit feedback: count assertions alone do not catch a
+        // micro-before-meso regression. Inspect the actual invocation
+        // sequence via ReceivedCalls() and assert macro → meso × N → micro.
+        var llmCallTypes = llm.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(ICoachingLlm.GenerateStructuredAsync))
+            .Select(c => c.GetMethodInfo().GetGenericArguments()[0])
+            .ToArray();
+
+        var expectedSequence = new List<Type>(2 + PlanGenerationService.MesoWeekCount)
+        {
+            typeof(MacroPlanOutput),
+        };
+        for (var i = 0; i < PlanGenerationService.MesoWeekCount; i++)
+        {
+            expectedSequence.Add(typeof(MesoWeekOutput));
+        }
+
+        expectedSequence.Add(typeof(MicroWorkoutListOutput));
+        llmCallTypes.Should().Equal(
+            expectedSequence,
+            because: "macro → meso×4 → micro must fire in canonical order");
     }
 
     [Fact]


### PR DESCRIPTION
Sixth and final PR splitting #67 into reviewable units. Stacked on #77.

## What this lands

The integration glue plus closeout fixes:

- \`db5f3a7\` — \`PlanGenerationService\` macro/meso/micro orchestration + \`IPlanGenerationService\` interface
- \`f6b674a\` — \`OnboardingTurnHandler\` per-turn handler with inline plan generation, output validator, completion gate, transaction-scope tests, controller endpoints
- \`2295ab7\` — Mid-cycle infra fixes: \`UserProfile\` Marten tenancy + sanitization corpus regressions (with two follow-up EF migrations)
- \`6a44d35\` — \`MartenStoreOptionsCompositionTests\` regression-guard pinning the \`opts.Add(...)\` registration shape (DEC-061)
- \`72dff5c\` — Camelcase wire format for assistant/user blocks + clarification fallback DTO fix
- \`b902f39\` — Pre-push hook drops integration tests via MTP-native \`-trait Category=Integration\` exclusion
- \`f01a03b\` (new in this split) — \`OnboardingTurnConcurrencyTests\`: 5 concurrent first-turn submissions for the same user-stream, asserts exactly 1 success and 4 \`ExistingStreamIdCollisionException\`/\`MartenCommandException\` failures. This is the regression guard for the DEC-057 contract enabled in 67a (#73). Resolves the test-only half of task #172.

## Why one PR

The handler, plan generation service, and corpus/tenancy fixes are tightly coupled — \`OnboardingTurnHandler\` invokes \`PlanGenerationService\`, both depend on the context assemblers from #77, and the \`2295ab7\` corpus regression touched both sanitizer and projection in a single fix. Splitting further would require extracting partial commits.

## Stacked on

#77 (\`slice-1a5-context-assembly\`). This is the new tip of the slice-1a chain — PRs #68-#72 will be rebased onto this branch.

## Testing

- \`dotnet build\` — zero warnings.
- Pre-push hook (unit + eval-cache replay) — green.
- DEC-057 concurrency regression test ships here.
- Full integration suite runs in CI; Marten advisory-lock fix from #73 expected to keep CI green on slow runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive onboarding flow with conversational turn submissions, state tracking, and answer revision endpoints
  * Integrated AI-powered coaching interactions with structured output validation
  * Implemented automatic training plan generation triggered upon onboarding completion
  * Enforced validation for required profile answers before plan creation

* **Tests**
  * Added comprehensive unit and integration test suites for onboarding workflows, completion logic, and plan generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->