### PR TITLE
fix(coaching): onboarding 500 — drop opaque IContextAssembler factory that broke Wolverine 6 codegen

### DIFF
--- a/backend/src/RunCoach.Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Options;
 using RunCoach.Api.Infrastructure.Idempotency;
 using RunCoach.Api.Modules.Coaching;
 using RunCoach.Api.Modules.Coaching.Prompts;
@@ -43,21 +42,18 @@ public static class ServiceCollectionExtensions
         // Coaching module — scoped services (per-request lifetime).
         services.AddScoped<ICoachingLlm, ClaudeCoachingLlm>();
 
-        // ContextAssembler exposes two public constructors — a 3-arg legacy
-        // form for plan-only tests and a 6-arg onboarding-aware form. The
-        // default container's "most-resolvable parameters" heuristic picked
-        // the 3-arg constructor at runtime in this project, leaving
-        // `_sanitizer` null and breaking `ComposeForOnboardingAsync` with an
-        // InvalidOperationException on every onboarding turn. Explicit
-        // factory registration locks the production path to the 6-arg
-        // constructor regardless of constructor-selection quirks.
-        services.AddScoped<IContextAssembler>(sp => new ContextAssembler(
-            sp.GetRequiredService<IPromptStore>(),
-            sp.GetRequiredService<TimeProvider>(),
-            sp.GetRequiredService<IPromptSanitizer>(),
-            sp.GetRequiredService<IHostEnvironment>(),
-            sp.GetRequiredService<IOptions<PromptStoreSettings>>(),
-            sp.GetRequiredService<ILogger<ContextAssembler>>()));
+        // ContextAssembler's 3-arg legacy constructor is `internal` (test-only via
+        // InternalsVisibleTo); the public surface is the single 6-arg
+        // onboarding-aware constructor, so the container unambiguously selects it
+        // from a plain implementation-type registration. This MUST stay a type
+        // registration, not an `sp => new ContextAssembler(...)` lambda factory:
+        // Wolverine 6 handler codegen (ServiceLocationPolicy.NotAllowed, DEC-071)
+        // cannot statically construct an opaque Scoped lambda factory, falls back
+        // to service location, and rejects it — breaking the OnboardingTurnHandler
+        // chain with an HTTP 500 on every onboarding turn. The no-opaque-factory
+        // rule is guarded by WolverineCodegenCompositionTests; correct 6-arg
+        // constructor selection is guarded by ContextAssemblerDiResolutionTests.
+        services.AddScoped<IContextAssembler, ContextAssembler>();
 
         // Prompt-injection sanitizer (Slice 1 § Unit 6 / DEC-059 / R-068).
         // Stateless layered sanitizer — singleton-safe; the pattern catalog

--- a/backend/tests/RunCoach.Api.Tests/Infrastructure/WolverineCodegenCompositionTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Infrastructure/WolverineCodegenCompositionTests.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using RunCoach.Api.Infrastructure;
+
+namespace RunCoach.Api.Tests.Infrastructure;
+
+/// <summary>
+/// Regression guard (DEC-071) for Wolverine 6 message-handler code generation.
+/// Wolverine 6 defaults to <c>ServiceLocationPolicy.NotAllowed</c>: when a handler
+/// depends on a service registered as an "opaque" lambda factory with a Scoped or
+/// Transient lifetime, Wolverine cannot construct it statically, falls back to
+/// service location, and throws <c>InvalidServiceLocationException</c> while
+/// compiling the handler chain — surfacing as an HTTP 500 on the affected endpoint
+/// (the <c>OnboardingTurnHandler</c> / POST <c>/api/v1/onboarding/turns</c> chain).
+///
+/// This blind spot existed because no green test compiled the production handler
+/// graph: the <c>*DiResolutionTests</c> only assert <c>GetRequiredService</c>
+/// succeeds (which an opaque lambda factory satisfies), the onboarding handler unit
+/// tests call the static <c>Handle</c> method directly with mocks (bypassing
+/// Wolverine codegen), and the HTTP/bus integration host swaps
+/// <c>IPlanGenerationService</c> for a stub that severs the failing dependency edge.
+///
+/// This test inspects the production registrations directly (no host boot, no DB,
+/// no LLM) and fails if any module service uses an opaque Scoped/Transient lambda
+/// factory, which would re-break handler codegen. If a future registration genuinely
+/// needs a factory, allow-list the service via
+/// <c>opts.CodeGeneration.AlwaysUseServiceLocationFor&lt;T&gt;()</c> in the Wolverine
+/// configuration AND add it to <see cref="KnownServiceLocationAllowList"/> in the
+/// same change.
+/// </summary>
+public sealed class WolverineCodegenCompositionTests
+{
+    /// <summary>
+    /// Service types intentionally permitted to use Wolverine service location via
+    /// <c>CodeGeneration.AlwaysUseServiceLocationFor&lt;T&gt;()</c>. Empty by design —
+    /// the module convention is concrete implementation-type registrations so handler
+    /// codegen stays static.
+    /// </summary>
+    private static readonly HashSet<Type> KnownServiceLocationAllowList = new();
+
+    [Fact]
+    public void AddApplicationModules_RegistersNoOpaqueScopedOrTransientLambdaFactories()
+    {
+        // Arrange: build the exact production registration graph Program.cs assembles
+        // (see Program.cs `builder.Services.AddApplicationModules(builder.Configuration)`).
+        var services = new ServiceCollection();
+        services.AddApplicationModules(new ConfigurationBuilder().Build());
+
+        // Act: find Scoped/Transient registrations that use an opaque implementation
+        // factory (lambda) rather than a concrete implementation type. Singletons are
+        // exempt — Wolverine resolves them as cached instances, not via per-handler
+        // constructor codegen.
+        var opaqueLambdaFactories = services
+            .Where(descriptor =>
+                descriptor.ImplementationFactory is not null
+                && descriptor.Lifetime != ServiceLifetime.Singleton
+                && !KnownServiceLocationAllowList.Contains(descriptor.ServiceType))
+            .Select(descriptor => descriptor.ServiceType.FullName)
+            .ToList();
+
+        // Assert.
+        opaqueLambdaFactories.Should()
+            .BeEmpty(
+                because: "Wolverine 6 handler codegen (ServiceLocationPolicy.NotAllowed) cannot " +
+                         "statically construct an opaque Scoped/Transient lambda factory and throws " +
+                         "InvalidServiceLocationException while compiling any handler that depends on " +
+                         "it (DEC-071). Register a concrete implementation type, or allow-list the " +
+                         "service via CodeGeneration.AlwaysUseServiceLocationFor<T>().");
+    }
+}


### PR DESCRIPTION
## Symptom

Every onboarding turn returned **HTTP 500** (`POST /api/v1/onboarding/turns`) → the UI showed *"That didn't go through. Try again?"* and stuck on "Sending…". Found during manual verification of the running app (the E2E suite stubs `/onboarding/*`, so it can't catch this).

## Root cause

A regression from the **Marten 9 / Wolverine 6 upgrade (DEC-071, #125)**. Wolverine 6 made `ServiceLocationPolicy.NotAllowed` the default — handler codegen now *throws* if it can't statically construct a dependency. `IContextAssembler` was registered via an **opaque Scoped lambda factory** (`sp => new ContextAssembler(...)`, the Slice 1 PR #77 constructor-selection workaround). Wolverine can't statically construct a lambda factory, falls back to service location, and throws `InvalidServiceLocationException` while compiling the `OnboardingTurnHandler` (`SubmitUserTurn`) chain:

```
Wolverine.Configuration.InvalidServiceLocationException: ... ServiceLocationPolicy.NotAllowed is in effect
  Service ...IContextAssembler: ... an 'opaque' lambda factory with the Scoped lifetime and requires service location
  at OnboardingController.SubmitTurn(...) line 66
```

## Fix

Register `IContextAssembler` with a **concrete implementation type** (`AddScoped<IContextAssembler, ContextAssembler>()`). The 3-arg legacy ctor is already `internal`, so the container unambiguously selects the public 6-arg onboarding-aware ctor — the lambda workaround is now redundant, and a type registration is statically constructible by Wolverine. (Also removed the then-unused `Microsoft.Extensions.Options` using.) Keeps the strict `NotAllowed` policy — the safety net that surfaced this — rather than relaxing it.

## The testing gap (closed here)

No green test compiled the **production** Wolverine handler graph:
- The `*DiResolutionTests` only assert `GetRequiredService` succeeds — which an opaque lambda factory satisfies. They don't exercise Wolverine codegen.
- The onboarding handler unit tests call the `static OnboardingTurnHandler.Handle(...)` directly with NSubstitute mocks — bypassing the bus/codegen.
- The HTTP/bus integration host (`RunCoachAppFactory`) swaps `IPlanGenerationService` for a stub with no `IContextAssembler` dependency — severing the exact edge that triggers the failure.

Added **`WolverineCodegenCompositionTests`** — a fast, host-free guard that inspects the production `AddApplicationModules` registrations and fails if any module service uses an opaque Scoped/Transient lambda factory (with an `AlwaysUseServiceLocationFor<T>` allow-list escape hatch). **Fails on the pre-fix code** (`found {IContextAssembler}`), passes after.

## Verification

- [x] New guard fails red pre-fix, green post-fix
- [x] `ContextAssemblerDiResolutionTests` still green (6-arg ctor still selected — no re-introduction of the original bug)
- [x] Full backend suite **1125/1125**
- [x] Live: backend restarted with the fix; onboarding turn now succeeds (manual)

## Follow-up (not in this PR)
A heavier CI guard could compile the whole handler graph (`dotnet run -- codegen` smoke or a host-boot `AssertWolverineConfigurationIsValid`) to catch *all* future codegen regressions, not just opaque-factory ones. The composition guard here covers the immediate class.