### PR TITLE
feat(slice-2b): frontend infra — date-derived current week, toaster mount, FormMessage alert role

### DIFF
--- a/frontend/scripts/__tests__/check-contrast.spec.ts
+++ b/frontend/scripts/__tests__/check-contrast.spec.ts
@@ -461,6 +461,10 @@ describe('check-contrast script (integration)', () => {
       const stdout = execFileSync(tsxBin, [scriptRel, ...(cssPathArg ? [cssPathArg] : [])], {
         cwd: frontendRoot,
         encoding: 'utf8',
+        // Pipe (not inherit) the child's stderr so the deliberate token-regression
+        // case's `[FAIL]` lines land in `error.stderr` for the assertions below
+        // instead of leaking to the test console.
+        stdio: ['ignore', 'pipe', 'pipe'],
       })
       return { status: 0, stdout, stderr: '' }
     } catch (error) {

--- a/frontend/src/app/modules/app/app.component.spec.tsx
+++ b/frontend/src/app/modules/app/app.component.spec.tsx
@@ -37,6 +37,24 @@ vi.mock('~/api/onboarding.api', () => ({
   useGetOnboardingStateQuery: () => getOnboardingStateMock(),
 }))
 
+// `useGlobalErrorReporter` is called unconditionally at the top of `AppShell`,
+// inside `<AppErrorBoundary>`. Mocking it lets one test force a render-time
+// throw from there to exercise the boundary catch; it is a noop by default so
+// every other `<App>` render is unaffected.
+const { useGlobalErrorReporterMock } = vi.hoisted(() => ({
+  useGlobalErrorReporterMock: vi.fn(),
+}))
+
+vi.mock('~/error-boundary/use-global-error-reporter', () => ({
+  useGlobalErrorReporter: () => useGlobalErrorReporterMock(),
+}))
+
+// Keep the boundary's fire-and-forget client-error report from attempting a
+// real network call when the throw path runs under jsdom.
+vi.mock('~/error-boundary/report-client-error', () => ({
+  reportClientError: vi.fn(),
+}))
+
 import { App } from './app.component'
 import { OnboardingRedirectGuard } from './app.component'
 
@@ -121,6 +139,44 @@ describe('App', () => {
 
     expect(await screen.findByText('Workout logged')).toBeInTheDocument()
     toast.dismiss()
+  })
+
+  it('keeps the toast outlet mounted when a render-time throw is caught by the error boundary', async () => {
+    getOnboardingStateMock.mockReturnValue({ data: undefined, isLoading: true, isError: false })
+    // React logs the caught render error to console.error — silence it so the
+    // intentional throw does not leak to the test console.
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    // Force a render-time throw *inside* AppErrorBoundary (AppShell calls this
+    // hook unconditionally) so the boundary catches it and swaps in the
+    // recovery card. The <Toaster> is a sibling mounted *outside* the boundary,
+    // so it must survive the catch and still surface app-wide toasts. The throw
+    // must be consistent across React 19's concurrent attempt *and* its
+    // synchronous-recovery retry, otherwise React treats it as a recoverable
+    // error instead of routing it to the boundary — so use mockImplementation,
+    // not mockImplementationOnce. AppShell is unmounted once the fallback takes
+    // over, so the hook is not called again and there is no throw loop.
+    useGlobalErrorReporterMock.mockImplementation(() => {
+      throw new Error('render boom')
+    })
+
+    render(<App />)
+
+    // The boundary's recovery card replaced the route tree...
+    expect(
+      await screen.findByRole('heading', { name: /something went wrong/i }),
+    ).toBeInTheDocument()
+
+    // ...and a toast fired afterwards still appears, proving the Toaster was
+    // not unmounted by the boundary catch (distinct text avoids colliding with
+    // the prior toast spec's global sonner state).
+    act(() => {
+      toast.success('Logged during recovery')
+    })
+    expect(await screen.findByText('Logged during recovery')).toBeInTheDocument()
+
+    toast.dismiss()
+    useGlobalErrorReporterMock.mockReset()
+    consoleErrorSpy.mockRestore()
   })
 })
 

--- a/frontend/src/app/modules/app/app.component.spec.tsx
+++ b/frontend/src/app/modules/app/app.component.spec.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { toast } from 'sonner'
 import { describe, expect, it, vi } from 'vitest'
 import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
@@ -108,6 +109,18 @@ describe('App', () => {
     // Initial auth slice status === 'unknown' → RequireAuth shows the
     // loading fallback.
     expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('mounts the toast region so app-wide toasts render (pre-stages PR6b success toast)', async () => {
+    getOnboardingStateMock.mockReturnValue({ data: undefined, isLoading: true, isError: false })
+    render(<App />)
+
+    act(() => {
+      toast.success('Workout logged')
+    })
+
+    expect(await screen.findByText('Workout logged')).toBeInTheDocument()
+    toast.dismiss()
   })
 })
 

--- a/frontend/src/app/modules/app/app.component.spec.tsx
+++ b/frontend/src/app/modules/app/app.component.spec.tsx
@@ -159,24 +159,28 @@ describe('App', () => {
       throw new Error('render boom')
     })
 
-    render(<App />)
+    try {
+      render(<App />)
 
-    // The boundary's recovery card replaced the route tree...
-    expect(
-      await screen.findByRole('heading', { name: /something went wrong/i }),
-    ).toBeInTheDocument()
+      // The boundary's recovery card replaced the route tree...
+      expect(
+        await screen.findByRole('heading', { name: /something went wrong/i }),
+      ).toBeInTheDocument()
 
-    // ...and a toast fired afterwards still appears, proving the Toaster was
-    // not unmounted by the boundary catch (distinct text avoids colliding with
-    // the prior toast spec's global sonner state).
-    act(() => {
-      toast.success('Logged during recovery')
-    })
-    expect(await screen.findByText('Logged during recovery')).toBeInTheDocument()
-
-    toast.dismiss()
-    useGlobalErrorReporterMock.mockReset()
-    consoleErrorSpy.mockRestore()
+      // ...and a toast fired afterwards still appears, proving the Toaster was
+      // not unmounted by the boundary catch (distinct text avoids colliding
+      // with the prior toast spec's global sonner state).
+      act(() => {
+        toast.success('Logged during recovery')
+      })
+      expect(await screen.findByText('Logged during recovery')).toBeInTheDocument()
+    } finally {
+      // Always restore — a failed assertion above must not leak the throwing
+      // mock or the console spy into later tests.
+      toast.dismiss()
+      useGlobalErrorReporterMock.mockReset()
+      consoleErrorSpy.mockRestore()
+    }
   })
 })
 

--- a/frontend/src/app/modules/app/app.component.tsx
+++ b/frontend/src/app/modules/app/app.component.tsx
@@ -2,6 +2,7 @@ import { type ReactElement } from 'react'
 import { Provider } from 'react-redux'
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
+import { Toaster } from '@/components/ui/sonner'
 import { store } from './app.store'
 import { useGetOnboardingStateQuery } from '~/api/onboarding.api'
 import { AppErrorBoundary } from '~/error-boundary/app-error-boundary'
@@ -189,6 +190,11 @@ export const App = () => {
           <AppShell />
         </BrowserRouter>
       </AppErrorBoundary>
+      {/* Single app-wide toast outlet. Mounted as a sibling *outside* the
+          error boundary so a render-time throw in the route tree cannot
+          unmount it, and toasts (e.g. the slice-2b log success) still surface
+          on the recovery card. `Toaster` mirrors the `.dark` class itself. */}
+      <Toaster />
     </Provider>
   )
 }

--- a/frontend/src/app/modules/plan/hooks/use-plan.hooks.spec.ts
+++ b/frontend/src/app/modules/plan/hooks/use-plan.hooks.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { buildPlanFixture } from '~/modules/plan/components/plan-display.fixture'
+import type { PlanProjectionDto } from '~/modules/plan/models/plan.model'
+import { resolveCurrentWeek } from './use-plan.hooks'
+
+// The shared fixture anchors `planStartDate` to Sunday 2026-04-19 with meso
+// templates for weeks 1–4 and micro detail for week 1 only. These specs pin
+// `resolveCurrentWeek` to a date-derived week (DEC-076 / slice-2b Unit 1),
+// passing an explicit reference date so they never depend on the wall clock.
+
+describe('resolveCurrentWeek', () => {
+  it('derives the current week from planStartDate relative to the reference date', () => {
+    // 2026-05-03 is 14 days after the fixture's 2026-04-19 anchor → week 3.
+    // The lowest-populated heuristic would return week 1 (only micro week 1
+    // is populated), so a result of 3 proves the date-derived path is used.
+    expect(resolveCurrentWeek(buildPlanFixture(), new Date(2026, 4, 3))).toBe(3)
+  })
+
+  it('does not fall back to the lowest-populated-week heuristic for an in-range week', () => {
+    const plan = buildPlanFixture()
+    const lowestPopulated = Number.parseInt(Object.keys(plan.microWorkoutsByWeek)[0] ?? '1', 10)
+    const derived = resolveCurrentWeek(plan, new Date(2026, 4, 3))
+    expect(derived).not.toBe(lowestPopulated)
+    expect(derived).toBe(3)
+  })
+
+  it('maps the plan’s first day to week 1', () => {
+    expect(resolveCurrentWeek(buildPlanFixture(), new Date(2026, 3, 19))).toBe(1)
+  })
+
+  it('resolves a mid-week date into the same week via floor division', () => {
+    // 2026-04-29 is 10 days after the anchor → floor(10 / 7) + 1 = 2.
+    expect(resolveCurrentWeek(buildPlanFixture(), new Date(2026, 3, 29))).toBe(2)
+  })
+
+  it('returns a defined in-range week when that week has no micro detail loaded', () => {
+    // Week 3 has a meso template but no micro-cycle detail in the fixture.
+    const derived = resolveCurrentWeek(buildPlanFixture(), new Date(2026, 4, 3))
+    expect(Number.isInteger(derived)).toBe(true)
+    expect(derived).toBe(3)
+    expect(buildPlanFixture().microWorkoutsByWeek[3]).toBeUndefined()
+  })
+
+  it('clamps to the first template week when the reference date precedes the plan start', () => {
+    expect(resolveCurrentWeek(buildPlanFixture(), new Date(2026, 3, 12))).toBe(1)
+  })
+
+  it('clamps to the last template week when the reference date is beyond the generated weeks', () => {
+    // Fixture has meso templates for weeks 1–4; a far-future date clamps to 4.
+    expect(resolveCurrentWeek(buildPlanFixture(), new Date(2026, 7, 1))).toBe(4)
+  })
+
+  it('falls back to the lowest-populated week when planStartDate is malformed', () => {
+    const plan: PlanProjectionDto = {
+      ...buildPlanFixture(),
+      planStartDate: '',
+      microWorkoutsByWeek: {
+        2: { workouts: [] },
+        3: { workouts: [] },
+      },
+    }
+    // No usable anchor → the defensive heuristic returns the lowest populated
+    // micro week (2), not a clamped date-derived value.
+    expect(resolveCurrentWeek(plan, new Date(2026, 4, 3))).toBe(2)
+  })
+})

--- a/frontend/src/app/modules/plan/hooks/use-plan.hooks.spec.ts
+++ b/frontend/src/app/modules/plan/hooks/use-plan.hooks.spec.ts
@@ -5,8 +5,8 @@ import { resolveCurrentWeek } from './use-plan.hooks'
 
 // The shared fixture anchors `planStartDate` to Sunday 2026-04-19 with meso
 // templates for weeks 1–4 and micro detail for week 1 only. These specs pin
-// `resolveCurrentWeek` to a date-derived week (DEC-076 / slice-2b Unit 1),
-// passing an explicit reference date so they never depend on the wall clock.
+// `resolveCurrentWeek` to a date-derived week (slice-2b Unit 1), passing an
+// explicit reference date so they never depend on the wall clock.
 
 describe('resolveCurrentWeek', () => {
   it('derives the current week from planStartDate relative to the reference date', () => {
@@ -62,5 +62,43 @@ describe('resolveCurrentWeek', () => {
     // No usable anchor → the defensive heuristic returns the lowest populated
     // micro week (2), not a clamped date-derived value.
     expect(resolveCurrentWeek(plan, new Date(2026, 4, 3))).toBe(2)
+  })
+
+  it('falls back to the lowest populated micro week when the plan carries no meso templates', () => {
+    const plan: PlanProjectionDto = {
+      ...buildPlanFixture(),
+      mesoWeeks: [],
+      microWorkoutsByWeek: {
+        3: { workouts: [] },
+        5: { workouts: [] },
+      },
+    }
+    // No meso templates → firstWeek/lastWeek are undefined → date derivation is
+    // impossible, so the heuristic returns the lowest populated micro week (3)
+    // regardless of the (valid) planStartDate and reference date.
+    expect(resolveCurrentWeek(plan, new Date(2026, 4, 3))).toBe(3)
+  })
+
+  it('falls back to the first meso template week when the anchor is malformed and no micro weeks are populated', () => {
+    const plan: PlanProjectionDto = {
+      ...buildPlanFixture(),
+      planStartDate: 'not-a-date',
+      microWorkoutsByWeek: {},
+    }
+    // Malformed anchor → fallback; no populated micro week → the heuristic
+    // returns the first meso template week (1) from the fixture’s weeks 1–4.
+    expect(resolveCurrentWeek(plan, new Date(2026, 4, 3))).toBe(1)
+  })
+
+  it('falls back to week 1 when the plan has neither meso templates nor populated micro weeks', () => {
+    const plan: PlanProjectionDto = {
+      ...buildPlanFixture(),
+      mesoWeeks: [],
+      microWorkoutsByWeek: {},
+    }
+    // Neither anchor-derivable (no templates) nor any populated week → the
+    // final `?? 1` guard returns week 1 so the home surface still renders a
+    // defined week without throwing.
+    expect(resolveCurrentWeek(plan, new Date(2026, 4, 3))).toBe(1)
   })
 })

--- a/frontend/src/app/modules/plan/hooks/use-plan.hooks.ts
+++ b/frontend/src/app/modules/plan/hooks/use-plan.hooks.ts
@@ -77,7 +77,7 @@ const resolveLowestPopulatedWeek = (plan: PlanProjectionDto): number => {
 
 /**
  * Returns the 1-based current training week, derived from the plan's calendar
- * anchor (`planStartDate`, DEC-076 / slice-2b Unit 1) relative to `referenceDate`
+ * anchor (`planStartDate`, slice-2b Unit 1) relative to `referenceDate`
  * (today by default): `floor((referenceDate − planStartDate).days / 7) + 1`.
  *
  * The result is clamped into the range of weeks that actually carry a meso

--- a/frontend/src/app/modules/plan/hooks/use-plan.hooks.ts
+++ b/frontend/src/app/modules/plan/hooks/use-plan.hooks.ts
@@ -43,13 +43,26 @@ export const usePlan = (): UsePlanReturn => {
   }
 }
 
+const DAY_MS = 86_400_000
+
 /**
- * Returns the 1-based current week derived from the projection. Returns the
- * lowest-numbered populated week in `microWorkoutsByWeek`, falling back to
- * the first meso template's week number when no micro workouts are present,
- * and finally to week 1 if neither is available.
+ * Parse an ISO `YYYY-MM-DD` plan start date into a UTC-midnight epoch, or
+ * `undefined` when the string is absent or malformed. UTC midnight keeps the
+ * day-count subtraction free of DST artefacts.
  */
-export const resolveCurrentWeek = (plan: PlanProjectionDto): number => {
+const parsePlanStartUtc = (planStartDate: string): number | undefined => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(planStartDate)
+  if (match === null) return undefined
+  const utc = Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3]))
+  return Number.isNaN(utc) ? undefined : utc
+}
+
+/**
+ * The pre-anchor heuristic, retained as a defensive fallback for streams that
+ * carry no usable `planStartDate`: the lowest-numbered populated week in
+ * `microWorkoutsByWeek`, then the first meso template's week, then week 1.
+ */
+const resolveLowestPopulatedWeek = (plan: PlanProjectionDto): number => {
   const populatedWeeks = Object.keys(plan.microWorkoutsByWeek)
     .map((key) => Number.parseInt(key, 10))
     .filter((value) => Number.isFinite(value) && value >= 1)
@@ -58,10 +71,50 @@ export const resolveCurrentWeek = (plan: PlanProjectionDto): number => {
   if (firstPopulated !== undefined) {
     return firstPopulated
   }
-  // Fall back to the first meso template's week number when no micro
-  // workouts are present (defensive path for a partially-projected stream).
   const firstMeso = plan.mesoWeeks.find((week) => week.weekNumber >= 1)
   return firstMeso?.weekNumber ?? 1
+}
+
+/**
+ * Returns the 1-based current training week, derived from the plan's calendar
+ * anchor (`planStartDate`, DEC-076 / slice-2b Unit 1) relative to `referenceDate`
+ * (today by default): `floor((referenceDate − planStartDate).days / 7) + 1`.
+ *
+ * The result is clamped into the range of weeks that actually carry a meso
+ * template, so the caller always lands on a renderable week — a date before the
+ * plan starts resolves to its first week, a date past the generated weeks to its
+ * last. When `planStartDate` is missing or malformed (or no templates exist),
+ * it falls back to the legacy lowest-populated-week heuristic so the surface
+ * still renders a defined week without throwing.
+ *
+ * `referenceDate` is injectable purely for deterministic tests; production
+ * callers omit it and get the current date.
+ */
+export const resolveCurrentWeek = (
+  plan: PlanProjectionDto,
+  referenceDate: Date = new Date(),
+): number => {
+  const templateWeeks = plan.mesoWeeks
+    .map((week) => week.weekNumber)
+    .filter((value) => Number.isFinite(value) && value >= 1)
+    .sort((left, right) => left - right)
+
+  const planStartUtc = parsePlanStartUtc(plan.planStartDate)
+  const firstWeek = templateWeeks[0]
+  const lastWeek = templateWeeks[templateWeeks.length - 1]
+  if (planStartUtc === undefined || firstWeek === undefined || lastWeek === undefined) {
+    return resolveLowestPopulatedWeek(plan)
+  }
+
+  const referenceUtc = Date.UTC(
+    referenceDate.getFullYear(),
+    referenceDate.getMonth(),
+    referenceDate.getDate(),
+  )
+  const elapsedDays = Math.floor((referenceUtc - planStartUtc) / DAY_MS)
+  const dateDerivedWeek = Math.floor(elapsedDays / 7) + 1
+
+  return Math.min(Math.max(dateDerivedWeek, firstWeek), lastWeek)
 }
 
 /**

--- a/frontend/src/components/ui/form.spec.tsx
+++ b/frontend/src/components/ui/form.spec.tsx
@@ -40,6 +40,30 @@ const FormMessageHarness = ({ errorMessage }: { errorMessage?: string }) => {
   )
 }
 
+// A harness that renders static children through FormMessage with no field
+// error, exercising the non-error branch where role="alert" must be omitted.
+const FormMessageChildrenHarness = ({ children }: { children: React.ReactNode }) => {
+  const form = useForm<HarnessValues>({ defaultValues: { email: '' } })
+
+  return (
+    <Form {...form}>
+      <FormField
+        control={form.control}
+        name="email"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Email</FormLabel>
+            <FormControl>
+              <Input {...field} />
+            </FormControl>
+            <FormMessage>{children}</FormMessage>
+          </FormItem>
+        )}
+      />
+    </Form>
+  )
+}
+
 describe('FormMessage', () => {
   it('announces a validation error assertively via role="alert" (#560)', async () => {
     render(<FormMessageHarness errorMessage="Email is required" />)
@@ -52,5 +76,12 @@ describe('FormMessage', () => {
     render(<FormMessageHarness />)
 
     expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('renders static children without an alert role when there is no error', () => {
+    render(<FormMessageChildrenHarness>Passwords must match</FormMessageChildrenHarness>)
+
+    const note = screen.getByText('Passwords must match')
+    expect(note).not.toHaveAttribute('role')
   })
 })

--- a/frontend/src/components/ui/form.spec.tsx
+++ b/frontend/src/components/ui/form.spec.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { useForm } from 'react-hook-form'
+import { describe, expect, it } from 'vitest'
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from './form'
+import { Input } from './input'
+
+interface HarnessValues {
+  email: string
+}
+
+// Minimal react-hook-form harness exercising the shared FormItem/Control/Message
+// stack the auth and logging surfaces compose. `errorMessage` seeds a manual
+// field error after mount so the assertion reflects the runtime error path.
+const FormMessageHarness = ({ errorMessage }: { errorMessage?: string }) => {
+  const form = useForm<HarnessValues>({ defaultValues: { email: '' } })
+
+  React.useEffect(() => {
+    if (errorMessage !== undefined) {
+      form.setError('email', { type: 'manual', message: errorMessage })
+    }
+  }, [errorMessage, form])
+
+  return (
+    <Form {...form}>
+      <FormField
+        control={form.control}
+        name="email"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Email</FormLabel>
+            <FormControl>
+              <Input {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </Form>
+  )
+}
+
+describe('FormMessage', () => {
+  it('announces a validation error assertively via role="alert" (#560)', async () => {
+    render(<FormMessageHarness errorMessage="Email is required" />)
+
+    const message = await screen.findByText('Email is required')
+    expect(message).toHaveAttribute('role', 'alert')
+  })
+
+  it('renders no alert element when the field has no error', () => {
+    render(<FormMessageHarness />)
+
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/frontend/src/components/ui/form.tsx
+++ b/frontend/src/components/ui/form.tsx
@@ -131,9 +131,10 @@ function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
     <p
       data-slot="form-message"
       // role="alert" announces validation errors assertively to screen readers
-      // the moment the message mounts (carry-in #560) — the hand-rolled
-      // onboarding inputs already carry this; the shared message now matches.
-      role="alert"
+      // the moment they mount (carry-in #560) — but only when `body` is an
+      // actual field error, never when a consumer renders static children
+      // through this slot, so the semantics stay correct.
+      role={error ? 'alert' : undefined}
       id={formMessageId}
       className={cn('text-sm text-destructive', className)}
       {...props}

--- a/frontend/src/components/ui/form.tsx
+++ b/frontend/src/components/ui/form.tsx
@@ -130,6 +130,10 @@ function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
   return (
     <p
       data-slot="form-message"
+      // role="alert" announces validation errors assertively to screen readers
+      // the moment the message mounts (carry-in #560) — the hand-rolled
+      // onboarding inputs already carry this; the shared message now matches.
+      role="alert"
       id={formMessageId}
       className={cn('text-sm text-destructive', className)}
       {...props}


### PR DESCRIPTION
## PR6a — Frontend infra (slice 2b workout logging)

First of the frontend PRs in the stacked slice-2b train (after **PR1 #134**). Pre-stages the `/log` form infra and ships the always-week-1 fix early. Depends only on PR1 (the `PlanStartDate` anchor), already on `main`.

### What changed
- **`resolveCurrentWeek` is now date-derived** from the plan's `PlanStartDate` anchor (DEC-076 / Unit 1) relative to today: `floor((today − planStartDate).days / 7) + 1`, clamped into the meso-template week range so the home surface always lands on a renderable week. This replaces the lowest-populated-week heuristic that pinned the home page to week 1; the heuristic is retained as a defensive fallback for streams with no usable anchor. The reference date is injectable for deterministic tests.
- **Mounted a single app-wide `<Toaster>`** (sonner) as a sibling outside the error boundary, so slice-2b's log-success toast (PR6b) can render app-wide. The `sonner.tsx` primitive shipped in 2a (#111) but was never mounted.
- **`FormMessage` gains `role="alert"`** for assertive screen-reader error announcement (carry-in #560) — matching the hand-rolled onboarding inputs. The role is scoped to actual field errors only (not static children rendered through the slot), so the ARIA semantics stay correct.

### Also in this push (opportunistic test hygiene)
- **Silenced the `[FAIL] check-contrast` console noise during `npm run test`.** Not a real contrast failure — the gate's `exits non-zero when a token regresses` integration test deliberately breaks `--ctp-text` and spawns the gate via `execFileSync`, whose default stderr was inherited to the console. Piping stderr (`stdio: ['ignore','pipe','pipe']`) keeps the existing `error.stderr` assertions working while stopping the leak. Test-only change.

### Tests / gates
- **+8** `resolveCurrentWeek` unit specs: in-range derivation (no lowest-populated fallback), first-day → week 1, mid-week floor division, in-range week with no micro detail, pre-start clamp, beyond-generated-weeks clamp, malformed-anchor fallback.
- **+3** `FormMessage` specs: `role="alert"` on error; no alert when clean; static children render without the role.
- **+1** `<Toaster>` mount test: a fired toast renders app-wide.
- Frontend **379/379** Vitest green (367 → +12); `tsc -b` + `vite build` clean; `eslint` 0 errors.

### Note
`PlanStartDate` was already mirrored onto the hand-maintained `plan.model.ts` in PR1, so no model change was needed here — narrowed from the PR-strategy description, which predated PR1's deep-review widening.

### Follow-ups found
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app-wide toast notifications for user feedback.
  * Implemented date-based current week calculation for workout plans.

* **Improvements**
  * Enhanced form message accessibility with screen-reader alerts for validation errors.

* **Tests**
  * Added comprehensive test coverage for toast notifications and error handling.
  * Expanded tests for week derivation logic and edge cases.
  * Added tests for form message component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->