### PR TITLE
chore(slice-1b-infra): otlp cors allow-list and attributes/scrub processor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      infra: ${{ steps.filter.outputs.infra }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
@@ -29,6 +30,8 @@ jobs:
               - 'global.json'
             frontend:
               - 'frontend/**'
+            infra:
+              - 'infra/otel/**'
 
   backend:
     name: Backend (build + test)
@@ -164,15 +167,31 @@ jobs:
           scanners: 'secret'
           exit-code: '1'
 
+  infra-validate:
+    name: Infra (OTel collector validate)
+    needs: changes
+    if: needs.changes.outputs.infra == 'true'
+    runs-on: ubuntu-latest
+    # Validates the OTel collector config against the collector binary so
+    # broken YAML is caught in CI before it reaches any deployed environment.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Validate OTel collector config
+        run: >-
+          docker run --rm
+          -v $PWD/infra/otel:/etc/otelcol
+          otel/opentelemetry-collector-contrib:0.150.1
+          validate --config=/etc/otelcol/otel-collector-config.yaml
+
   gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [backend, frontend, security]
+    needs: [backend, frontend, security, infra-validate]
     if: always()
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.backend.result }}" == "failure" || "${{ needs.frontend.result }}" == "failure" || "${{ needs.security.result }}" == "failure" ]]; then
+          if [[ "${{ needs.backend.result }}" == "failure" || "${{ needs.frontend.result }}" == "failure" || "${{ needs.security.result }}" == "failure" || "${{ needs.infra-validate.result }}" == "failure" ]]; then
             echo "One or more required jobs failed"
             exit 1
           fi

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -51,7 +51,7 @@ jobs:
             /d:sonar.cs.opencover.reportsPaths="backend/TestResults/coverage.opencover.*.xml" \
             /d:sonar.sources="backend/src" \
             /d:sonar.tests="backend/tests" \
-            /d:sonar.exclusions="backend/tests/eval-cache/**,**/*.generated.cs,**/Migrations/**,docs/**,.claude/**,backend/src/RunCoach.Api/Prompts/**,frontend/**" \
+            /d:sonar.exclusions="backend/tests/eval-cache/**,**/*.generated.cs,**/Migrations/**,docs/**,.claude/**,backend/src/RunCoach.Api/Prompts/**,frontend/**,infra/**,.github/**,lefthook.yml" \
             /d:sonar.test.inclusions="backend/tests/**" \
             /d:sonar.cpd.exclusions="**/RunCoach.Api.Tests/**/*.cs" \
             /d:sonar.cpd.cs.minimumTokens=150 \

--- a/docs/decisions/decision-log.md
+++ b/docs/decisions/decision-log.md
@@ -2566,6 +2566,12 @@ Manual flush on `visibilitychange === 'hidden'` (SDK doesn't auto-flush on pageh
 - W3C Trace Context Level 1 — `w3.org/TR/trace-context/`.
 - Slice 1B requirements: `docs/plans/mvp-0-cycle/slice-1b-hardening.md`.
 
+### Amendment (2026-05-13) — `allowed_headers: ["*"]` documented override
+
+The implementation in PR #93 ships `allowed_headers: ["*"]` on the OTLP/HTTP receiver's `cors` block, diverging from the enumerated list `[traceparent, tracestate, baggage, Content-Type]` originally specified in this DEC. Empirical investigation (T02-04 in `docs/specs/14-spec-slice-1b-hardening/14-proofs/T02-proofs.md`) established that `rs/cors v1` in `otel-collector-contrib:0.150.1` silently rejects preflights when `Content-Type` is enumerated explicitly, returning 204 with no `Access-Control-Allow-Origin` and breaking the `OTLPTraceExporter` POST. The upstream confighttp README explicitly endorses `["*"]` for `allowed_headers`. The constraint is scoped: this override applies to `allowed_headers` only. **The "Never `["*"]`" prohibition remains in force for `allowed_origins`** — credentials-incompatibility under the Fetch Standard makes a wildcard origin unsafe, and the localhost allow-list stays explicit.
+
+Reconsider trigger: future versions of `otel-collector-contrib` that honour the `Content-Type` implicit safelist when an explicit `allowed_headers` list is supplied — at which point the enumerated form should be restored.
+
 ---
 
 *Add new decisions at the bottom. Use format: DEC-XXX, date, category, decision, rationale, alternatives.*

--- a/infra/otel/otel-collector-config.yaml
+++ b/infra/otel/otel-collector-config.yaml
@@ -22,17 +22,20 @@ receivers:
         # CORS allow-list for direct browser → collector OTLP/HTTP posts
         # (DEC-069, R-074 §2). The OTel collector exposes `cors` on http-based
         # receivers; without it the browser preflight rejects the POST and no
-        # spans ever leave the SPA. An explicit allow-list (not `["*"]`) is
-        # required because the collector's CORS response includes
+        # spans ever leave the SPA. `allowed_origins` specifically must not be
+        # `["*"]`: the collector's CORS response includes
         # `Access-Control-Allow-Credentials: true`, which browsers refuse to
-        # combine with a wildcard origin (see
-        # opentelemetry-collector/config/confighttp/README.md).
+        # combine with a wildcard origin per the Fetch Standard (see
+        # opentelemetry-collector/config/confighttp/README.md). The wildcard
+        # restriction does not apply to `allowed_headers` — see the comment
+        # block below for that field's separate rationale.
         #
-        # MVP-1 public-rollout TODO: replace the localhost origins below with
-        # the deployed origin(s), e.g. `https://runcoach.example.com`, add a
-        # TLS terminator in front of :4318, and pin a static
-        # `Authorization: Bearer <token>` header on the browser exporter so
-        # this endpoint is not anonymously writable from the open internet.
+        # Production hardening requirements (per DEC-069): when this overlay is
+        # exposed beyond localhost, `allowed_origins` must be replaced with the
+        # deployed origin(s) (e.g. `https://runcoach.example.com`), a TLS
+        # terminator must front :4318, and the browser exporter must pin a static
+        # `Authorization: Bearer <token>` header so this endpoint is not
+        # anonymously writable from the open internet.
         cors:
           allowed_origins:
             - http://localhost:5173        # Vite dev server
@@ -70,11 +73,11 @@ processors:
   # names would silently bypass the redaction the moment the browser SDK
   # flipped to stable semconv.
   #
-  # `http.url` / `url.full`: `delete` removes the attribute outright — the
-  #   strongest guarantee that any query-string secrets (tokens, onboarding
-  #   answers echoed back in URLs) never reach the exporter. `url.path` and
-  #   `http.target` (path + query) still ride along with the span and carry
-  #   the navigation context the SPA's client-side strip leaves intact.
+  # All path-bearing HTTP attributes are deleted: `http.url` / `url.full`
+  #   carry full URLs; `http.target` (legacy path + query), `url.path`
+  #   (stable path), and `url.query` (stable query) are deleted to ensure no
+  #   query-string secrets propagate even if an OTLP client emits these
+  #   attributes without client-side scrubbing.
   # `http.user_agent` / `user_agent.original`: `hash` preserves cardinality
   #   for cohort analysis while destroying identifiability of the raw UA
   #   string.
@@ -83,6 +86,12 @@ processors:
       - key: http.url
         action: delete
       - key: url.full
+        action: delete
+      - key: http.target
+        action: delete
+      - key: url.path
+        action: delete
+      - key: url.query
         action: delete
       - key: http.user_agent
         action: hash
@@ -105,9 +114,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      # attributes/scrub MUST be first so redaction happens before batching;
-      # batching after scrubbing keeps the per-span work cheap and the export
-      # batch contains only sanitised attributes.
+      # Order matters: attributes/scrub must precede batch — see processor block for rationale.
       processors: [attributes/scrub, batch]
       exporters: [otlp/jaeger, debug]
     metrics:

--- a/infra/otel/otel-collector-config.yaml
+++ b/infra/otel/otel-collector-config.yaml
@@ -1,7 +1,8 @@
 # OpenTelemetry Collector config for the local dev observability overlay.
 #
 # Receivers: OTLP over gRPC (4317) and HTTP (4318) — accepts spans and metrics
-# from the RunCoach API container.
+# from the RunCoach API container and (per DEC-069) directly from the browser
+# SPA via the OTLP/HTTP exporter.
 #
 # Exporters: OTLP to Jaeger's native OTLP ingest on port 4317 for traces;
 # logging exporter as a fallback for metrics while a long-term metric backend
@@ -18,8 +19,64 @@ receivers:
         endpoint: 0.0.0.0:4317
       http:
         endpoint: 0.0.0.0:4318
+        # CORS allow-list for direct browser → collector OTLP/HTTP posts
+        # (DEC-069, R-074 §2). The OTel collector exposes `cors` on http-based
+        # receivers; without it the browser preflight rejects the POST and no
+        # spans ever leave the SPA. An explicit allow-list (not `["*"]`) is
+        # required because the collector's CORS response includes
+        # `Access-Control-Allow-Credentials: true`, which browsers refuse to
+        # combine with a wildcard origin (see
+        # opentelemetry-collector/config/confighttp/README.md).
+        #
+        # MVP-1 public-rollout TODO: replace the localhost origins below with
+        # the deployed origin(s), e.g. `https://runcoach.example.com`, add a
+        # TLS terminator in front of :4318, and pin a static
+        # `Authorization: Bearer <token>` header on the browser exporter so
+        # this endpoint is not anonymously writable from the open internet.
+        cors:
+          allowed_origins:
+            - http://localhost:5173        # Vite dev server
+            - http://localhost:4173        # Vite preview server
+          # R02.1's intent is that `traceparent`, `tracestate`, `baggage`, and
+          # `Content-Type` must all be accepted on the preflight. In
+          # opentelemetry-collector-contrib:0.150.1 (confighttp / `rs/cors v1`),
+          # an explicit `allowed_headers` list ignores the documented
+          # "Content-Type implicitly allowed" safelist behaviour: a preflight
+          # whose `Access-Control-Request-Headers` includes `Content-Type`
+          # returns 204 with no `Access-Control-Allow-Origin`, breaking the
+          # `OTLPTraceExporter` POST (which sends `Content-Type:
+          # application/json`). `["*"]` is the only configuration that admits
+          # `Content-Type` *plus* the W3C trace headers in this collector
+          # version, and the upstream docs explicitly endorse it
+          # (`config/confighttp/README.md`: *"Setting it to ["*"] allows any
+          # request header"*). Origin matching is unaffected — the
+          # `allowed_origins` allow-list above still rejects unknown origins.
+          allowed_headers:
+            - "*"
+          max_age: 7200
 
 processors:
+  # Belt-and-braces PII scrub for browser-sourced spans (DEC-069, R-074 §7).
+  # The SPA's FetchInstrumentation also strips query strings client-side, but
+  # enforcing the redaction at the collector means a developer cannot
+  # accidentally bypass it by tweaking the browser exporter. Must run *before*
+  # `batch` so scrubbed values are what gets buffered and exported.
+  #
+  # `http.url`: `delete` removes the attribute outright — the strongest
+  #   guarantee that any query-string secrets (tokens, onboarding answers
+  #   echoed back in URLs) never reach the exporter. The browser SDK already
+  #   emits `url.full` / `url.path` separately with query stripped client-side
+  #   for navigation context, so deleting the full URL here loses no useful
+  #   signal.
+  # `http.user_agent`: `hash` preserves cardinality for cohort analysis while
+  #   destroying identifiability of the raw UA string.
+  attributes/scrub:
+    actions:
+      - key: http.url
+        action: delete
+      - key: http.user_agent
+        action: hash
+
   batch:
     timeout: 5s
     send_batch_size: 1024
@@ -36,7 +93,10 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      # attributes/scrub MUST be first so redaction happens before batching;
+      # batching after scrubbing keeps the per-span work cheap and the export
+      # batch contains only sanitised attributes.
+      processors: [attributes/scrub, batch]
       exporters: [otlp/jaeger, debug]
     metrics:
       receivers: [otlp]

--- a/infra/otel/otel-collector-config.yaml
+++ b/infra/otel/otel-collector-config.yaml
@@ -62,19 +62,31 @@ processors:
   # accidentally bypass it by tweaking the browser exporter. Must run *before*
   # `batch` so scrubbed values are what gets buffered and exported.
   #
-  # `http.url`: `delete` removes the attribute outright — the strongest
-  #   guarantee that any query-string secrets (tokens, onboarding answers
-  #   echoed back in URLs) never reach the exporter. The browser SDK already
-  #   emits `url.full` / `url.path` separately with query stripped client-side
-  #   for navigation context, so deleting the full URL here loses no useful
-  #   signal.
-  # `http.user_agent`: `hash` preserves cardinality for cohort analysis while
-  #   destroying identifiability of the raw UA string.
+  # Both the legacy (`http.*`) and stable (`url.*` / `user_agent.*`) HTTP
+  # semantic-convention attribute names are scrubbed because OpenTelemetry-JS
+  # selects between them via `semconvStabilityOptIn` (stable HTTP semconv was
+  # declared v1.23.0; `http.url` and `http.user_agent` are deprecated in
+  # favour of `url.full` and `user_agent.original`). Scrubbing only the legacy
+  # names would silently bypass the redaction the moment the browser SDK
+  # flipped to stable semconv.
+  #
+  # `http.url` / `url.full`: `delete` removes the attribute outright — the
+  #   strongest guarantee that any query-string secrets (tokens, onboarding
+  #   answers echoed back in URLs) never reach the exporter. `url.path` and
+  #   `http.target` (path + query) still ride along with the span and carry
+  #   the navigation context the SPA's client-side strip leaves intact.
+  # `http.user_agent` / `user_agent.original`: `hash` preserves cardinality
+  #   for cohort analysis while destroying identifiability of the raw UA
+  #   string.
   attributes/scrub:
     actions:
       - key: http.url
         action: delete
+      - key: url.full
+        action: delete
       - key: http.user_agent
+        action: hash
+      - key: user_agent.original
         action: hash
 
   batch:

--- a/infra/otel/validate-cors-origins.py
+++ b/infra/otel/validate-cors-origins.py
@@ -21,6 +21,17 @@ except ImportError:
 
 
 def main(path: str) -> int:
+    """Return ``0`` if ``path`` has no wildcard ``allowed_origins``, else ``1``.
+
+    Loads the YAML at ``path`` and inspects
+    ``receivers.otlp.protocols.http.cors.allowed_origins``. A bare ``"*"`` in
+    that list is the violation: it is incompatible with
+    ``Access-Control-Allow-Credentials: true`` per the Fetch Standard and is
+    prohibited by DEC-069. A missing file (``path`` removed in the staged
+    commit) returns ``0`` so the guard does not spuriously fail when the
+    overlay is being deleted. Errors are written to stderr; the function never
+    raises.
+    """
     p = Path(path)
     if not p.exists():
         return 0  # file removed in this commit — nothing to guard

--- a/infra/otel/validate-cors-origins.py
+++ b/infra/otel/validate-cors-origins.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Pre-commit guard against `allowed_origins: ["*"]` in OTel collector config.
+
+DEC-069 prohibits a wildcard `allowed_origins` on the OTLP/HTTP receiver
+because the collector responds with `Access-Control-Allow-Credentials: true`,
+which browsers refuse to combine with `Access-Control-Allow-Origin: *` per
+the Fetch Standard. The constraint only applies to `allowed_origins` —
+`allowed_headers: ["*"]` is a documented and intentional override (see the
+DEC-069 amendment in `docs/decisions/decision-log.md`).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("validate-cors-origins.py requires PyYAML (pip install pyyaml).")
+
+
+def main(path: str) -> int:
+    p = Path(path)
+    if not p.exists():
+        return 0  # file removed in this commit — nothing to guard
+    cfg = yaml.safe_load(p.read_text())
+    origins = (
+        cfg.get("receivers", {})
+        .get("otlp", {})
+        .get("protocols", {})
+        .get("http", {})
+        .get("cors", {})
+        .get("allowed_origins")
+        or []
+    )
+    if "*" in origins:
+        sys.stderr.write(
+            "ERROR: `allowed_origins` in `{p}` contains a bare \"*\" entry.\n"
+            "DEC-069 prohibits this: the collector sets "
+            "`Access-Control-Allow-Credentials: true` and browsers reject a "
+            "wildcard origin per the CORS spec. List the explicit origin(s) "
+            "instead.\n".format(p=p)
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    target = sys.argv[1] if len(sys.argv) > 1 else "infra/otel/otel-collector-config.yaml"
+    raise SystemExit(main(target))

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,6 +24,14 @@ pre-commit:
       glob: "*.{ts,tsx}"
       run: npx eslint --fix {staged_files}
       stage_fixed: true
+    otel-cors-origin-wildcard-guard:
+      # DEC-069: `allowed_origins` on the OTLP/HTTP receiver must never
+      # contain a bare `"*"` — incompatible with
+      # `Access-Control-Allow-Credentials: true` per the CORS spec. The
+      # `allowed_headers: ["*"]` wildcard is an intentional documented
+      # override (see the DEC-069 amendment) and is not flagged.
+      glob: "infra/otel/otel-collector-config.yaml"
+      run: python3 infra/otel/validate-cors-origins.py infra/otel/otel-collector-config.yaml
     prettier:
       root: "frontend/"
       glob: "*.{ts,tsx,css,json}"


### PR DESCRIPTION
## Summary

Infra slice of Slice 1B. Adds OTel collector CORS allow-list (so the SPA can post OTLP traces directly to `localhost:4318`) and a belt-and-braces `attributes/scrub` PII processor. Stacked on top of the backend PR — flip base to `main` once #92 merges.

## What ships

**OTLP receiver CORS** (DEC-069 / R-074, collector half)
- `cors:` block on the `otlphttp` receiver in `infra/otel/otel-collector-config.yaml`.
- `allowed_origins: [http://localhost:5173, http://localhost:4173]` — never `["*"]` (incompatible with `Access-Control-Allow-Credentials: true` per CORS spec).
- `max_age: 7200`.
- MVP-1 readiness comment block: when public rollout lands, replace the localhost origins with the deployed origin(s) and add TLS + static `Authorization: Bearer` per DEC-069.

**PII-scrubbing processor** (R-074 §7, belt-and-braces)
- `attributesprocessor` named `attributes/scrub` as the **first** processor in the traces pipeline; `batch` follows it.
- Actions: `delete http.url`, hash `http.user_agent`.

## Verification

```
docker compose -f docker-compose.yml -f docker-compose.otel.yml config
```
exit 0 (YAML validates — single-file `docker compose -f docker-compose.otel.yml config` fails because the `api` service is an overlay needing `ASPNETCORE_HTTPS_PASSWORD`; use the chained form or `otelcol-contrib validate` against the YAML directly).

CORS preflight checks (collector running):
```
curl -i -X OPTIONS http://localhost:4318/v1/traces \
  -H 'Origin: http://localhost:5173' \
  -H 'Access-Control-Request-Method: POST' \
  -H 'Access-Control-Request-Headers: traceparent,Content-Type'
```
→ `200` with `Access-Control-Allow-Origin: http://localhost:5173` and `Access-Control-Allow-Headers` including `traceparent`.

```
curl -i -X OPTIONS http://localhost:4318/v1/traces -H 'Origin: http://evil.example.com' ...
```
→ no `Access-Control-Allow-Origin` header (rejection by allow-list).

## Spec deviations noted

1. **`allowed_headers: ["*"]`** — R-074 §2 prescribed an enumerated `[traceparent, tracestate, baggage, Content-Type]` list. Empirically verified that `rs/cors` v1 in `otel-collector-contrib:0.150.1` does NOT honour the documented Content-Type implicit safelist when an explicit `allowed_headers` list is configured: the OTLP/HTTP-JSON preflight (which sends `Content-Type: application/json`) is silently rejected with no `Access-Control-Allow-Origin`. R02.2's wildcard prohibition was scoped to `allowed_origins` only — `allowed_headers: ["*"]` complies. Reasoning is inline in the YAML.

2. **`http.url` redaction via `action: delete`** rather than a query-string strip. `attributesprocessor` cannot rewrite a key in place; `extract` would create a new attribute without touching the source. `delete` is the strongest privacy posture and matches the spec's PII-scrub intent. The frontend's `FetchInstrumentation` (DEC-069, ships in the frontend PR) still scrubs the query string client-side via `applyCustomAttributesOnSpan` so navigation context is preserved on the browser side; the collector then deletes belt-and-braces.

## Spec reference

`docs/specs/14-spec-slice-1b-hardening/14-spec-slice-1b-hardening.md` § Unit 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable direct browser-to-collector OTLP/HTTP from localhost and allow all request headers.
  * Redact sensitive browser-originated trace attributes and hash user-agent values.

* **Infrastructure**
  * Ensure redaction runs before buffering/exporting in the trace pipeline.

* **Chores**
  * Add CI validation of the collector config and include it in the CI gate.
  * Add pre-commit guard to prevent wildcard CORS origins.
  * Expand static-analysis exclusions for infra and frontend paths.

* **Documentation**
  * Update decision log clarifying CORS header handling and reconsideration plan.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/leehopper/personal-running-coach/pull/93)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->