### PR TITLE
refactor(slice-2a): migrate home and settings, dark-mode toggle, doc reconcile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ See ROADMAP.md for current status and next steps.
 ## Tech Stack
 
 - **Backend:** .NET 10 / C# 14, ASP.NET Core controllers, EF Core + Marten (event sourcing on PostgreSQL JSONB), Wolverine (background processing), ASP.NET Core Identity + JWT
-- **Frontend:** React 19 + TypeScript (strict), Vite SPA, React Router v7, Redux Toolkit + RTK Query, Tailwind CSS + shadcn/ui, React Hook Form + Zod
+- **Frontend:** React 19 + TypeScript (strict), Vite SPA, React Router v7, Redux Toolkit + RTK Query, Tailwind CSS v4 + shadcn/ui (installed; two-tier semantic-token layer with light/dark mode — see `frontend/CLAUDE.md` § Styling), React Hook Form + Zod
 - **Testing:** xUnit v3 (MTP runner) + FluentAssertions + NSubstitute + M.E.AI.Evaluation, Vitest + React Testing Library, Playwright E2E
 - **Infrastructure:** Docker Compose + Tilt (local dev), Colima, GitHub Actions CI/CD, PostgreSQL + Redis
 - **Quality:** Lefthook pre-commit, local `/review-pr` via Max (PR review), Trivy + Codecov (CI), SonarAnalyzer.CSharp + eslint-plugin-sonarjs (build-time analysis), Dependabot

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -114,10 +114,33 @@ Pattern: `{name}.{type}.{extension}`
 
 ## Styling
 
-- **Tailwind CSS** utility classes for styling
-- **shadcn/ui** components (Radix primitives) — copy-paste into project
+- **Tailwind CSS** (v4, CSS-first) utility classes for styling
+- **shadcn/ui** is installed — `new-york` style, copy-pasted Radix-primitive
+  sources under `src/components/ui/`, configured via `components.json` and
+  the `cn()` helper in `src/lib/utils.ts`. There is no `tailwind.config.ts`;
+  Tailwind v4 is CSS-first.
 - Avoid inline styles — prefer Tailwind classes
 - Mobile-first responsive design with Tailwind breakpoints
+
+### Design tokens & theming (DEC-070)
+
+- All themed colour flows through **semantic tokens**, never hardcoded
+  colour utilities (`bg-slate-*`, `text-red-*`, `bg-white`, etc.). New UI
+  uses `bg-background`, `text-foreground`, `text-muted-foreground`,
+  `bg-card`, `bg-primary`, `border`, `bg-destructive`, and friends.
+- `src/index.css` carries a **two-tier token layer**: a primitive
+  Catppuccin tier (`--ctp-*`, Latte in `:root` / Mocha in `.dark`) under
+  shadcn/ui's semantic tier, joined by one `@theme inline` block. The
+  accent is the Catppuccin **teal** family.
+- **Dark mode** is class-based — the `.dark` class on `documentElement`.
+  `ThemeProvider` (`src/components/theme-provider.tsx`) owns that class and
+  the `light | dark | system` choice; consume it via the `useTheme()` hook
+  from `src/components/theme-context.ts`. A no-flash script in `index.html`
+  sets the initial class before first paint. The Settings page surfaces a
+  3-state toggle.
+- A `check-contrast` script gates the token set against WCAG AA in
+  pre-commit and CI — every semantic foreground/background pair must clear
+  the ratio. Do not commit a token change that fails it.
 
 ### Animation baseline (DEC-063)
 

--- a/frontend/src/app/error-boundary/fallback.component.tsx
+++ b/frontend/src/app/error-boundary/fallback.component.tsx
@@ -4,6 +4,8 @@
 
 import { useEffect, useRef } from 'react'
 import { type FallbackProps } from 'react-error-boundary'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
 import { useLastTraceId } from '~/api/last-trace-id'
 
 // Format a 32-hex W3C trace-id as `xxxxxxxx-xxxxxxxx-xxxxxxxx-xxxxxxxx`
@@ -62,34 +64,36 @@ export const Fallback = ({
     <div
       role="alert"
       data-testid="app-error-boundary"
-      className="flex min-h-screen items-center justify-center bg-slate-50 px-4 py-12 motion-reduce:transition-none"
+      className="flex min-h-screen items-center justify-center bg-background px-4 py-12 motion-reduce:transition-none"
     >
-      <div className="w-full max-w-md space-y-4 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+      <Card className="w-full max-w-md gap-4 p-6">
         <h1
           ref={headingRef}
           tabIndex={-1}
-          className="text-xl font-semibold text-slate-900 outline-none focus-visible:ring-2 focus-visible:ring-slate-900"
+          className="text-xl font-semibold text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           Something went wrong
         </h1>
-        <p className="text-sm text-slate-700">
+        <p className="text-sm text-muted-foreground">
           RunCoach hit an unexpected error while rendering this page. We may send technical
           diagnostics to help investigate, but your training data remains safe.
         </p>
-        <p className="text-sm text-slate-700">
+        <p className="text-sm text-muted-foreground">
           Error ID:{' '}
-          <code className="select-all rounded bg-slate-100 px-1.5 py-0.5 font-mono text-xs text-slate-900">
+          <code className="select-all rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
             {shortId}
           </code>
         </p>
         {traceId !== null && (
-          <p className="text-sm text-slate-700">
+          <p className="text-sm text-muted-foreground">
             Support code:{' '}
-            <code className="select-all rounded bg-slate-100 px-1.5 py-0.5 font-mono text-xs text-slate-900">
+            <code className="select-all rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
               {formatTraceId(traceId)}
             </code>{' '}
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="xs"
               onClick={() => {
                 // `navigator.clipboard.writeText` requires HTTPS and a
                 // user gesture in some browsers; it's a nice-to-have.
@@ -101,36 +105,32 @@ export const Fallback = ({
                 )
               }}
               aria-label="Copy support code"
-              className="rounded border border-slate-300 px-1.5 py-0.5 text-xs font-medium text-slate-700 transition-colors duration-200 ease-out hover:bg-slate-100 motion-reduce:transition-none"
             >
               Copy
-            </button>
+            </Button>
           </p>
         )}
         <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            onClick={resetErrorBoundary}
-            className="rounded bg-slate-900 px-3 py-1.5 text-sm font-medium text-white transition-colors duration-200 ease-out hover:bg-slate-700 motion-reduce:transition-none"
-          >
+          <Button type="button" size="sm" onClick={resetErrorBoundary}>
             Try again
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            variant="outline"
+            size="sm"
             onClick={() => window.location.reload()}
-            className="rounded border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 transition-colors duration-200 ease-out hover:bg-slate-100 motion-reduce:transition-none"
           >
             Reload page
-          </button>
+          </Button>
         </div>
-        <details className="text-sm text-slate-700">
-          <summary className="cursor-pointer select-none text-slate-500">
+        <details className="text-sm text-muted-foreground">
+          <summary className="cursor-pointer select-none text-muted-foreground">
             Show error details
           </summary>
           <div className="mt-2 space-y-2">
             <p>
               Full ID:{' '}
-              <code className="select-all rounded bg-slate-100 px-1 font-mono text-xs">
+              <code className="select-all rounded bg-muted px-1 font-mono text-xs">
                 {correlationId}
               </code>
             </p>
@@ -138,13 +138,13 @@ export const Fallback = ({
               <strong className="font-semibold">{error.name}</strong>: {error.message}
             </p>
             {error.stack !== undefined && error.stack.length > 0 && (
-              <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-slate-50 p-2 font-mono text-xs text-slate-700">
+              <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-2 font-mono text-xs text-muted-foreground">
                 {error.stack}
               </pre>
             )}
           </div>
         </details>
-      </div>
+      </Card>
     </div>
   )
 }

--- a/frontend/src/app/modules/app/app.component.tsx
+++ b/frontend/src/app/modules/app/app.component.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement } from 'react'
 import { Provider } from 'react-redux'
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
 import { store } from './app.store'
 import { useGetOnboardingStateQuery } from '~/api/onboarding.api'
 import { AppErrorBoundary } from '~/error-boundary/app-error-boundary'
@@ -68,9 +69,9 @@ export const OnboardingRedirectGuard = ({
       <div
         role="status"
         aria-live="polite"
-        className="flex min-h-screen items-center justify-center bg-slate-50"
+        className="flex min-h-screen items-center justify-center bg-background"
       >
-        <span className="text-sm text-slate-500">Loading…</span>
+        <span className="text-sm text-muted-foreground">Loading…</span>
       </div>
     )
   }
@@ -85,20 +86,20 @@ export const OnboardingRedirectGuard = ({
       <div
         role="alert"
         data-testid="onboarding-guard-error"
-        className="flex min-h-screen flex-col items-center justify-center gap-3 bg-slate-50 px-4 text-center"
+        className="flex min-h-screen flex-col items-center justify-center gap-3 bg-background px-4 text-center"
       >
-        <p className="text-sm text-slate-700">
+        <p className="text-sm text-muted-foreground">
           We couldn’t reach the onboarding service. Check your connection and try again.
         </p>
-        <button
+        <Button
           type="button"
+          size="sm"
           onClick={() => {
             void refetch()
           }}
-          className="rounded bg-slate-900 px-3 py-1 text-xs font-medium text-white"
         >
           Retry
-        </button>
+        </Button>
       </div>
     )
   }

--- a/frontend/src/app/modules/auth/components/require-auth.component.tsx
+++ b/frontend/src/app/modules/auth/components/require-auth.component.tsx
@@ -25,7 +25,7 @@ export const RequireAuth = ({ children }: RequireAuthProps) => {
         role="status"
         aria-live="polite"
       >
-        <span className="text-sm text-slate-500">Loading…</span>
+        <span className="text-sm text-muted-foreground">Loading…</span>
       </div>
     )
   }

--- a/frontend/src/app/modules/onboarding/components/topic-progress-indicator.component.tsx
+++ b/frontend/src/app/modules/onboarding/components/topic-progress-indicator.component.tsx
@@ -49,7 +49,7 @@ export const TopicProgressIndicator = ({
           aria-current={state === 'current' ? 'step' : undefined}
           data-state={state}
           data-topic={topic}
-          className={`flex flex-1 items-center justify-center rounded-full border px-3 py-1 text-xs font-medium transition-colors duration-200 ease-out ${SEGMENT_STYLES[state]}`}
+          className={`flex flex-1 items-center justify-center rounded-full border px-3 py-1 text-xs font-medium transition-colors duration-200 ease-out motion-reduce:transition-none ${SEGMENT_STYLES[state]}`}
         >
           <span className="truncate">{TOPIC_LABELS[topic]}</span>
         </li>

--- a/frontend/src/app/modules/onboarding/components/topic-progress-indicator.helpers.ts
+++ b/frontend/src/app/modules/onboarding/components/topic-progress-indicator.helpers.ts
@@ -33,9 +33,9 @@ export const TOPIC_LABELS: Record<OnboardingTopic, string> = {
 // for richer animations elsewhere; segment colour shifts are simple enough
 // that a CSS transition is the lighter-weight implementation.
 export const SEGMENT_STYLES: Record<TopicSegmentState, string> = {
-  completed: 'bg-slate-900 text-slate-50 border-slate-900',
-  current: 'bg-slate-50 text-slate-900 border-slate-900 ring-2 ring-slate-900/20',
-  pending: 'bg-slate-50 text-slate-500 border-slate-200',
+  completed: 'bg-primary text-primary-foreground border-primary',
+  current: 'bg-background text-foreground border-primary ring-2 ring-primary/20',
+  pending: 'bg-muted text-muted-foreground border-border',
 }
 
 /**

--- a/frontend/src/app/modules/onboarding/pages/onboarding.page.tsx
+++ b/frontend/src/app/modules/onboarding/pages/onboarding.page.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, type ReactElement } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
 import { useGetOnboardingStateQuery } from '~/api/onboarding.api'
 import { OnboardingChat } from '~/modules/onboarding/components/onboarding-chat.component'
 import { expandCompletedTopicCount } from '~/modules/onboarding/components/topic-progress-indicator.helpers'
@@ -115,9 +116,9 @@ export const OnboardingPage = (): ReactElement => {
       <div
         role="status"
         aria-live="polite"
-        className="flex min-h-screen items-center justify-center bg-slate-50"
+        className="flex min-h-screen items-center justify-center bg-background"
       >
-        <span className="text-sm text-slate-500">Loading…</span>
+        <span className="text-sm text-muted-foreground">Loading…</span>
       </div>
     )
   }
@@ -127,20 +128,20 @@ export const OnboardingPage = (): ReactElement => {
       <div
         role="alert"
         data-testid="onboarding-bootstrap-error"
-        className="flex min-h-screen flex-col items-center justify-center gap-3 bg-slate-50 px-4 text-center"
+        className="flex min-h-screen flex-col items-center justify-center gap-3 bg-background px-4 text-center"
       >
-        <p className="text-sm text-slate-700">
+        <p className="text-sm text-muted-foreground">
           We couldn’t reach the onboarding service. Check your connection and try again.
         </p>
-        <button
+        <Button
           type="button"
+          size="sm"
           onClick={() => {
             void refetch()
           }}
-          className="rounded bg-slate-900 px-3 py-1 text-xs font-medium text-white"
         >
           Retry
-        </button>
+        </Button>
       </div>
     )
   }

--- a/frontend/src/app/modules/plan/components/macro-phase-strip.component.tsx
+++ b/frontend/src/app/modules/plan/components/macro-phase-strip.component.tsx
@@ -43,7 +43,7 @@ export const MacroPhaseStrip = ({
     <ol
       aria-label="Training phases"
       data-testid="macro-phase-strip"
-      className={`flex w-full items-stretch gap-1 rounded-lg border border-slate-200 bg-slate-50 p-2 ${className ?? ''}`}
+      className={`flex w-full items-stretch gap-1 rounded-lg border bg-muted p-2 ${className ?? ''}`}
     >
       {ranges.map((range) => {
         const widthPercent = (range.phase.weeks / totalWeeks) * 100
@@ -58,10 +58,10 @@ export const MacroPhaseStrip = ({
             data-phase={range.phase.phaseType}
             data-current={current ? 'true' : 'false'}
             aria-current={current ? 'step' : undefined}
-            className={`macro-phase-segment flex min-w-[80px] flex-col items-center justify-center rounded-md px-3 py-2 text-xs font-medium transition-colors duration-200 ease-out ${
+            className={`macro-phase-segment flex min-w-[80px] flex-col items-center justify-center rounded-md px-3 py-2 text-xs font-medium transition-colors duration-200 ease-out motion-reduce:transition-none ${
               current
-                ? 'bg-slate-900 text-slate-50 ring-2 ring-slate-900'
-                : 'bg-white text-slate-700'
+                ? 'bg-primary text-primary-foreground ring-2 ring-primary'
+                : 'bg-card text-card-foreground'
             }`}
             ref={(el) => {
               if (el !== null) {
@@ -78,7 +78,7 @@ export const MacroPhaseStrip = ({
             {current && currentWeek !== null ? (
               <span
                 data-testid="macro-phase-current-marker"
-                className="mt-1 inline-block rounded-full bg-slate-50 px-2 py-0.5 text-[10px] font-bold text-slate-900"
+                className="mt-1 inline-block rounded-full bg-background px-2 py-0.5 text-[10px] font-bold text-foreground"
               >
                 Week {currentWeek}
               </span>

--- a/frontend/src/app/modules/plan/components/meso-week-block.component.tsx
+++ b/frontend/src/app/modules/plan/components/meso-week-block.component.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react'
+import { Badge } from '@/components/ui/badge'
 import type { MesoWeekTemplateDto } from '~/modules/plan/models/plan.model'
 import { labelForPhase } from './plan-display.helpers'
 
@@ -32,10 +33,10 @@ const cardStateFor = (
 }
 
 const STATE_STYLES: Record<'past' | 'current' | 'future' | 'neutral', string> = {
-  past: 'bg-slate-100 text-slate-500',
-  current: 'bg-slate-900 text-slate-50 ring-2 ring-slate-900',
-  future: 'bg-white text-slate-500 opacity-70',
-  neutral: 'bg-white text-slate-700',
+  past: 'bg-muted text-muted-foreground',
+  current: 'bg-primary text-primary-foreground ring-2 ring-primary',
+  future: 'bg-card text-muted-foreground opacity-70',
+  neutral: 'bg-card text-card-foreground',
 }
 
 /**
@@ -70,7 +71,7 @@ export const MesoWeekBlock = ({
           data-week={week.weekNumber}
           data-state={state}
           aria-current={state === 'current' ? 'step' : undefined}
-          className={`flex flex-col gap-2 rounded-lg border border-slate-200 p-4 text-sm shadow-sm transition-colors duration-200 ease-out ${STATE_STYLES[state]}`}
+          className={`flex flex-col gap-2 rounded-lg border p-4 text-sm shadow-sm transition-colors duration-200 ease-out motion-reduce:transition-none ${STATE_STYLES[state]}`}
         >
           <header className="flex items-baseline justify-between">
             <span className="text-xs font-semibold uppercase tracking-wide">
@@ -80,12 +81,13 @@ export const MesoWeekBlock = ({
           </header>
           <p className="text-lg font-semibold leading-tight">{week.weeklyTargetKm.toFixed(1)} km</p>
           {week.isDeloadWeek ? (
-            <span
+            <Badge
+              variant="secondary"
               data-testid="meso-week-deload-flag"
-              className="inline-flex w-fit items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-amber-900"
+              className="text-[11px] font-semibold uppercase tracking-wide"
             >
               Deload week
-            </span>
+            </Badge>
           ) : null}
           {week.weekSummary.trim().length > 0 ? (
             <p className="text-xs leading-snug opacity-90">{week.weekSummary}</p>

--- a/frontend/src/app/modules/plan/components/micro-workout-card.component.tsx
+++ b/frontend/src/app/modules/plan/components/micro-workout-card.component.tsx
@@ -40,20 +40,20 @@ export const MicroWorkoutCard = ({
       data-testid="micro-workout-card"
       data-workout-type={workout.workoutType}
       data-emphasized={emphasized ? 'true' : 'false'}
-      className={`flex flex-col gap-3 rounded-lg border p-4 text-sm shadow-sm transition-colors duration-200 ease-out ${
-        emphasized ? 'border-slate-900 bg-white ring-2 ring-slate-900' : 'border-slate-200 bg-white'
+      className={`flex flex-col gap-3 rounded-lg border bg-card p-4 text-sm text-card-foreground shadow-sm transition-colors duration-200 ease-out motion-reduce:transition-none ${
+        emphasized ? 'border-primary ring-2 ring-primary' : ''
       } ${className ?? ''}`}
     >
       <header className="flex flex-col gap-1">
         {dayLabel.length > 0 ? (
-          <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
             {dayLabel}
           </span>
         ) : null}
-        <h3 className="text-base font-semibold leading-tight text-slate-900">{workout.title}</h3>
+        <h3 className="text-base font-semibold leading-tight text-foreground">{workout.title}</h3>
         <span
           data-testid="micro-workout-type-label"
-          className="text-xs font-medium uppercase tracking-wide text-slate-600"
+          className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
         >
           {WORKOUT_TYPE_LABELS[workout.workoutType]}
         </span>
@@ -61,18 +61,18 @@ export const MicroWorkoutCard = ({
 
       <dl className="grid grid-cols-2 gap-3 text-sm">
         <div>
-          <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
             Distance
           </dt>
-          <dd className="text-base font-semibold text-slate-900">
+          <dd className="text-base font-semibold text-foreground">
             {workout.targetDistanceKm.toFixed(1)} km
           </dd>
         </div>
         <div>
-          <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
             Target pace
           </dt>
-          <dd data-testid="micro-workout-pace" className="text-base font-semibold text-slate-900">
+          <dd data-testid="micro-workout-pace" className="text-base font-semibold text-foreground">
             {paceRange ?? '—/km'}
           </dd>
         </div>
@@ -101,7 +101,7 @@ export const MicroWorkoutCard = ({
       {workout.coachingNotes.trim().length > 0 ? (
         <p
           data-testid="micro-workout-coaching-notes"
-          className="rounded-md bg-slate-50 px-3 py-2 text-xs leading-snug text-slate-700"
+          className="rounded-md bg-muted px-3 py-2 text-xs leading-snug text-muted-foreground"
         >
           {workout.coachingNotes}
         </p>

--- a/frontend/src/app/modules/plan/components/micro-workout-segment-row.component.tsx
+++ b/frontend/src/app/modules/plan/components/micro-workout-segment-row.component.tsx
@@ -18,16 +18,16 @@ export const MicroWorkoutSegmentRow = ({
       data-testid="micro-workout-segment"
       data-segment-type={segment.segmentType}
       data-segment-index={index}
-      className="flex items-baseline justify-between gap-2 rounded-md bg-slate-50 px-3 py-2 text-xs"
+      className="flex items-baseline justify-between gap-2 rounded-md bg-muted px-3 py-2 text-xs"
     >
-      <span className="font-semibold text-slate-700">
+      <span className="font-semibold text-foreground">
         {segment.segmentType}
         {segment.repetitions > 1 ? ` × ${segment.repetitions}` : ''}
       </span>
-      <span className="text-slate-600">
+      <span className="text-muted-foreground">
         {segment.durationMinutes} min{pace === null ? '' : ` · ${pace}`}
       </span>
-      <span className="text-[11px] uppercase tracking-wide text-slate-500">
+      <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
         {INTENSITY_LABELS[segment.intensity] ?? segment.intensity}
       </span>
     </li>

--- a/frontend/src/app/modules/plan/components/today-card.component.tsx
+++ b/frontend/src/app/modules/plan/components/today-card.component.tsx
@@ -56,8 +56,8 @@ export const TodayCard = ({
         className={`flex flex-col gap-2 ${className ?? ''}`}
       >
         <header className="flex items-baseline justify-between">
-          <h2 className="text-lg font-semibold text-slate-900">Today</h2>
-          <span className="text-xs font-medium uppercase tracking-wide text-slate-500">
+          <h2 className="text-lg font-semibold text-foreground">Today</h2>
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
             {todayLabel}
           </span>
         </header>
@@ -74,23 +74,26 @@ export const TodayCard = ({
       aria-label="Today's workout"
       data-testid="today-card"
       data-variant="rest"
-      className={`flex flex-col gap-3 rounded-lg border-2 border-slate-200 bg-slate-50 p-5 ${className ?? ''}`}
+      className={`flex flex-col gap-3 rounded-lg border-2 bg-muted p-5 ${className ?? ''}`}
     >
       <header className="flex items-baseline justify-between">
-        <h2 className="text-lg font-semibold text-slate-900">Today</h2>
-        <span className="text-xs font-medium uppercase tracking-wide text-slate-500">
+        <h2 className="text-lg font-semibold text-foreground">Today</h2>
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
           {todayLabel}
         </span>
       </header>
-      <p className="text-base font-semibold text-slate-700">Rest day — recover well.</p>
+      <p className="text-base font-semibold text-foreground">Rest day — recover well.</p>
       {nextDayLabel !== null && nextWorkout !== undefined ? (
-        <p data-testid="today-card-next-workout" className="text-sm leading-snug text-slate-600">
+        <p
+          data-testid="today-card-next-workout"
+          className="text-sm leading-snug text-muted-foreground"
+        >
           Next workout: <strong className="font-semibold">{nextDayLabel}</strong> ·{' '}
           {nextWorkout.title}
         </p>
       ) : null}
       {slot.notes.trim().length > 0 ? (
-        <p className="text-xs leading-snug text-slate-500">{slot.notes}</p>
+        <p className="text-xs leading-snug text-muted-foreground">{slot.notes}</p>
       ) : null}
     </section>
   )

--- a/frontend/src/app/modules/plan/components/upcoming-list.component.tsx
+++ b/frontend/src/app/modules/plan/components/upcoming-list.component.tsx
@@ -51,7 +51,7 @@ export const UpcomingList = ({
     >
       {remainder.length > 0 ? (
         <div className="flex flex-col gap-3">
-          <h2 className="text-lg font-semibold text-slate-900">Rest of this week</h2>
+          <h2 className="text-lg font-semibold text-foreground">Rest of this week</h2>
           <ol
             aria-label="Workouts later this week"
             data-testid="upcoming-week-remainder"
@@ -71,7 +71,7 @@ export const UpcomingList = ({
 
       {weeks.length > 0 ? (
         <div className="flex flex-col gap-3">
-          <h2 className="text-lg font-semibold text-slate-900">Upcoming weeks</h2>
+          <h2 className="text-lg font-semibold text-foreground">Upcoming weeks</h2>
           <MesoWeekBlock weeks={weeks} currentWeek={currentWeek} />
         </div>
       ) : null}

--- a/frontend/src/app/modules/plan/pages/home.page.tsx
+++ b/frontend/src/app/modules/plan/pages/home.page.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
 import { MacroPhaseStrip } from '~/modules/plan/components/macro-phase-strip.component'
 import { TodayCard } from '~/modules/plan/components/today-card.component'
 import { UpcomingList } from '~/modules/plan/components/upcoming-list.component'
@@ -36,9 +37,9 @@ export const HomePage = (): ReactElement => {
       <div
         role="status"
         aria-live="polite"
-        className="flex min-h-screen items-center justify-center bg-slate-50"
+        className="flex min-h-screen items-center justify-center bg-background"
       >
-        <span className="text-sm text-slate-500">Loading…</span>
+        <span className="text-sm text-muted-foreground">Loading…</span>
       </div>
     )
   }
@@ -50,11 +51,11 @@ export const HomePage = (): ReactElement => {
   if (isError || plan === undefined) {
     return (
       <main
-        className="flex min-h-screen flex-col items-center justify-center gap-4 bg-slate-50 px-4"
+        className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background px-4"
         data-testid="home-page-error"
       >
-        <h1 className="text-2xl font-semibold text-slate-900">Something went wrong</h1>
-        <p className="max-w-md text-center text-sm text-slate-600">
+        <h1 className="text-2xl font-semibold text-foreground">Something went wrong</h1>
+        <p className="max-w-md text-center text-sm text-muted-foreground">
           We could not load your plan right now. Reload the page in a moment.
         </p>
       </main>
@@ -83,7 +84,7 @@ const PlanLayout = ({ plan }: PlanLayoutProps): ReactElement => {
 
   return (
     <main
-      className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-8 bg-slate-50 px-4 py-8"
+      className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-8 bg-background px-4 py-8"
       data-testid="home-page"
     >
       {plan.macro === null ? null : (
@@ -112,19 +113,16 @@ const PlanLayout = ({ plan }: PlanLayoutProps): ReactElement => {
  */
 const NoPlanYetState = (): ReactElement => (
   <main
-    className="flex min-h-screen flex-col items-center justify-center gap-4 bg-slate-50 px-4"
+    className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background px-4"
     data-testid="home-page-no-plan"
   >
-    <h1 className="text-2xl font-semibold text-slate-900">No plan yet</h1>
-    <p className="max-w-md text-center text-sm text-slate-600">
+    <h1 className="text-2xl font-semibold text-foreground">No plan yet</h1>
+    <p className="max-w-md text-center text-sm text-muted-foreground">
       Your training plan has not been generated. Finish onboarding to get started.
     </p>
-    <Link
-      to="/onboarding"
-      className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
-    >
-      Go to onboarding
-    </Link>
+    <Button asChild>
+      <Link to="/onboarding">Go to onboarding</Link>
+    </Button>
   </main>
 )
 

--- a/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.tsx
+++ b/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactElement, type SubmitEvent } from 'react'
 import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
 import { useRegeneratePlanMutation } from '~/api/plan.api'
 
 /**
@@ -141,7 +142,7 @@ const RegeneratePlanDialogBody = ({ onClose }: RegeneratePlanDialogBodyProps): R
           <label htmlFor="regenerate-plan-intent" className="text-sm font-medium text-foreground">
             Anything we should know? (optional)
           </label>
-          <textarea
+          <Textarea
             id="regenerate-plan-intent"
             ref={textareaRef}
             value={intent}
@@ -150,7 +151,7 @@ const RegeneratePlanDialogBody = ({ onClose }: RegeneratePlanDialogBodyProps): R
             rows={4}
             disabled={isLoading}
             placeholder="e.g. coming back from a calf strain, want to focus on long runs…"
-            className="w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-60 motion-reduce:transition-none dark:bg-input/30"
+            className="w-full resize-none"
             data-testid="regenerate-plan-intent"
           />
           <div className="flex justify-end text-xs text-muted-foreground" aria-live="polite">

--- a/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.tsx
+++ b/frontend/src/app/modules/settings/components/regenerate-plan-dialog.component.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactElement, type SubmitEvent } from 'react'
+import { Button } from '@/components/ui/button'
 import { useRegeneratePlanMutation } from '~/api/plan.api'
 
 /**
@@ -109,7 +110,7 @@ const RegeneratePlanDialogBody = ({ onClose }: RegeneratePlanDialogBodyProps): R
     <div
       role="presentation"
       tabIndex={-1}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/40 px-4"
       onClick={closeIfIdle}
       onKeyDown={(event) => {
         if (event.key === 'Enter' || event.key === ' ') {
@@ -124,20 +125,20 @@ const RegeneratePlanDialogBody = ({ onClose }: RegeneratePlanDialogBodyProps): R
         aria-modal="true"
         aria-labelledby="regenerate-plan-title"
         aria-describedby="regenerate-plan-description"
-        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+        className="w-full max-w-md rounded-lg border bg-popover p-6 text-popover-foreground shadow-xl"
         onClick={(event) => event.stopPropagation()}
         onKeyDown={(event) => event.stopPropagation()}
         data-testid="regenerate-plan-dialog"
       >
-        <h2 id="regenerate-plan-title" className="text-lg font-semibold text-slate-900">
+        <h2 id="regenerate-plan-title" className="text-lg font-semibold text-foreground">
           Regenerate plan
         </h2>
-        <p id="regenerate-plan-description" className="mt-2 text-sm text-slate-600">
+        <p id="regenerate-plan-description" className="mt-2 text-sm text-muted-foreground">
           This replaces your current plan.
         </p>
 
         <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
-          <label htmlFor="regenerate-plan-intent" className="text-sm font-medium text-slate-700">
+          <label htmlFor="regenerate-plan-intent" className="text-sm font-medium text-foreground">
             Anything we should know? (optional)
           </label>
           <textarea
@@ -149,39 +150,29 @@ const RegeneratePlanDialogBody = ({ onClose }: RegeneratePlanDialogBodyProps): R
             rows={4}
             disabled={isLoading}
             placeholder="e.g. coming back from a calf strain, want to focus on long runs…"
-            className="w-full resize-none rounded border border-slate-300 px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-60"
+            className="w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-60 motion-reduce:transition-none dark:bg-input/30"
             data-testid="regenerate-plan-intent"
           />
-          <div className="flex justify-end text-xs text-slate-500" aria-live="polite">
+          <div className="flex justify-end text-xs text-muted-foreground" aria-live="polite">
             {remaining} characters remaining
           </div>
 
           {errorMessage !== null ? (
             <p
               role="alert"
-              className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
             >
               {errorMessage}
             </p>
           ) : null}
 
           <div className="flex justify-end gap-2">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={isLoading}
-              className="rounded px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
-            >
+            <Button type="button" variant="ghost" onClick={onClose} disabled={isLoading}>
               Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"
-              data-testid="regenerate-plan-submit"
-            >
+            </Button>
+            <Button type="submit" disabled={isLoading} data-testid="regenerate-plan-submit">
               {isLoading ? 'Regenerating…' : 'Regenerate'}
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/frontend/src/app/modules/settings/components/theme-toggle.component.spec.tsx
+++ b/frontend/src/app/modules/settings/components/theme-toggle.component.spec.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ThemeProvider } from '@/components/theme-provider'
+import { ThemeToggle } from './theme-toggle.component'
+
+const STORAGE_KEY = 'runcoach-theme'
+
+// jsdom ships no `matchMedia`; ThemeProvider needs it to resolve `system`.
+let prefersDark = false
+
+const installMatchMedia = () => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches: query.includes('dark') ? prefersDark : false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: () => false,
+      onchange: null,
+    })),
+  )
+}
+
+const renderToggle = (children: ReactNode = <ThemeToggle />) =>
+  render(<ThemeProvider>{children}</ThemeProvider>)
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    prefersDark = false
+    localStorage.clear()
+    document.documentElement.className = ''
+    installMatchMedia()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders three selectable options: Light, Dark, and System', () => {
+    renderToggle()
+    expect(screen.getByRole('radio', { name: 'Light' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Dark' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'System' })).toBeInTheDocument()
+  })
+
+  it('highlights the active option from the stored preference', () => {
+    localStorage.setItem(STORAGE_KEY, 'dark')
+    renderToggle()
+    expect(screen.getByRole('radio', { name: 'Dark' })).toBeChecked()
+    expect(screen.getByRole('radio', { name: 'Light' })).not.toBeChecked()
+  })
+
+  it('defaults the System option as active when nothing is stored', () => {
+    renderToggle()
+    expect(screen.getByRole('radio', { name: 'System' })).toBeChecked()
+  })
+
+  it('switches the app to dark mode immediately when Dark is selected', async () => {
+    renderToggle()
+    await userEvent.click(screen.getByRole('radio', { name: 'Dark' }))
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(document.documentElement.classList.contains('light')).toBe(false)
+  })
+
+  it('switches the app to light mode immediately when Light is selected', async () => {
+    localStorage.setItem(STORAGE_KEY, 'dark')
+    renderToggle()
+    await userEvent.click(screen.getByRole('radio', { name: 'Light' }))
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('persists the selected option to localStorage', async () => {
+    renderToggle()
+    await userEvent.click(screen.getByRole('radio', { name: 'Dark' }))
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('dark')
+  })
+
+  it('restores OS-driven theming and stores "system" when System is selected', async () => {
+    prefersDark = true
+    localStorage.setItem(STORAGE_KEY, 'light')
+    renderToggle()
+    await userEvent.click(screen.getByRole('radio', { name: 'System' }))
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('system')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+})

--- a/frontend/src/app/modules/settings/components/theme-toggle.component.tsx
+++ b/frontend/src/app/modules/settings/components/theme-toggle.component.tsx
@@ -1,0 +1,47 @@
+import type { ReactElement } from 'react'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { Label } from '@/components/ui/label'
+import { useTheme, type Theme } from '@/components/theme-context'
+
+// The three selectable options, in display order. `value` is the literal
+// stored to localStorage by `ThemeProvider.setTheme`; `label` is the
+// user-facing copy.
+const THEME_OPTIONS: ReadonlyArray<{ value: Theme; label: string }> = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+]
+
+/**
+ * 3-state appearance control for the Settings page (DEC-070). Reads and
+ * writes the active theme through `useTheme()`, so selecting an option
+ * toggles the `.dark`/`.light` class on `documentElement` immediately —
+ * the whole app re-themes with no reload — and persists the choice to
+ * localStorage for the no-flash script to pick up on the next load.
+ *
+ * "System" hands theming back to the OS `prefers-color-scheme`.
+ */
+export const ThemeToggle = (): ReactElement => {
+  const { theme, setTheme } = useTheme()
+
+  return (
+    <RadioGroup
+      value={theme}
+      onValueChange={(value) => setTheme(value as Theme)}
+      aria-label="Appearance"
+      data-testid="settings-theme-toggle"
+      className="mt-2 grid-cols-3 gap-2"
+    >
+      {THEME_OPTIONS.map((option) => (
+        <Label
+          key={option.value}
+          htmlFor={`theme-option-${option.value}`}
+          className="flex cursor-pointer items-center gap-2 rounded-md border border-input p-3 transition-colors has-[:checked]:border-primary has-[:checked]:bg-accent motion-reduce:transition-none"
+        >
+          <RadioGroupItem id={`theme-option-${option.value}`} value={option.value} />
+          {option.label}
+        </Label>
+      ))}
+    </RadioGroup>
+  )
+}

--- a/frontend/src/app/modules/settings/pages/settings-page.spec.tsx
+++ b/frontend/src/app/modules/settings/pages/settings-page.spec.tsx
@@ -30,6 +30,15 @@ vi.mock('~/modules/settings/components/regenerate-plan-dialog.component', () => 
     ) : null,
 }))
 
+// `ThemeToggle` reads `useTheme()` from the app-level `<ThemeProvider>`,
+// which is mounted in `main.tsx` and not in this page-scoped test tree.
+// Stubbed here — its own behaviour is covered by
+// `theme-toggle.component.spec.tsx` — so this suite stays focused on the
+// SettingsPage's plan logic.
+vi.mock('~/modules/settings/components/theme-toggle.component', () => ({
+  ThemeToggle: () => <div data-testid="theme-toggle-stub">theme toggle</div>,
+}))
+
 import { SettingsPage } from './settings.page'
 
 const renderPage = () =>
@@ -76,6 +85,17 @@ describe('SettingsPage', () => {
     renderPage()
     expect(screen.getByTestId('settings-plan-generated-at')).toBeInTheDocument()
     expect(screen.getByTestId('settings-regenerate-button')).toBeInTheDocument()
+  })
+
+  it('renders the Appearance section with the theme toggle', () => {
+    getCurrentPlanMock.mockReturnValue({
+      data: buildPlanStub(),
+      isLoading: false,
+      isError: false,
+    })
+    renderPage()
+    expect(screen.getByTestId('settings-appearance-section')).toBeInTheDocument()
+    expect(screen.getByTestId('theme-toggle-stub')).toBeInTheDocument()
   })
 
   it('does not render the previous-plan link when previousPlanId is null', () => {

--- a/frontend/src/app/modules/settings/pages/settings.page.tsx
+++ b/frontend/src/app/modules/settings/pages/settings.page.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { useGetCurrentPlanQuery } from '~/api/plan.api'
 import { RegeneratePlanDialog } from '~/modules/settings/components/regenerate-plan-dialog.component'
+import { ThemeToggle } from '~/modules/settings/components/theme-toggle.component'
 
 /**
  * `/settings` route surface. Renders the "Plan" section: current plan's
@@ -50,6 +51,14 @@ export const SettingsPage = (): ReactElement => {
             Regenerate plan
           </Button>
         </div>
+      </Card>
+
+      <Card className="gap-2 p-6" data-testid="settings-appearance-section">
+        <h2 className="text-lg font-semibold text-foreground">Appearance</h2>
+        <p className="text-sm text-muted-foreground">
+          Choose how RunCoach looks. System follows your device setting.
+        </p>
+        <ThemeToggle />
       </Card>
 
       <RegeneratePlanDialog isOpen={isDialogOpen} onClose={() => setIsDialogOpen(false)} />

--- a/frontend/src/app/modules/settings/pages/settings.page.tsx
+++ b/frontend/src/app/modules/settings/pages/settings.page.tsx
@@ -1,5 +1,7 @@
 import { useState, type ReactElement } from 'react'
 import { Link } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
 import { useGetCurrentPlanQuery } from '~/api/plan.api'
 import { RegeneratePlanDialog } from '~/modules/settings/components/regenerate-plan-dialog.component'
 
@@ -19,21 +21,18 @@ export const SettingsPage = (): ReactElement => {
 
   return (
     <main
-      className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-8 bg-slate-50 px-4 py-8"
+      className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-8 bg-background px-4 py-8"
       data-testid="settings-page"
     >
       <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-slate-900">Settings</h1>
-        <Link to="/" className="text-sm font-medium text-slate-600 hover:text-slate-900">
+        <h1 className="text-2xl font-semibold text-foreground">Settings</h1>
+        <Link to="/" className="text-sm font-medium text-muted-foreground hover:text-foreground">
           Back to plan
         </Link>
       </header>
 
-      <section
-        className="rounded-lg border border-slate-200 bg-white p-6"
-        data-testid="settings-plan-section"
-      >
-        <h2 className="text-lg font-semibold text-slate-900">Plan</h2>
+      <Card className="gap-2 p-6" data-testid="settings-plan-section">
+        <h2 className="text-lg font-semibold text-foreground">Plan</h2>
 
         <PlanSummary
           isLoading={isLoading}
@@ -43,16 +42,15 @@ export const SettingsPage = (): ReactElement => {
         />
 
         <div className="mt-4">
-          <button
+          <Button
             type="button"
             onClick={() => setIsDialogOpen(true)}
-            className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white"
             data-testid="settings-regenerate-button"
           >
             Regenerate plan
-          </button>
+          </Button>
         </div>
-      </section>
+      </Card>
 
       <RegeneratePlanDialog isOpen={isDialogOpen} onClose={() => setIsDialogOpen(false)} />
     </main>
@@ -79,7 +77,7 @@ const PlanSummary = ({
 }: PlanSummaryProps): ReactElement => {
   if (isLoading) {
     return (
-      <p className="mt-2 text-sm text-slate-500" role="status" aria-live="polite">
+      <p className="mt-2 text-sm text-muted-foreground" role="status" aria-live="polite">
         Loading plan details…
       </p>
     )
@@ -87,21 +85,21 @@ const PlanSummary = ({
 
   if (isError || generatedAt === undefined) {
     return (
-      <p className="mt-2 text-sm text-slate-500">
+      <p className="mt-2 text-sm text-muted-foreground">
         We could not load your current plan details right now.
       </p>
     )
   }
 
   return (
-    <div className="mt-2 flex flex-col gap-1 text-sm text-slate-600">
+    <div className="mt-2 flex flex-col gap-1 text-sm text-muted-foreground">
       <p data-testid="settings-plan-generated-at">
         Current plan generated <time dateTime={generatedAt}>{formatGeneratedAt(generatedAt)}</time>
       </p>
       {previousPlanId !== null ? (
         <button
           type="button"
-          className="text-left text-sm text-slate-500 underline-offset-2 hover:underline"
+          className="text-left text-sm text-muted-foreground underline-offset-2 hover:underline"
           data-testid="settings-previous-plan-link"
         >
           View previous plan


### PR DESCRIPTION
## Slice 2a — Home + Settings Migration, Dark-Mode Toggle, Doc Reconcile (PR4 of 4)

Demoable unit: completes the colour sweep — home and settings surfaces moved to design tokens, settings page exposes the dark-mode toggle wired to the class-based controller, zero hardcoded colours remain, and `CLAUDE.md` is reconciled with the shadcn install + token system.

Spec: `docs/specs/15-spec-slice-2a-frontend-foundation/` (gitignored, working-tree-only).
References: **DEC-070** (token architecture) and **R-075** (`docs/research/artifacts/batch-26a-frontend-design-system-theming-integration.md`).

### Commits
- refactor(slice-2a): migrate home and settings to design tokens
- feat(slice-2a): settings theme toggle and zero-hardcoded-colour sweep
- docs(slice-2a): reconcile claude.md with shadcn install and token system

### Stacking
Base: `slice-2a-migration`. GitHub will auto-retarget to `main` once PR3 merges.

Merge order: **foundation → {contrast-gate, migration} → home-settings**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a three-state Theme toggle (Light / Dark / System) in Settings.

* **Improvements**
  * Switched UI to design-system tokens for consistent theming and color semantics.
  * Replaced ad-hoc controls with shared components (buttons, cards, badges, inputs) for visual consistency.
  * Accessibility: motion-reduce support and contrast checks for WCAG AA; refined loading/error surfaces.

* **Tests**
  * Added unit tests covering theme toggle behavior and persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/leehopper/personal-running-coach/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->