### PR TITLE
docs: mark slice 2a Playwright E2E verified (12/12 green)

### DIFF
--- a/docs/plans/mvp-0-cycle/cycle-plan.md
+++ b/docs/plans/mvp-0-cycle/cycle-plan.md
@@ -20,14 +20,14 @@ This status block is the single source of truth for "where are we?" — mirrored
 
 ### Slice 2a — post-merge verification
 
-Slice 2a merged 2026-05-30 across PRs #111–#114 (foundation → contrast-gate → auth/onboarding migration → home/settings + dark-mode toggle), in dependency order. Close-out status:
+Slice 2a merged 2026-05-30 across PRs #111–#114 (foundation → contrast-gate → auth/onboarding migration → home/settings + dark-mode toggle), in dependency order. Close-out status — **all verified**:
 
 - [x] Four `slice-2a-*` branches pushed; four stacked PRs opened, reviewed, and merged in dependency order. The R-075 integrate commit `fbe80c4` rode in via the foundation PR (#111).
 - [x] **`check-contrast` passes on the fully-integrated `main`** — all 28 semantic foreground/background pairs clear their WCAG thresholds (`npm run check-contrast`, 2026-05-30). The gate runs in pre-commit + CI.
 - [x] Frontend type-check + unit suite green on integrated `main` — `tsc -b` clean, **367/367 Vitest tests** pass across 35 files.
 - [x] Worktrees torn down and the four merged local `slice-2a-*` branches deleted; no stray Vite dev server (port 5234 clear) or leftover `git` processes.
 - [x] Slice 2a marked complete in this Status block and `ROADMAP.md`, with a Cycle History row added.
-- [ ] **Playwright E2E (`npm run e2e`) on `main`** — needs the full stack up (Postgres + backend API on `https://localhost:5001` + Vite); folded into the post-merge manual stability run. The 5 onboarding specs assert `data-testid` selectors the colour-only migration preserved. This is the one open item; everything else above is verified.
+- [x] **Playwright E2E (`npm run e2e`) — 12/12 specs pass** against the host-run stack (Postgres + backend API on `https://localhost:5001` + Vite, 2026-05-30): error-boundary, theme, auth, onboarding, plan-render, regenerate-plan. Onboarding/plan responses are stubbed via Playwright `route` interception (real backend only for `register`), so the run makes no Anthropic calls. The colour-only migration preserved every `data-testid` selector and flow.
 
 ---
 


### PR DESCRIPTION
Closes the final Slice 2a post-merge checklist item.

Ran the full Playwright E2E suite against the host-run stack on `main`:

```
12 passed (3.4s)
✓ error-boundary.spec.ts (3)   ✓ theme.spec.ts (5)
✓ auth.spec.ts                 ✓ onboarding.spec.ts
✓ plan-render.spec.ts          ✓ regenerate-plan.spec.ts
```

Onboarding/plan responses are stubbed via Playwright `route` interception (the suite uses the real backend only for `register`), so the run makes **no Anthropic calls**. The Slice 2a colour-only migration preserved every `data-testid` selector and flow.

Flips the one remaining `[ ]` in the cycle-plan's "Slice 2a — post-merge verification" ledger to `[x]`. Slice 2a is now fully verified and closed. Docs-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation to reflect completion of end-to-end testing verification for a development phase, confirming all test specifications passed and interactions were properly stubbed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->