### PR TITLE
chore(deps): upgrade marten 8->9 and wolverine 5->6 (critter stack)

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -30,11 +30,12 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <!-- Persistence — Marten + Wolverine (event-sourcing + outbox) -->
-    <PackageVersion Include="Marten" Version="8.37.1" />
-    <PackageVersion Include="Marten.EntityFrameworkCore" Version="8.37.1" />
-    <PackageVersion Include="WolverineFx" Version="5.39.3" />
-    <PackageVersion Include="WolverineFx.EntityFrameworkCore" Version="5.39.3" />
-    <PackageVersion Include="WolverineFx.Marten" Version="5.39.3" />
+    <PackageVersion Include="Marten" Version="9.2.1" />
+    <PackageVersion Include="Marten.EntityFrameworkCore" Version="9.2.1" />
+    <PackageVersion Include="WolverineFx" Version="6.1.0" />
+    <PackageVersion Include="WolverineFx.EntityFrameworkCore" Version="6.1.0" />
+    <PackageVersion Include="WolverineFx.Marten" Version="6.1.0" />
+    <PackageVersion Include="WolverineFx.RuntimeCompilation" Version="6.1.0" />
     <!-- Observability — OpenTelemetry -->
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/backend/src/RunCoach.Api/Infrastructure/Idempotency/IdempotencyMarker.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/Idempotency/IdempotencyMarker.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using Marten.Schema;
+using JasperFx;
 
 namespace RunCoach.Api.Infrastructure.Idempotency;
 

--- a/backend/src/RunCoach.Api/Infrastructure/MartenConfiguration.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/MartenConfiguration.cs
@@ -4,6 +4,8 @@ using JasperFx.CodeGeneration;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
+using JasperFx.MultiTenancy;
+using JasperFx.OpenTelemetry;
 using Marten;
 using Marten.EntityFrameworkCore;
 using Marten.Services;

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingProjection.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingProjection.cs
@@ -6,10 +6,11 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding;
 
 /// <summary>
 /// Inline single-stream projection that materializes the runner's in-flight onboarding state
-/// into an <see cref="OnboardingView"/> Marten document (spec 13 § Unit 1, R01.4). Marten's
-/// codegen wires each <c>Apply</c> overload below to the corresponding event type via
-/// pattern-matching at startup; the document is upserted on the same <c>IDocumentSession</c>
-/// as the event append, preserving atomicity for the per-turn handler.
+/// into an <see cref="OnboardingView"/> Marten document (spec 13 § Unit 1, R01.4). Marten 9's
+/// compile-time JasperFx source generator dispatches each <c>Apply</c>/<c>Create</c> convention
+/// method below to its event type, which is why this class must be declared <c>partial</c>; the
+/// document is upserted on the same <c>IDocumentSession</c> as the event append, preserving
+/// atomicity for the per-turn handler.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -22,7 +23,7 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding;
 /// branch so the in-memory view stays in sync with the EF projection (DEC-060 / R-069).
 /// </para>
 /// </remarks>
-public sealed class OnboardingProjection : SingleStreamProjection<OnboardingView, Guid>
+public sealed partial class OnboardingProjection : SingleStreamProjection<OnboardingView, Guid>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="OnboardingProjection"/> class. Marten's

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanProjection.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanProjection.cs
@@ -7,8 +7,9 @@ namespace RunCoach.Api.Modules.Training.Plan;
 /// <summary>
 /// Inline single-stream projection that materializes a Plan stream into a
 /// <see cref="PlanProjectionDto"/> Marten document the frontend renders directly
-/// (spec 13 § Unit 2, R02.3). Marten's codegen wires each <c>Apply</c> overload
-/// below to its event type via pattern-matching at startup; the document is
+/// (spec 13 § Unit 2, R02.3). Marten 9's compile-time JasperFx source generator
+/// dispatches each <c>Apply</c>/<c>Create</c> convention method below to its event
+/// type, which is why this class must be declared <c>partial</c>; the document is
 /// upserted on the same <c>IDocumentSession</c> as the event append, preserving
 /// atomicity for the calling handler (Unit 1 onboarding terminal-branch handler
 /// in Slice 1, Unit 5 regenerate handler later).
@@ -28,7 +29,7 @@ namespace RunCoach.Api.Modules.Training.Plan;
 /// <c>Apply</c> methods - no breaking changes for the Slice 1 frontend.
 /// </para>
 /// </remarks>
-public sealed class PlanProjection : SingleStreamProjection<PlanProjectionDto, Guid>
+public sealed partial class PlanProjection : SingleStreamProjection<PlanProjectionDto, Guid>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="PlanProjection"/> class. Marten's

--- a/backend/src/RunCoach.Api/Program.cs
+++ b/backend/src/RunCoach.Api/Program.cs
@@ -91,13 +91,15 @@ builder.Host.UseWolverine(opts =>
     //     default retry pipeline and re-runs the handler, defeating the
     //     "first response wins" contract the marker exists to enforce.
     //
-    // Note: `DocumentAlreadyExistsException` is a sibling — not a parent — of
-    // the two stream-collision exceptions in Marten's hierarchy, so the rule
-    // must be registered explicitly; the existing two registrations do not
-    // cover it transitively.
+    // Note: `DocumentAlreadyExistsException` is not a parent of the two
+    // stream-collision exceptions — Marten 9 relocated it to the shared
+    // `JasperFx` assembly (`JasperFx.DocumentAlreadyExistsException`) while the
+    // stream-collision pair stays in `Marten.Exceptions`, so no inheritance
+    // links them and the rule must be registered explicitly; the existing two
+    // registrations do not cover it transitively.
     opts.OnException<Marten.Exceptions.ExistingStreamIdCollisionException>().MoveToErrorQueue();
     opts.OnException<Marten.Exceptions.ConcurrentUpdateException>().MoveToErrorQueue();
-    opts.OnException<Marten.Exceptions.DocumentAlreadyExistsException>().MoveToErrorQueue();
+    opts.OnException<JasperFx.DocumentAlreadyExistsException>().MoveToErrorQueue();
 
     // Must match Marten's `AddAsyncDaemon(DaemonMode.Solo)` — `HotCold` takes
     // advisory locks that collide with `ApplyAllDatabaseChangesOnStartup`.

--- a/backend/src/RunCoach.Api/RunCoach.Api.csproj
+++ b/backend/src/RunCoach.Api/RunCoach.Api.csproj
@@ -29,6 +29,13 @@
     <PackageReference Include="WolverineFx" />
     <PackageReference Include="WolverineFx.EntityFrameworkCore" />
     <PackageReference Include="WolverineFx.Marten" />
+    <!-- Wolverine 6 extracted runtime Roslyn code generation into this package.
+         Required because Development (dev runs + the integration-test host) boots
+         with CodeGeneration.TypeLoadMode.Auto (Program.cs), which compiles handler
+         and projection dispatch code at startup; without it the host throws
+         "No IAssemblyGenerator is registered". Production uses TypeLoadMode.Static
+         (pre-generated) and never invokes runtime compilation. -->
+    <PackageReference Include="WolverineFx.RuntimeCompilation" />
     <!-- Observability -->
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />

--- a/backend/tests/RunCoach.Api.Tests/Infrastructure/Idempotency/WolverineErrorRoutingTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Infrastructure/Idempotency/WolverineErrorRoutingTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using JasperFx;
 using Marten.Exceptions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;


### PR DESCRIPTION
## Summary

Coordinated **major upgrade of the full Critter Stack** — Marten 8 → 9 and Wolverine 5 → 6 (JasperFx 2.0). This consolidates the four dependabot PRs that each failed CI in isolation because the five packages are interdependent and must move together:

- supersedes #119 (Marten), #120 (WolverineFx), #121 (WolverineFx.EntityFrameworkCore), #122 (WolverineFx.Marten)

## Package changes (`backend/Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| Marten | 8.37.1 | **9.2.1** |
| Marten.EntityFrameworkCore | 8.37.1 | **9.2.1** |
| WolverineFx | 5.39.3 | **6.1.0** |
| WolverineFx.EntityFrameworkCore | 5.39.3 | **6.1.0** |
| WolverineFx.Marten | 5.39.3 | **6.1.0** |
| WolverineFx.RuntimeCompilation | — | **6.1.0** (new) |

NuGet resolves JasperFx 2.2.0 / JasperFx.Events / Weasel 9.0 transitively; all five packages target `net10.0`. EF Core floors already satisfied (≥ 10.0.2).

## Breaking-change fixes (Marten 9 / Wolverine 6 / JasperFx 2.0)

Verified against the restored 9.2.1 / 6.1.0 assemblies (reflection) and the migration guide:

1. **`[Identity]` attribute relocated** `Marten.Schema` → `JasperFx` — `IdempotencyMarker.cs` (Marten no longer defines its own; it honors the shared JasperFx attribute).
2. **Enum/exception namespace moves** (JasperFx 2.0 consolidation):
   - `TenancyStyle` → `JasperFx.MultiTenancy`, `TrackLevel` → `JasperFx.OpenTelemetry` (`MartenConfiguration.cs` usings).
   - `DocumentAlreadyExistsException` → `JasperFx` (out of `Marten.Exceptions`; the two stream-collision exceptions stayed) — `Program.cs` `OnException` registration + `WolverineErrorRoutingTests.cs`.
3. **Projection programming-model change** — convention-method `SingleStreamProjection` subclasses (`OnboardingProjection`, `PlanProjection`) must now be `partial` so the compile-time `JasperFx.Events` source generator (shipped in the Marten analyzer asset) emits the aggregate dispatcher; the runtime reflection fallback was removed. `UserProfileFromOnboardingProjection` uses an explicit `ApplyEvent` override, so it is unaffected.
4. **Wolverine 6 extracted runtime Roslyn codegen** into `WolverineFx.RuntimeCompilation`. Required for the Development / integration-test host, which boots with `CodeGeneration.TypeLoadMode.Auto`; without it the host throws `No IAssemblyGenerator is registered`. Production uses `TypeLoadMode.Static` and never invokes it.

The reflection-based per-event schema-version helper (`MapEventTypeWithSchemaVersion` / `EventStoreOptionsExtensions`) is **unchanged** — verified the assembly-root type and method signature are byte-identical in 9.2.1.

## Verification

- `dotnet build RunCoach.slnx` — clean, **0 warnings** (SonarAnalyzer 10.27 + StyleCop pass under `TreatWarningsAsErrors`).
- Full suite **1124 / 1124 passing** (`dotnet test --solution RunCoach.slnx`) on Testcontainers Postgres, including: Solo async daemon + `ApplyAllDatabaseChangesOnStartup` clean boot, the legacy-event upcaster synthetic-row regression test, and the idempotency Wolverine error-routing tests.
- No behavioral regressions observed in the documented risk areas (daemon advisory locks, transaction bracketing, projection dispatch, serialization round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
