### PR TITLE
feat(plan): add a plan calendar anchor for date-to-slot mapping

### DIFF
--- a/backend/openapi/swagger.json
+++ b/backend/openapi/swagger.json
@@ -1333,6 +1333,7 @@
           "microWorkoutsByWeek",
           "modelId",
           "planId",
+          "planStartDate",
           "promptVersion",
           "userId"
         ],
@@ -1349,6 +1350,10 @@
           "generatedAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "planStartDate": {
+            "type": "string",
+            "format": "date"
           },
           "previousPlanId": {
             "type": "string",

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/Models/PlanProjectionDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/Models/PlanProjectionDto.cs
@@ -36,6 +36,14 @@ public sealed record PlanProjectionDto
     public DateTimeOffset GeneratedAt { get; set; }
 
     /// <summary>
+    /// Gets or sets the calendar date on which the plan's week 1, day 0 (Sunday)
+    /// begins — the start-of-week of the generation date. Threaded through from
+    /// <see cref="PlanGenerated.PlanStartDate"/> verbatim; the frontend derives the
+    /// current week from this anchor relative to today (slice-2b Unit 1 / DEC-076).
+    /// </summary>
+    public DateOnly PlanStartDate { get; set; }
+
+    /// <summary>
     /// Gets or sets the prior plan id when this plan came from the regenerate-from-settings
     /// flow, otherwise <see langword="null"/>. Threaded through from
     /// <see cref="PlanGenerated.PreviousPlanId"/> verbatim.

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanCalendar.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanCalendar.cs
@@ -42,9 +42,24 @@ public static class PlanCalendar
     /// <param name="occurredOn">The date the run actually occurred.</param>
     /// <param name="weekCount">The number of weeks the plan spans (1-based count).</param>
     /// <returns>The resolved slot, or <see langword="null"/> when off-plan.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="weekCount"/> is zero or negative.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="planStartDate"/> is not a Sunday. The week/day math is only
+    /// meaningful against a Sunday anchor (day 0 = Sunday), so a non-Sunday anchor
+    /// would silently yield shifted week boundaries; this guard makes that a loud
+    /// failure rather than a wrong-but-plausible slot. Anchors produced by
+    /// <see cref="StartOfTrainingWeek"/> always satisfy this.
+    /// </exception>
     public static PlanSlot? ResolveSlot(DateOnly planStartDate, DateOnly occurredOn, int weekCount)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(weekCount);
+
+        if (planStartDate.DayOfWeek != DayOfWeek.Sunday)
+        {
+            throw new ArgumentException(
+                $"PlanStartDate must be a Sunday (week 1, day 0); got {planStartDate:O} ({planStartDate.DayOfWeek}).",
+                nameof(planStartDate));
+        }
 
         if (occurredOn < planStartDate)
         {

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanCalendar.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanCalendar.cs
@@ -1,0 +1,65 @@
+namespace RunCoach.Api.Modules.Training.Plan;
+
+/// <summary>
+/// Deterministic calendar mapping between a plan's <c>PlanStartDate</c> anchor
+/// (week 1, day 0 = the Sunday the plan begins) and concrete run dates. Pure,
+/// stateless, and timezone-free: MVP-0 treats <c>PlanStartDate</c> and a run's
+/// <c>OccurredOn</c> as plain local training dates (slice-2b spec § Technical
+/// Considerations — single-timezone solo user, deliberately not over-engineered).
+/// </summary>
+public static class PlanCalendar
+{
+    /// <summary>Number of calendar days in a training week.</summary>
+    private const int DaysPerWeek = 7;
+
+    /// <summary>
+    /// Returns the Sunday on or before <paramref name="date"/> — the calendar
+    /// anchor for a plan generated (or regenerated) on that date. Day 0 of every
+    /// training week is Sunday, matching
+    /// <see cref="Coaching.Models.Structured.WorkoutOutput.DayOfWeek"/> (0 = Sunday).
+    /// Idempotent when <paramref name="date"/> already falls on a Sunday.
+    /// </summary>
+    /// <param name="date">The generation (or regeneration) date.</param>
+    /// <returns>The Sunday that opens the week containing <paramref name="date"/>.</returns>
+    public static DateOnly StartOfTrainingWeek(DateOnly date)
+    {
+        // System.DayOfWeek numbers Sunday as 0, so the enum value is exactly the
+        // count of days to step back to reach this week's Sunday.
+        var daysSinceSunday = (int)date.DayOfWeek;
+        return date.AddDays(-daysSinceSunday);
+    }
+
+    /// <summary>
+    /// Maps a run's date to its 1-based <see cref="PlanSlot"/> within a plan
+    /// anchored at <paramref name="planStartDate"/> and spanning
+    /// <paramref name="weekCount"/> generated weeks:
+    /// <c>weekNumber = floor((occurredOn - planStartDate).Days / 7) + 1</c>,
+    /// <c>dayOfWeek = (int)occurredOn.DayOfWeek</c>. Returns <see langword="null"/>
+    /// (off-plan) when <paramref name="occurredOn"/> falls before the plan start
+    /// or beyond the generated weeks.
+    /// </summary>
+    /// <param name="planStartDate">The plan's week-1, day-0 anchor (a Sunday).</param>
+    /// <param name="occurredOn">The date the run actually occurred.</param>
+    /// <param name="weekCount">The number of weeks the plan spans (1-based count).</param>
+    /// <returns>The resolved slot, or <see langword="null"/> when off-plan.</returns>
+    public static PlanSlot? ResolveSlot(DateOnly planStartDate, DateOnly occurredOn, int weekCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(weekCount);
+
+        if (occurredOn < planStartDate)
+        {
+            return null;
+        }
+
+        // occurredOn >= planStartDate, so the offset is non-negative and integer
+        // division floors as the spec requires.
+        var dayOffset = occurredOn.DayNumber - planStartDate.DayNumber;
+        var weekNumber = (dayOffset / DaysPerWeek) + 1;
+        if (weekNumber > weekCount)
+        {
+            return null;
+        }
+
+        return new PlanSlot(weekNumber, (int)occurredOn.DayOfWeek);
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanGenerated.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanGenerated.cs
@@ -12,6 +12,14 @@ namespace RunCoach.Api.Modules.Training.Plan;
 /// <param name="UserId">The runner's user id - the plan's owner.</param>
 /// <param name="Macro">The periodized macro plan emitted by the macro-tier LLM call.</param>
 /// <param name="GeneratedAt">Wall-clock time the plan was generated.</param>
+/// <param name="PlanStartDate">
+/// The calendar date on which the plan's week 1, day 0 (Sunday, matching
+/// <see cref="Coaching.Models.Structured.WorkoutOutput.DayOfWeek"/> 0 = Sunday)
+/// begins — the start-of-week (Sunday) of the generation date. Lets a logged
+/// run's date map deterministically to a <c>(week, day)</c> slot server-side
+/// (slice-2b Unit 1 / DEC-076); the regenerate flow re-anchors week 1 to the
+/// regeneration week because it shares this construction site.
+/// </param>
 /// <param name="PromptVersion">
 /// The semantic version of the coaching prompt YAML that produced the plan
 /// (e.g. <c>"coaching-v1"</c>) - lets future slices replay or A/B against
@@ -32,6 +40,7 @@ public sealed record PlanGenerated(
     Guid UserId,
     MacroPlanOutput Macro,
     DateTimeOffset GeneratedAt,
+    DateOnly PlanStartDate,
     string PromptVersion,
     string ModelId,
     Guid? PreviousPlanId);

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanGenerationService.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanGenerationService.cs
@@ -288,13 +288,18 @@ public sealed partial class PlanGenerationService : IPlanGenerationService
             totalUsage = totalUsage.Add(microUsage);
 
             var promptVersion = _promptStore.GetActiveVersion(ContextAssembler.CoachingPromptId);
+            var generatedAt = _timeProvider.GetUtcNow();
 
-            // Assemble the canonical Slice 1 plan event sequence.
+            // Assemble the canonical Slice 1 plan event sequence. PlanStartDate anchors
+            // week 1, day 0 (Sunday) to the start of the generation week so a logged run's
+            // date maps deterministically to a (week, day) slot (slice-2b Unit 1 / DEC-076).
+            // The regenerate flow re-anchors automatically because it shares this site.
             var planGenerated = new PlanGenerated(
                 PlanId: planId,
                 UserId: userId,
                 Macro: macro,
-                GeneratedAt: _timeProvider.GetUtcNow(),
+                GeneratedAt: generatedAt,
+                PlanStartDate: PlanCalendar.StartOfTrainingWeek(DateOnly.FromDateTime(generatedAt.UtcDateTime)),
                 PromptVersion: promptVersion,
                 ModelId: _settings.ModelId,
                 PreviousPlanId: previousPlanId);

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanProjection.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanProjection.cs
@@ -59,6 +59,7 @@ public sealed partial class PlanProjection : SingleStreamProjection<PlanProjecti
             PlanId = @event.PlanId,
             UserId = @event.UserId,
             GeneratedAt = @event.GeneratedAt,
+            PlanStartDate = @event.PlanStartDate,
             PromptVersion = @event.PromptVersion,
             ModelId = @event.ModelId,
             PreviousPlanId = @event.PreviousPlanId,

--- a/backend/src/RunCoach.Api/Modules/Training/Plan/PlanSlot.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Plan/PlanSlot.cs
@@ -1,0 +1,12 @@
+namespace RunCoach.Api.Modules.Training.Plan;
+
+/// <summary>
+/// A resolved position within a training plan: a 1-based week index and a 0–6
+/// day-of-week where 0 = Sunday, matching
+/// <see cref="Coaching.Models.Structured.WorkoutOutput.DayOfWeek"/>. Produced by
+/// <see cref="PlanCalendar.ResolveSlot"/> and consumed by Slice 2b's
+/// server-authoritative prescription snapshot (Unit 3 / DEC-076).
+/// </summary>
+/// <param name="WeekNumber">1-based week index within the plan.</param>
+/// <param name="DayOfWeek">Day of week, 0 = Sunday through 6 = Saturday.</param>
+public readonly record struct PlanSlot(int WeekNumber, int DayOfWeek);

--- a/backend/tests/RunCoach.Api.Tests/Infrastructure/StubPlanGenerationService.cs
+++ b/backend/tests/RunCoach.Api.Tests/Infrastructure/StubPlanGenerationService.cs
@@ -74,6 +74,7 @@ public sealed class StubPlanGenerationService : IPlanGenerationService
             userId,
             BuildMacro(goal),
             generatedAt,
+            PlanStartDate: PlanCalendar.StartOfTrainingWeek(DateOnly.FromDateTime(generatedAt.UtcDateTime)),
             PromptVersion: "coaching-v1",
             ModelId: "claude-sonnet-4-5",
             PreviousPlanId: previousPlanId);

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnHandlerUnitTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnHandlerUnitTests.cs
@@ -511,6 +511,7 @@ public class OnboardingTurnHandlerUnitTests
                 Warnings = string.Empty,
             },
             GeneratedAt: generatedAt,
+            PlanStartDate: PlanCalendar.StartOfTrainingWeek(DateOnly.FromDateTime(generatedAt.UtcDateTime)),
             PromptVersion: "v1",
             ModelId: "test-model",
             PreviousPlanId: null);

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanCalendarTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanCalendarTests.cs
@@ -109,4 +109,20 @@ public sealed class PlanCalendarTests
         // Assert
         act.Should().Throw<ArgumentOutOfRangeException>();
     }
+
+    [Fact]
+    public void ResolveSlot_NonSundayPlanStartDate_Throws()
+    {
+        // Arrange — a Wednesday anchor violates the week-1/day-0 = Sunday invariant
+        // that the week/day math relies on. The guard surfaces this loudly instead
+        // of returning a plausible-but-wrong slot (e.g. for a defaulted 0001-01-01).
+        var planStartDate = new DateOnly(2026, 6, 10); // Wednesday
+        var occurredOn = new DateOnly(2026, 6, 10);
+
+        // Act
+        var act = () => PlanCalendar.ResolveSlot(planStartDate, occurredOn, weekCount: 8);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
 }

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanCalendarTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanCalendarTests.cs
@@ -1,0 +1,112 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Training.Plan;
+
+namespace RunCoach.Api.Tests.Modules.Training.Plan;
+
+/// <summary>
+/// Pure-function tests over <see cref="PlanCalendar"/> — the deterministic
+/// <c>PlanStartDate</c> calendar anchor (slice-2b Unit 1 / DEC-076). Covers the
+/// start-of-week (Sunday) computation that anchors a generated plan and the
+/// <c>OccurredOn → (week, day)</c> slot mapping that Unit 3 uses for
+/// server-authoritative prescription snapshotting. No Marten or database.
+/// </summary>
+public sealed class PlanCalendarTests
+{
+    [Theory]
+    [InlineData(2026, 6, 10, 2026, 6, 7)] // Wednesday → preceding Sunday
+    [InlineData(2026, 6, 7, 2026, 6, 7)] // Sunday → itself (idempotent)
+    [InlineData(2026, 6, 13, 2026, 6, 7)] // Saturday (end of week) → that week's Sunday
+    [InlineData(2026, 6, 23, 2026, 6, 21)] // Tuesday of the next-but-one week → 2026-06-21 Sunday
+    public void StartOfTrainingWeek_ReturnsSundayOnOrBeforeDate(
+        int year,
+        int month,
+        int day,
+        int expectedYear,
+        int expectedMonth,
+        int expectedDay)
+    {
+        // Arrange
+        var date = new DateOnly(year, month, day);
+        var expectedStart = new DateOnly(expectedYear, expectedMonth, expectedDay);
+
+        // Act
+        var actualStart = PlanCalendar.StartOfTrainingWeek(date);
+
+        // Assert
+        actualStart.DayOfWeek.Should().Be(DayOfWeek.Sunday, because: "every training week opens on a Sunday");
+        actualStart.Should().Be(expectedStart);
+    }
+
+    [Theory]
+    [InlineData(2026, 6, 7, 8, 1, 0)] // first day → week 1, Sunday
+    [InlineData(2026, 6, 18, 8, 2, 4)] // 11 days in → week 2, Thursday
+    [InlineData(2026, 6, 13, 8, 1, 6)] // last day of week 1 → week 1, Saturday
+    [InlineData(2026, 6, 14, 8, 2, 0)] // first day of week 2 → week 2, Sunday
+    [InlineData(2026, 7, 26, 8, 8, 0)] // 49 days in → week 8 (final week), Sunday
+    public void ResolveSlot_OnPlanDate_ReturnsExpectedWeekAndDay(
+        int occurredYear,
+        int occurredMonth,
+        int occurredDay,
+        int weekCount,
+        int expectedWeek,
+        int expectedDay)
+    {
+        // Arrange
+        var planStartDate = new DateOnly(2026, 6, 7);
+        var occurredOn = new DateOnly(occurredYear, occurredMonth, occurredDay);
+
+        // Act
+        var actualSlot = PlanCalendar.ResolveSlot(planStartDate, occurredOn, weekCount);
+
+        // Assert
+        actualSlot.Should().NotBeNull();
+        actualSlot!.Value.WeekNumber.Should().Be(expectedWeek);
+        actualSlot.Value.DayOfWeek.Should().Be(expectedDay);
+    }
+
+    [Theory]
+    [InlineData(2026, 6, 5)] // before plan start (2026-06-05 < 2026-06-07) → off-plan
+    [InlineData(2026, 8, 23)] // 77 days in → week 12, beyond the 8 generated weeks → off-plan
+    public void ResolveSlot_OffPlanDate_ReturnsNull(int year, int month, int day)
+    {
+        // Arrange — an 8-week plan anchored at 2026-06-07.
+        var planStartDate = new DateOnly(2026, 6, 7);
+        var occurredOn = new DateOnly(year, month, day);
+        const int weekCount = 8;
+
+        // Act
+        var actualSlot = PlanCalendar.ResolveSlot(planStartDate, occurredOn, weekCount);
+
+        // Assert
+        actualSlot.Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveSlot_DayBeyondFinalWeek_ReturnsNull()
+    {
+        // Arrange — week 9 of an 8-week plan is exactly one week past the end.
+        var planStartDate = new DateOnly(2026, 6, 7);
+        var occurredOn = planStartDate.AddDays(8 * 7); // first day of week 9
+        const int weekCount = 8;
+
+        // Act
+        var actualSlot = PlanCalendar.ResolveSlot(planStartDate, occurredOn, weekCount);
+
+        // Assert
+        actualSlot.Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveSlot_NonPositiveWeekCount_Throws()
+    {
+        // Arrange
+        var planStartDate = new DateOnly(2026, 6, 7);
+        var occurredOn = new DateOnly(2026, 6, 7);
+
+        // Act
+        var act = () => PlanCalendar.ResolveSlot(planStartDate, occurredOn, weekCount: 0);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanEventSequenceTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanEventSequenceTests.cs
@@ -151,6 +151,7 @@ public sealed class PlanEventSequenceTests
             Warnings = string.Empty,
         },
         GeneratedAt: new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero),
+        PlanStartDate: PlanCalendar.StartOfTrainingWeek(new DateOnly(2026, 5, 1)),
         PromptVersion: "v1",
         ModelId: "test-model",
         PreviousPlanId: null);

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanGenerationServiceTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanGenerationServiceTests.cs
@@ -137,6 +137,44 @@ public sealed class PlanGenerationServiceTests
         generated.PromptVersion.Should().Be("v1");
         generated.ModelId.Should().Be("test-model-id");
         generated.GeneratedAt.Should().Be(Now);
+
+        // PlanStartDate anchors to the Sunday opening the generation week.
+        // Now is 2026-04-25 (a Saturday); the preceding Sunday is 2026-04-19.
+        generated.PlanStartDate.Should().Be(new DateOnly(2026, 4, 19));
+    }
+
+    [Fact]
+    public async Task GeneratePlanAsync_AnchorsPlanStartDateToGenerationWeekSunday()
+    {
+        // Arrange — generate on Wednesday 2026-06-10; week 1, day 0 anchors to the
+        // preceding Sunday 2026-06-07 (slice-2b Unit 1 / DEC-076).
+        var generationDate = new DateTimeOffset(2026, 6, 10, 9, 30, 0, TimeSpan.Zero);
+        var (sut, llm, _) = CreateSut(generationDate);
+        ConfigureLlmHappyPath(llm);
+        var view = CreateCompletedView();
+
+        // Act
+        var sequence = await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        sequence.Macro.PlanStartDate.Should().Be(new DateOnly(2026, 6, 7));
+    }
+
+    [Fact]
+    public async Task GeneratePlanAsync_Regenerate_ReanchorsPlanStartDateToRegenerationWeek()
+    {
+        // Arrange — regenerating on Tuesday 2026-06-23 re-anchors week 1 to that
+        // week's Sunday 2026-06-21; the regenerate flow shares this construction site.
+        var regenerationDate = new DateTimeOffset(2026, 6, 23, 18, 0, 0, TimeSpan.Zero);
+        var (sut, llm, _) = CreateSut(regenerationDate);
+        ConfigureLlmHappyPath(llm);
+        var view = CreateCompletedView();
+
+        // Act
+        var sequence = await sut.GeneratePlanAsync(view, UserId, PlanId, intent: null, previousPlanId: PreviousPlanId, TestContext.Current.CancellationToken);
+
+        // Assert
+        sequence.Macro.PlanStartDate.Should().Be(new DateOnly(2026, 6, 21));
     }
 
     [Fact]
@@ -497,7 +535,8 @@ public sealed class PlanGenerationServiceTests
         actual.IsDeloadCandidate.Should().BeFalse();
     }
 
-    private static (PlanGenerationService Sut, ICoachingLlm Llm, IContextAssembler Assembler) CreateSut()
+    private static (PlanGenerationService Sut, ICoachingLlm Llm, IContextAssembler Assembler) CreateSut(
+        DateTimeOffset? now = null)
     {
         var assembler = Substitute.For<IContextAssembler>();
         assembler
@@ -535,7 +574,7 @@ public sealed class PlanGenerationServiceTests
         });
 
         var timeProvider = Substitute.For<TimeProvider>();
-        timeProvider.GetUtcNow().Returns(Now);
+        timeProvider.GetUtcNow().Returns(now ?? Now);
 
         var sut = new PlanGenerationService(
             assembler,

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanProjectionTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanProjectionTests.cs
@@ -21,6 +21,9 @@ public sealed class PlanProjectionTests
 
     private static readonly DateTimeOffset Now = new(2026, 4, 25, 12, 0, 0, TimeSpan.Zero);
 
+    // 2026-04-19 is the Sunday opening the week that contains Now (2026-04-25, a Saturday).
+    private static readonly DateOnly PlanStartDate = new(2026, 4, 19);
+
     private static readonly Guid PlanId = new("22222222-2222-2222-2222-222222222222");
 
     private static readonly Guid UserId = new("11111111-1111-1111-1111-111111111111");
@@ -35,6 +38,7 @@ public sealed class PlanProjectionTests
         var expectedPlanId = PlanId;
         var expectedUserId = UserId;
         var expectedGeneratedAt = Now;
+        var expectedPlanStartDate = PlanStartDate;
         var expectedPromptVersion = PromptVersion;
         var expectedModelId = ModelId;
         var generated = new PlanGenerated(
@@ -42,6 +46,7 @@ public sealed class PlanProjectionTests
             expectedUserId,
             expectedMacro,
             expectedGeneratedAt,
+            expectedPlanStartDate,
             expectedPromptVersion,
             expectedModelId,
             PreviousPlanId: null);
@@ -53,6 +58,7 @@ public sealed class PlanProjectionTests
         actual.PlanId.Should().Be(expectedPlanId);
         actual.UserId.Should().Be(expectedUserId);
         actual.GeneratedAt.Should().Be(expectedGeneratedAt);
+        actual.PlanStartDate.Should().Be(expectedPlanStartDate);
         actual.PromptVersion.Should().Be(expectedPromptVersion);
         actual.ModelId.Should().Be(expectedModelId);
         actual.PreviousPlanId.Should().BeNull();
@@ -72,6 +78,7 @@ public sealed class PlanProjectionTests
             UserId,
             BuildMacro(),
             Now,
+            PlanStartDate,
             PromptVersion,
             ModelId,
             PreviousPlanId: expectedPreviousPlanId);
@@ -293,6 +300,7 @@ public sealed class PlanProjectionTests
             UserId,
             BuildMacro(),
             Now,
+            PlanStartDate,
             PromptVersion,
             ModelId,
             PreviousPlanId: null);

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanRenderingControllerIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Plan/PlanRenderingControllerIntegrationTests.cs
@@ -130,6 +130,7 @@ public class PlanRenderingControllerIntegrationTests(RunCoachAppFactory factory)
         actual!.PlanId.Should().Be(planId);
         actual.UserId.Should().Be(userId);
         actual.GeneratedAt.Should().Be(PlanGeneratedAt);
+        actual.PlanStartDate.Should().Be(new DateOnly(2026, 4, 19), because: "PlanGeneratedAt 2026-04-25 (Saturday) anchors to the preceding Sunday");
         actual.PromptVersion.Should().Be("coaching-v1");
         actual.ModelId.Should().Be("claude-sonnet-4-5");
         actual.PreviousPlanId.Should().BeNull();
@@ -150,6 +151,7 @@ public class PlanRenderingControllerIntegrationTests(RunCoachAppFactory factory)
             PlanId = planId,
             UserId = userId,
             GeneratedAt = PlanGeneratedAt,
+            PlanStartDate = new DateOnly(2026, 4, 19),
             PromptVersion = "coaching-v1",
             ModelId = "claude-sonnet-4-5",
             PreviousPlanId = null,
@@ -516,6 +518,7 @@ public class PlanRenderingControllerIntegrationTests(RunCoachAppFactory factory)
             userId,
             BuildMacro(),
             PlanGeneratedAt,
+            PlanStartDate: PlanCalendar.StartOfTrainingWeek(DateOnly.FromDateTime(PlanGeneratedAt.UtcDateTime)),
             PromptVersion: "coaching-v1",
             ModelId: "claude-sonnet-4-5",
             PreviousPlanId: null);

--- a/frontend/src/app/api/generated/rtk/api.ts
+++ b/frontend/src/app/api/generated/rtk/api.ts
@@ -389,6 +389,7 @@ export type PlanProjectionDto = {
   planId: string
   userId: string
   generatedAt: string
+  planStartDate: string
   previousPlanId?: string | null
   promptVersion: string
   modelId: string

--- a/frontend/src/app/api/generated/zod/plan-rendering/plan-rendering.ts
+++ b/frontend/src/app/api/generated/zod/plan-rendering/plan-rendering.ts
@@ -10,6 +10,7 @@ export const GetApiV1PlanCurrentResponse = zod.strictObject({
   planId: zod.uuid(),
   userId: zod.uuid(),
   generatedAt: zod.iso.datetime({ offset: true }),
+  planStartDate: zod.iso.date(),
   previousPlanId: zod.uuid().nullish(),
   promptVersion: zod.string(),
   modelId: zod.string(),

--- a/frontend/src/app/api/plan.api.spec.ts
+++ b/frontend/src/app/api/plan.api.spec.ts
@@ -43,9 +43,7 @@ describe('planApi.regeneratePlan query factory', () => {
   let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    fetchMock = vi
-      .fn()
-      .mockResolvedValue(jsonResponse({ planId: 'plan-1', status: 'generated' }))
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({ planId: 'plan-1', status: 'generated' }))
     vi.stubGlobal('fetch', fetchMock)
     vi.stubGlobal('Request', PatchedRequest)
   })
@@ -99,6 +97,7 @@ describe('planApi.getCurrentPlan query factory', () => {
         planId: 'plan-1',
         userId: 'user-1',
         generatedAt: '2026-04-25T15:00:00.000Z',
+        planStartDate: '2026-04-19',
         previousPlanId: null,
         promptVersion: 'coaching-v1',
         modelId: 'claude-sonnet-4-6',

--- a/frontend/src/app/modules/plan/components/plan-display.fixture.ts
+++ b/frontend/src/app/modules/plan/components/plan-display.fixture.ts
@@ -107,6 +107,8 @@ export const buildPlanFixture = (): PlanProjectionDto => ({
   planId: '00000000-0000-0000-0000-00000000abcd',
   userId: '00000000-0000-0000-0000-0000000000aa',
   generatedAt: '2026-04-25T10:00:00Z',
+  // 2026-04-19 is the Sunday opening the week containing generatedAt (a Saturday).
+  planStartDate: '2026-04-19',
   previousPlanId: null,
   promptVersion: 'v1',
   modelId: 'claude-sonnet-test',

--- a/frontend/src/app/modules/plan/models/plan.model.ts
+++ b/frontend/src/app/modules/plan/models/plan.model.ts
@@ -179,6 +179,12 @@ export interface PlanProjectionDto {
   planId: string
   userId: string
   generatedAt: string
+  /**
+   * The calendar date (ISO `YYYY-MM-DD`) on which the plan's week 1, day 0
+   * (Sunday) begins — the start-of-week of the generation date. Mirrors
+   * `PlanProjectionDto.PlanStartDate` (slice-2b Unit 1 / DEC-076).
+   */
+  planStartDate: string
   previousPlanId: string | null
   promptVersion: string
   modelId: string

--- a/frontend/src/app/modules/settings/pages/settings-page.spec.tsx
+++ b/frontend/src/app/modules/settings/pages/settings-page.spec.tsx
@@ -52,6 +52,7 @@ const buildPlanStub = (overrides: Partial<PlanProjectionDto> = {}): PlanProjecti
   planId: 'plan-1',
   userId: 'user-1',
   generatedAt: '2026-04-25T15:00:00.000Z',
+  planStartDate: '2026-04-19',
   previousPlanId: null,
   promptVersion: 'coaching-v1',
   modelId: 'claude-sonnet-4-6',


### PR DESCRIPTION
## Slice 2b · PR1 — Plan calendar anchor (`PlanStartDate`)

First PR of the 8-PR slice-2b stack. Backend-only; ships the calendar anchor that later PRs build on.

### What
- `PlanStartDate` (`DateOnly`) on the `PlanGenerated` event + `PlanProjectionDto`, set in `PlanGenerationService` to the **Sunday opening the generation week** — for both the initial and regenerate flows (shared construction site → regenerate re-anchors automatically). `PlanStartDate` is week 1, day 0, matching `WorkoutOutput.DayOfWeek` (0 = Sunday).
- New `PlanCalendar` helper:
  - `StartOfTrainingWeek(date)` → the Sunday on/before a date.
  - `ResolveSlot(planStartDate, occurredOn, weekCount)` → 1-based `(WeekNumber, DayOfWeek)` `PlanSlot`, or `null` when the date is pre-start or beyond the generated weeks. This is the **server-authoritative date→slot mapper** Unit 3's create endpoint will consume; it ships unreferenced by production code here.
- Regenerated `swagger.json` + Orval/RTK artifacts (DEC-066 drift gate). `planStartDate` serializes as `string` / `format: date` → `zod.iso.date()`.

### Why
DEC-076 / slice-2b Unit 1: give the plan a real calendar anchor so a logged run's date maps to a `(week, day)` slot **server-side** for the prescription snapshot, and retire the frontend's lowest-populated-week hack.

### Not in this PR (deliberate scope boundary)
- Frontend `resolveCurrentWeek` rewrite → **PR6a** per the stacked strategy. (`PlanStartDate` is now mirrored onto the hand-maintained `plan.model.ts` — see *Post-review hardening* below — but the lowest-populated-week consumer rewrite that will use it stays in PR6a.)
- No Marten upcaster: no production plan streams exist yet; the new field defaults harmlessly across in-test fixtures. `ResolveSlot` now rejects a non-Sunday anchor (incl. a defaulted `0001-01-01`) loudly rather than resolving a wrong slot — see *Post-review hardening*.

### Tests
- `PlanCalendarTests` — TDD'd red→green: start-of-week (Sun/Wed/Sat/cross-week), slot mapping (in-week, week boundaries, first/final week), off-plan (pre-start, beyond-generated), non-positive `weekCount` guard, non-Sunday `planStartDate` guard.
- `PlanGenerationServiceTests` — anchors to generation-week Sunday (Wed 2026-06-10 → 2026-06-07) and re-anchors on regenerate (Tue 2026-06-23 → 2026-06-21).
- `PlanProjectionTests` / `PlanRenderingControllerIntegrationTests` — `PlanStartDate` round-trips through projection + HTTP response.
- Backend **1141/1141**, frontend **367/367**; both builds + lint green; codegen drift gate green.

### Post-review hardening (deep-review on PR1)
A local deep-review pass produced no blocking issues. Two low-priority suggestions plus one defensive item were addressed in a follow-up commit:
- **Frontend contract sync** — `PlanStartDate` is now on the hand-maintained `PlanProjectionDto` (`plan.model.ts`) and the plan fixtures/specs, so the runtime-consumed type matches the wire contract and its “Mirrors the backend record” doc comment is accurate again. The `resolveCurrentWeek` consumer rewrite still lands in PR6a.
- **`ResolveSlot` invariant guard** — the documented week-1/day-0 = Sunday precondition is enforced with an `ArgumentException`, so a non-Sunday anchor fails loudly instead of returning a plausible-but-wrong slot. This also de-fangs the no-upcaster edge: a defaulted `0001-01-01` anchor (a Monday) throws rather than silently mapping every date off-plan.

### Follow-ups found
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Training plans now include a start date field, enabling the app to accurately calculate the current week relative to today's date.

* **Tests**
  * Added comprehensive test coverage for plan date calculations and calendar slot resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
