### PR TITLE
feat(slice-2b): workout-log persistence foundation

### DIFF
--- a/backend/src/RunCoach.Api/Infrastructure/RunCoachDbContext.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/RunCoachDbContext.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using RunCoach.Api.Modules.Coaching.Onboarding.Entities;
 using RunCoach.Api.Modules.Identity.Entities;
+using RunCoach.Api.Modules.Training.Workouts;
 
 namespace RunCoach.Api.Infrastructure;
 
@@ -23,6 +24,8 @@ public class RunCoachDbContext(DbContextOptions<RunCoachDbContext> options)
     public DbSet<DataProtectionKey> DataProtectionKeys => Set<DataProtectionKey>();
 
     public DbSet<RunnerOnboardingProfile> RunnerOnboardingProfiles => Set<RunnerOnboardingProfile>();
+
+    public DbSet<WorkoutLog> WorkoutLogs => Set<WorkoutLog>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/backend/src/RunCoach.Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using RunCoach.Api.Modules.Coaching.Prompts;
 using RunCoach.Api.Modules.Coaching.Sanitization;
 using RunCoach.Api.Modules.Training.Computations;
 using RunCoach.Api.Modules.Training.Plan;
+using RunCoach.Api.Modules.Training.Workouts;
 
 namespace RunCoach.Api.Infrastructure;
 
@@ -35,6 +36,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IPaceZoneIndexCalculator, PaceZoneIndexCalculator>();
         services.AddSingleton<IPaceZoneCalculator, PaceZoneCalculator>();
         services.AddSingleton<IHeartRateZoneCalculator, HeartRateZoneCalculator>();
+
+        // Training module — workout-log persistence (scoped, shares the request DbContext).
+        services.AddScoped<IWorkoutLogRepository, WorkoutLogRepository>();
 
         // Coaching module — prompt store is singleton (caches templates for app lifetime).
         services.AddSingleton<IPromptStore, YamlPromptStore>();

--- a/backend/src/RunCoach.Api/Migrations/20260602210941_AddWorkoutLog.Designer.cs
+++ b/backend/src/RunCoach.Api/Migrations/20260602210941_AddWorkoutLog.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RunCoach.Api.Infrastructure;
@@ -12,9 +13,11 @@ using RunCoach.Api.Infrastructure;
 namespace RunCoach.Api.Migrations
 {
     [DbContext(typeof(RunCoachDbContext))]
-    partial class RunCoachDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260602210941_AddWorkoutLog")]
+    partial class AddWorkoutLog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/RunCoach.Api/Migrations/20260602210941_AddWorkoutLog.cs
+++ b/backend/src/RunCoach.Api/Migrations/20260602210941_AddWorkoutLog.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RunCoach.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkoutLog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "WorkoutLog",
+                schema: "public",
+                columns: table => new
+                {
+                    WorkoutLogId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<string>(type: "text", nullable: true),
+                    OccurredOn = table.Column<DateOnly>(type: "date", nullable: false),
+                    Distance = table.Column<double>(type: "double precision", nullable: false),
+                    Duration = table.Column<long>(type: "bigint", nullable: false),
+                    CompletionStatus = table.Column<int>(type: "integer", nullable: false),
+                    Notes = table.Column<string>(type: "text", nullable: true),
+                    Metrics = table.Column<string>(type: "jsonb", nullable: true),
+                    Splits = table.Column<string>(type: "jsonb", nullable: true),
+                    CreatedOn = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ModifiedOn = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Prescription_DayOfWeek = table.Column<int>(type: "integer", nullable: true),
+                    Prescription_PrescribedDistance = table.Column<double>(type: "double precision", nullable: true),
+                    Prescription_PrescribedDuration = table.Column<long>(type: "bigint", nullable: true),
+                    Prescription_PrescribedPaceFast = table.Column<double>(type: "double precision", nullable: true),
+                    Prescription_PrescribedPaceSlow = table.Column<double>(type: "double precision", nullable: true),
+                    Prescription_SourcePlanId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Prescription_WeekNumber = table.Column<int>(type: "integer", nullable: true),
+                    Prescription_WorkoutType = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkoutLog", x => x.WorkoutLogId);
+                    table.ForeignKey(
+                        name: "FK_WorkoutLog_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalSchema: "public",
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkoutLog_UserId_OccurredOn_WorkoutLogId",
+                schema: "public",
+                table: "WorkoutLog",
+                columns: new[] { "UserId", "OccurredOn", "WorkoutLogId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WorkoutLog",
+                schema: "public");
+        }
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Constants/WorkoutMetricKey.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Constants/WorkoutMetricKey.cs
@@ -1,0 +1,62 @@
+namespace RunCoach.Api.Modules.Training.Constants;
+
+/// <summary>
+/// Canonical set of optional workout-metric keys (DEC-072). This enum is the
+/// single source of truth surfaced to the frontend via the OpenAPI codegen
+/// pipeline; the matching wire strings (the keys used inside the open
+/// <c>WorkoutLog.Metrics</c> <c>jsonb</c> bag) are derived from each member's
+/// name via <see cref="WorkoutMetricKeys.ToWireKey"/>. Values are explicitly
+/// numbered so reordering members in source does not shift the wire encoding.
+/// Names are chosen to match HealthKit / Strava / Garmin source fields so that
+/// future auto-fill ingestion needs no migration.
+/// </summary>
+public enum WorkoutMetricKey
+{
+    /// <summary>Rating of perceived exertion, 1–10 scale.</summary>
+    Rpe = 0,
+
+    /// <summary>Average heart rate over the run, bpm.</summary>
+    HrAvg = 1,
+
+    /// <summary>Maximum heart rate over the run, bpm.</summary>
+    HrMax = 2,
+
+    /// <summary>Energy expenditure, kcal.</summary>
+    Calories = 3,
+
+    /// <summary>Heart-rate variability (SDNN), ms.</summary>
+    Hrv = 4,
+
+    /// <summary>Wearable sleep score, 0–100.</summary>
+    SleepScore = 5,
+
+    /// <summary>Wearable recovery / readiness score, 0–100.</summary>
+    RecoveryScore = 6,
+
+    /// <summary>Average cadence, full steps per minute.</summary>
+    Cadence = 7,
+
+    /// <summary>Total elevation gain, m.</summary>
+    ElevationGain = 8,
+
+    /// <summary>Average running power, W.</summary>
+    Power = 9,
+
+    /// <summary>Free-text weather descriptor.</summary>
+    Weather = 10,
+
+    /// <summary>Free-text terrain descriptor.</summary>
+    Terrain = 11,
+
+    /// <summary>Per-lap splits (array). Stored as the typed <c>Splits</c> column on the entity.</summary>
+    Splits = 12,
+
+    /// <summary>Reserved (DEC-072): vertical oscillation, cm. Unpopulated at MVP-0.</summary>
+    VerticalOscillation = 13,
+
+    /// <summary>Reserved (DEC-072): ground contact time, ms. Unpopulated at MVP-0.</summary>
+    GroundContactTime = 14,
+
+    /// <summary>Reserved (DEC-072): stride length, m. Unpopulated at MVP-0.</summary>
+    StrideLength = 15,
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Constants/WorkoutMetricKeys.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Constants/WorkoutMetricKeys.cs
@@ -1,0 +1,84 @@
+namespace RunCoach.Api.Modules.Training.Constants;
+
+/// <summary>
+/// Single-sourced canonical metric-key strings for the open
+/// <c>WorkoutLog.Metrics</c> <c>jsonb</c> bag (DEC-072). The <see cref="All"/>
+/// set and the ergonomic <c>const</c> strings below are kept drift-free against
+/// <see cref="WorkoutMetricKey"/> by <c>WorkoutMetricKeysTests</c>: every key is
+/// the lower-camel form of its enum member name (<see cref="ToWireKey"/>), so
+/// the UI metric-meta map and the LLM context formatter (slice-2b Unit 5) read
+/// the same labels and cannot diverge.
+/// </summary>
+public static class WorkoutMetricKeys
+{
+    /// <summary>Rating of perceived exertion, 1–10.</summary>
+    public const string Rpe = "rpe";
+
+    /// <summary>Average heart rate, bpm.</summary>
+    public const string HrAvg = "hrAvg";
+
+    /// <summary>Maximum heart rate, bpm.</summary>
+    public const string HrMax = "hrMax";
+
+    /// <summary>Energy expenditure, kcal.</summary>
+    public const string Calories = "calories";
+
+    /// <summary>Heart-rate variability (SDNN), ms.</summary>
+    public const string Hrv = "hrv";
+
+    /// <summary>Sleep score, 0–100.</summary>
+    public const string SleepScore = "sleepScore";
+
+    /// <summary>Recovery / readiness score, 0–100.</summary>
+    public const string RecoveryScore = "recoveryScore";
+
+    /// <summary>Average cadence, full steps per minute.</summary>
+    public const string Cadence = "cadence";
+
+    /// <summary>Total elevation gain, m.</summary>
+    public const string ElevationGain = "elevationGain";
+
+    /// <summary>Average running power, W.</summary>
+    public const string Power = "power";
+
+    /// <summary>Free-text weather descriptor.</summary>
+    public const string Weather = "weather";
+
+    /// <summary>Free-text terrain descriptor.</summary>
+    public const string Terrain = "terrain";
+
+    /// <summary>Per-lap splits (array).</summary>
+    public const string Splits = "splits";
+
+    /// <summary>Reserved: vertical oscillation, cm.</summary>
+    public const string VerticalOscillation = "verticalOscillation";
+
+    /// <summary>Reserved: ground contact time, ms.</summary>
+    public const string GroundContactTime = "groundContactTime";
+
+    /// <summary>Reserved: stride length, m.</summary>
+    public const string StrideLength = "strideLength";
+
+    /// <summary>
+    /// Every canonical wire key, documented and reserved. Kept symmetric with
+    /// <see cref="WorkoutMetricKey"/> by <c>WorkoutMetricKeysTests</c>.
+    /// </summary>
+    public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.Ordinal)
+    {
+        Rpe, HrAvg, HrMax, Calories, Hrv, SleepScore, RecoveryScore,
+        Cadence, ElevationGain, Power, Weather, Terrain, Splits,
+        VerticalOscillation, GroundContactTime, StrideLength,
+    };
+
+    /// <summary>
+    /// Derives the wire key for a <see cref="WorkoutMetricKey"/> by lower-casing
+    /// the first character of its member name (e.g. <c>HrAvg</c> → <c>hrAvg</c>).
+    /// </summary>
+    /// <param name="key">The canonical metric key.</param>
+    /// <returns>The lower-camel wire string used inside the metrics bag.</returns>
+    public static string ToWireKey(WorkoutMetricKey key)
+    {
+        var name = key.ToString();
+        return char.ToLowerInvariant(name[0]) + name[1..];
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Models/Duration.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Models/Duration.cs
@@ -1,0 +1,40 @@
+namespace RunCoach.Api.Modules.Training.Models;
+
+/// <summary>
+/// An elapsed running duration, stored canonically as <see cref="System.TimeSpan.Ticks"/>
+/// (100-ns units) so it maps to a single <c>bigint</c> column via the repo's
+/// <c>DurationValueConverter</c> (DEC-072). A <c>readonly record struct</c> so EF
+/// snapshots and compares by value without a custom comparer. Non-negative.
+/// </summary>
+public readonly record struct Duration
+{
+    private Duration(long ticks)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(ticks);
+        Ticks = ticks;
+    }
+
+    /// <summary>Gets the duration in <see cref="System.TimeSpan.Ticks"/> (100-ns units).</summary>
+    public long Ticks { get; }
+
+    /// <summary>Gets the duration in total seconds.</summary>
+    public double TotalSeconds => TimeSpan.FromTicks(Ticks).TotalSeconds;
+
+    /// <summary>Gets the duration in total minutes.</summary>
+    public double TotalMinutes => TimeSpan.FromTicks(Ticks).TotalMinutes;
+
+    /// <summary>Returns this duration as a <see cref="System.TimeSpan"/>.</summary>
+    public TimeSpan ToTimeSpan() => TimeSpan.FromTicks(Ticks);
+
+    /// <summary>Creates a <see cref="Duration"/> from a tick count (100-ns units).</summary>
+    public static Duration FromTicks(long ticks) => new(ticks);
+
+    /// <summary>Creates a <see cref="Duration"/> from a number of seconds.</summary>
+    public static Duration FromSeconds(double seconds) => new(TimeSpan.FromSeconds(seconds).Ticks);
+
+    /// <summary>Creates a <see cref="Duration"/> from a number of minutes.</summary>
+    public static Duration FromMinutes(double minutes) => new(TimeSpan.FromMinutes(minutes).Ticks);
+
+    /// <summary>Creates a <see cref="Duration"/> from a <see cref="System.TimeSpan"/>.</summary>
+    public static Duration FromTimeSpan(TimeSpan value) => new(value.Ticks);
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/CompletionStatus.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/CompletionStatus.cs
@@ -1,0 +1,17 @@
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// How fully the runner completed a logged workout. Values are explicitly
+/// numbered so reordering members does not shift the stored integer encoding.
+/// </summary>
+public enum CompletionStatus
+{
+    /// <summary>The workout was completed as intended.</summary>
+    Complete = 0,
+
+    /// <summary>The workout was started but cut short (distance/duration below plan).</summary>
+    Partial = 1,
+
+    /// <summary>The workout was not done.</summary>
+    Skipped = 2,
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/DistanceValueConverter.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/DistanceValueConverter.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using RunCoach.Api.Modules.Training.Models;
+
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// Maps a <see cref="Distance"/> value object to a <c>double</c> column of meters
+/// (DEC-072). The repo's first EF <c>ValueConverter</c>; reused by both the
+/// entity's own distance and the prescription snapshot's prescribed distance.
+/// </summary>
+public sealed class DistanceValueConverter : ValueConverter<Distance, double>
+{
+    public DistanceValueConverter()
+        : base(distance => distance.Meters, meters => Distance.FromMeters(meters))
+    {
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/DurationValueConverter.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/DurationValueConverter.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using RunCoach.Api.Modules.Training.Models;
+
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// Maps a <see cref="Duration"/> value object to a <c>bigint</c> column (DEC-072).
+/// </summary>
+public sealed class DurationValueConverter : ValueConverter<Duration, long>
+{
+    public DurationValueConverter()
+        : base(duration => duration.Ticks, ticks => Duration.FromTicks(ticks))
+    {
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/IWorkoutLogRepository.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/IWorkoutLogRepository.cs
@@ -1,0 +1,40 @@
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// Data access for <see cref="WorkoutLog"/> rows (slice-2b Unit 2). Pure
+/// persistence — no endpoints, no LLM. Reads are user-scoped; the prescription
+/// coordinate query backs Slice 3's prescribed-vs-actual lookup.
+/// </summary>
+public interface IWorkoutLogRepository
+{
+    /// <summary>
+    /// Persists a new log. Calls <c>SaveChangesAsync</c> directly, so it is safe
+    /// for a controller/service caller but MUST NOT be called from inside a
+    /// Wolverine handler body — that would commit the EF write in a separate
+    /// transaction from the handler's Marten session and break dual-write
+    /// atomicity (DEC-060). A future plan-adaptation handler (Slice 3) should
+    /// stage the row via the projection pattern, not this method.
+    /// </summary>
+    Task CreateAsync(WorkoutLog log, CancellationToken ct);
+
+    /// <summary>Loads a single log by id, or null if absent.</summary>
+    Task<WorkoutLog?> GetByIdAsync(Guid workoutLogId, CancellationToken ct);
+
+    /// <summary>
+    /// Returns a user's logs newest-first (by <c>OccurredOn</c> then id) as a
+    /// keyset page. Pass the last page's tail as <paramref name="cursor"/> to get
+    /// the next page; pass null for the first page. <paramref name="limit"/> must
+    /// be positive (the caller is responsible for clamping an upper page-size
+    /// bound on any client-supplied value).
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="limit"/> is zero or negative.</exception>
+    Task<IReadOnlyList<WorkoutLog>> GetByUserAsync(
+        Guid userId, WorkoutLogCursor? cursor, int limit, CancellationToken ct);
+
+    /// <summary>
+    /// Returns logs whose prescription snapshot matches the given plan-slot
+    /// coordinate. Off-plan logs (null prescription) never match (DEC-076).
+    /// </summary>
+    Task<IReadOnlyList<WorkoutLog>> GetByPlannedWorkoutAsync(
+        Guid sourcePlanId, int weekNumber, int dayOfWeek, CancellationToken ct);
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/PaceValueConverter.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/PaceValueConverter.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using RunCoach.Api.Modules.Training.Models;
+
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// Maps a <see cref="Pace"/> value object to a <c>double</c> column of seconds
+/// per kilometer (DEC-072). Used by the prescription snapshot's fast/slow pace
+/// bounds inside the <c>WorkoutLog.Prescription</c> complex type.
+/// </summary>
+public sealed class PaceValueConverter : ValueConverter<Pace, double>
+{
+    public PaceValueConverter()
+        : base(pace => pace.SecondsPerKm, seconds => Pace.FromSecondsPerKm(seconds))
+    {
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLog.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLog.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Marten.Metadata;
+using RunCoach.Api.Modules.Identity.Entities;
+using RunCoach.Api.Modules.Training.Models;
+
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// An immutable historical record of a workout the runner actually did
+/// (slice-2b / DEC-072 / DEC-076). Flexible across data richness: required core
+/// fields, an open optional-metrics <c>jsonb</c> bag, typed display-only splits,
+/// a first-class freeform note, and a nullable server-authoritative prescription
+/// snapshot. EF Core entity (the plan stays Marten); tenanted for parity with the
+/// rest of the relational schema.
+/// </summary>
+[Table("WorkoutLog")]
+public class WorkoutLog : ITenanted
+{
+    /// <summary>Gets or sets the primary key.</summary>
+    [Key]
+    public Guid WorkoutLogId { get; set; }
+
+    /// <summary>Gets or sets the owning runner's user id.</summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>Gets or sets the navigation to the owning Identity user.</summary>
+    [ForeignKey(nameof(UserId))]
+    public ApplicationUser? User { get; set; }
+
+    /// <summary>Gets or sets the Marten conjoined-tenancy parity column (DEC-072). Set by the writer to the user id.</summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>Gets or sets the calendar date the run occurred — the prescription-matching anchor (DEC-076).</summary>
+    public DateOnly OccurredOn { get; set; }
+
+    /// <summary>Gets or sets the total distance run (value-converted to a meters column).</summary>
+    public Distance Distance { get; set; }
+
+    /// <summary>Gets or sets the total elapsed duration (value-converted to a ticks column).</summary>
+    public Duration Duration { get; set; }
+
+    /// <summary>Gets or sets how fully the workout was completed.</summary>
+    public CompletionStatus CompletionStatus { get; set; }
+
+    /// <summary>Gets or sets the freeform "what happened" note. No server-side length cap.</summary>
+    public string? Notes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the open optional-metrics bag as a raw JSON string mapped to <c>jsonb</c>
+    /// (DEC-072) — the API owns the JSON; canonical keys live in
+    /// <c>WorkoutMetricKeys</c>. Null when no optional metrics were provided.
+    /// </summary>
+    public string? Metrics { get; set; }
+
+    /// <summary>Gets or sets the typed per-lap splits, stored as a single <c>jsonb</c> column. Null when none.</summary>
+    public List<WorkoutSplit>? Splits { get; set; }
+
+    /// <summary>Gets or sets the server-authoritative prescription snapshot, or null when off-plan (DEC-076).</summary>
+    public WorkoutPrescriptionSnapshot? Prescription { get; set; }
+
+    /// <summary>Gets or sets the audit timestamp for when the log row was created.</summary>
+    public DateTimeOffset CreatedOn { get; set; }
+
+    /// <summary>Gets or sets the audit timestamp for when the log row was last modified.</summary>
+    public DateTimeOffset ModifiedOn { get; set; }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogConfiguration.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogConfiguration.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// EF Core mapping for <see cref="WorkoutLog"/>: value-converted distance/duration
+/// (the repo's first converters), an open <c>jsonb</c> metrics bag, a typed
+/// <c>jsonb</c> splits column, and the nullable EF Core 10 optional complex-type
+/// prescription snapshot (table-split to real columns). Discovered via
+/// <c>ApplyConfigurationsFromAssembly</c>.
+/// </summary>
+internal sealed class WorkoutLogConfiguration : IEntityTypeConfiguration<WorkoutLog>
+{
+    public void Configure(EntityTypeBuilder<WorkoutLog> builder)
+    {
+        // UserId FK to the Identity user; a deleted user cascades their logs away.
+        builder
+            .HasOne(w => w.User)
+            .WithMany()
+            .HasForeignKey(w => w.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Property(w => w.Distance).HasConversion(new DistanceValueConverter());
+        builder.Property(w => w.Duration).HasConversion(new DurationValueConverter());
+
+        // Open optional-metrics bag — raw JSON owned by the API (DEC-072).
+        builder.Property(w => w.Metrics).HasColumnType("jsonb");
+
+        // Typed splits serialized into a single jsonb column.
+        builder
+            .Property(w => w.Splits)
+            .HasConversion(new WorkoutSplitsValueConverter(), new WorkoutSplitsValueComparer())
+            .HasColumnType("jsonb");
+
+        // Server-authoritative prescription snapshot (DEC-076): EF Core 10 optional
+        // complex type, table-split. Distance/Duration/Pace bounds value-converted
+        // on their complex-type member properties; the computed PaceRange view is
+        // ignored (a single converter cannot span the two pace columns).
+        builder.ComplexProperty(w => w.Prescription, prescription =>
+        {
+            // Store WorkoutType by name, not ordinal: the snapshot is durable state,
+            // and the name survives reordering/insertion of enum members (which the
+            // int encoding would not). Matches WorkoutType's JSON representation.
+            prescription.Property(p => p.WorkoutType).HasConversion(new EnumToStringConverter<WorkoutType>());
+            prescription.Property(p => p.PrescribedDistance).HasConversion(new DistanceValueConverter());
+            prescription.Property(p => p.PrescribedDuration).HasConversion(new DurationValueConverter());
+            prescription.Property(p => p.PrescribedPaceFast).HasConversion(new PaceValueConverter());
+            prescription.Property(p => p.PrescribedPaceSlow).HasConversion(new PaceValueConverter());
+            prescription.Ignore(p => p.PrescribedPace);
+        });
+
+        // Supports the newest-first keyset read-by-user.
+        builder.HasIndex(w => new { w.UserId, w.OccurredOn, w.WorkoutLogId });
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogCursor.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogCursor.cs
@@ -1,0 +1,11 @@
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// Keyset cursor for newest-first workout-log paging: the last seen
+/// <c>(OccurredOn, WorkoutLogId)</c> pair. The next page is everything strictly
+/// older than this anchor under the <c>OccurredOn DESC, WorkoutLogId DESC</c>
+/// ordering, so there are no skips or duplicates across a page boundary.
+/// </summary>
+/// <param name="OccurredOn">The last seen run date.</param>
+/// <param name="WorkoutLogId">The last seen log id (tiebreak within a date).</param>
+public readonly record struct WorkoutLogCursor(DateOnly OccurredOn, Guid WorkoutLogId);

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogRepository.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogRepository.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore;
+using RunCoach.Api.Infrastructure;
+
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// EF Core implementation of <see cref="IWorkoutLogRepository"/> over
+/// <see cref="RunCoachDbContext"/>. Sorting and keyset paging execute as SQL;
+/// reads are no-tracking (a log is an immutable historical fact).
+/// </summary>
+public sealed partial class WorkoutLogRepository(
+    RunCoachDbContext db,
+    ILogger<WorkoutLogRepository> logger) : IWorkoutLogRepository
+{
+    private readonly RunCoachDbContext _db = db;
+    private readonly ILogger<WorkoutLogRepository> _logger = logger;
+
+    /// <inheritdoc />
+    public async Task CreateAsync(WorkoutLog log, CancellationToken ct)
+    {
+        _db.WorkoutLogs.Add(log);
+        await _db.SaveChangesAsync(ct);
+        LogCreated(_logger, log.WorkoutLogId, log.UserId);
+    }
+
+    /// <inheritdoc />
+    public Task<WorkoutLog?> GetByIdAsync(Guid workoutLogId, CancellationToken ct) =>
+        _db.WorkoutLogs
+            .AsNoTracking()
+            .FirstOrDefaultAsync(w => w.WorkoutLogId == workoutLogId, ct);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<WorkoutLog>> GetByUserAsync(
+        Guid userId, WorkoutLogCursor? cursor, int limit, CancellationToken ct)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
+
+        var query = _db.WorkoutLogs.AsNoTracking().Where(w => w.UserId == userId);
+
+        if (cursor is { } anchor)
+        {
+            // Strictly older than the anchor under OccurredOn DESC, Id DESC.
+            query = query.Where(w =>
+                w.OccurredOn < anchor.OccurredOn ||
+                (w.OccurredOn == anchor.OccurredOn && w.WorkoutLogId < anchor.WorkoutLogId));
+        }
+
+        return await query
+            .OrderByDescending(w => w.OccurredOn)
+            .ThenByDescending(w => w.WorkoutLogId)
+            .Take(limit)
+            .ToListAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<WorkoutLog>> GetByPlannedWorkoutAsync(
+        Guid sourcePlanId, int weekNumber, int dayOfWeek, CancellationToken ct)
+    {
+        // Comparing the complex-type coordinate columns naturally excludes
+        // off-plan rows: their Prescription columns are NULL, so the equality is
+        // never true (SQL three-valued logic).
+        return await _db.WorkoutLogs
+            .AsNoTracking()
+            .Where(w =>
+                w.Prescription!.SourcePlanId == sourcePlanId &&
+                w.Prescription.WeekNumber == weekNumber &&
+                w.Prescription.DayOfWeek == dayOfWeek)
+            .ToListAsync(ct);
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Created WorkoutLog {WorkoutLogId} for user {UserId}.")]
+    private static partial void LogCreated(ILogger logger, Guid workoutLogId, Guid userId);
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutPrescriptionSnapshot.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutPrescriptionSnapshot.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+using RunCoach.Api.Modules.Training.Models;
+
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// Server-authoritative, point-in-time snapshot of the prescription a logged run
+/// fulfilled (DEC-076). Mapped as an EF Core 10 <b>optional complex type</b>
+/// (table-split to real columns on <c>WorkoutLog</c>, not owned-type or JSON) so
+/// Slice 3's deterministic deviation engine can compare prescribed-vs-actual
+/// without re-resolving a regenerable plan, and so the
+/// <c>(SourcePlanId, WeekNumber, DayOfWeek)</c> coordinate is an indexable query.
+/// A null <c>Prescription</c> on the entity means the run was off-plan.
+/// <see cref="SourcePlanId"/> is the ≥1 EF-required property an optional complex
+/// type needs to detect presence.
+/// </summary>
+public sealed record WorkoutPrescriptionSnapshot
+{
+    /// <summary>Gets the plan stream id whose week/day slot located this prescription.</summary>
+    public Guid SourcePlanId { get; init; }
+
+    /// <summary>Gets the 1-based week index within the source plan.</summary>
+    public int WeekNumber { get; init; }
+
+    /// <summary>Gets the day of week, 0 = Sunday through 6 = Saturday.</summary>
+    public int DayOfWeek { get; init; }
+
+    /// <summary>Gets the frozen copy of the prescribed workout type.</summary>
+    public WorkoutType WorkoutType { get; init; }
+
+    /// <summary>Gets the frozen prescribed total distance.</summary>
+    public Distance PrescribedDistance { get; init; }
+
+    /// <summary>Gets the frozen prescribed total duration.</summary>
+    public Duration PrescribedDuration { get; init; }
+
+    /// <summary>Gets the frozen prescribed fast (lower sec/km) pace bound.</summary>
+    public Pace PrescribedPaceFast { get; init; }
+
+    /// <summary>Gets the frozen prescribed slow (higher sec/km) pace bound.</summary>
+    public Pace PrescribedPaceSlow { get; init; }
+
+    /// <summary>
+    /// Gets the prescribed pace as a <see cref="PaceRange"/> value object — a computed
+    /// view over the two stored bounds, not mapped to its own column(s) (a single
+    /// value converter cannot span two columns). Ignored by EF in
+    /// <c>WorkoutLogConfiguration</c>.
+    /// </summary>
+    [NotMapped]
+    public PaceRange PrescribedPace => new(PrescribedPaceFast, PrescribedPaceSlow);
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutSplit.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutSplit.cs
@@ -1,0 +1,18 @@
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// One recorded lap/split within a logged workout (DEC-072). Primitive-typed so
+/// it serializes cleanly into the entity's typed <c>Splits</c> <c>jsonb</c>
+/// column; display-only at MVP-0 (no aggregation server-side).
+/// </summary>
+/// <param name="Index">1-based split index in run order.</param>
+/// <param name="DistanceMeters">Split distance in meters.</param>
+/// <param name="DurationSeconds">Split elapsed time in seconds.</param>
+/// <param name="PaceSecPerKm">Split pace in seconds per kilometer.</param>
+/// <param name="AverageHeartRate">Optional average heart rate over the split, bpm.</param>
+public sealed record WorkoutSplit(
+    int Index,
+    double DistanceMeters,
+    double DurationSeconds,
+    double PaceSecPerKm,
+    int? AverageHeartRate);

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutSplitsValueComparer.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutSplitsValueComparer.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// Structural change-tracking comparer for the value-converted <c>Splits</c>
+/// collection. <see cref="WorkoutSplit"/> is a record (value equality), so
+/// sequence equality is correct; the snapshot copies the list so EF detects
+/// in-place mutation.
+/// </summary>
+public sealed class WorkoutSplitsValueComparer : ValueComparer<List<WorkoutSplit>>
+{
+    public WorkoutSplitsValueComparer()
+        : base(
+            (a, b) => (a == null && b == null) || (a != null && b != null && a.SequenceEqual(b)),
+            v => v.Aggregate(0, (hash, split) => HashCode.Combine(hash, split.GetHashCode())),
+            v => v.ToList())
+    {
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutSplitsValueConverter.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutSplitsValueConverter.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// Serializes the typed <c>Splits</c> collection to/from a single <c>jsonb</c>
+/// column (DEC-072). Web (camelCase) naming so the stored shape matches the
+/// frontend split DTO. EF maps a null collection to a null column without
+/// invoking the converter, so an absent <c>Splits</c> stays NULL.
+/// </summary>
+public sealed class WorkoutSplitsValueConverter : ValueConverter<List<WorkoutSplit>?, string>
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    public WorkoutSplitsValueConverter()
+        : base(
+            splits => JsonSerializer.Serialize(splits, Options),
+            json => JsonSerializer.Deserialize<List<WorkoutSplit>>(json, Options))
+    {
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Constants/WorkoutMetricKeysTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Constants/WorkoutMetricKeysTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Training.Constants;
+
+namespace RunCoach.Api.Tests.Modules.Training.Constants;
+
+public class WorkoutMetricKeysTests
+{
+    // The canonical metric keys documented in DEC-072 / slice-2b spec § Unit 2.
+    // Pinned here so adding or removing a key forces a conscious test update.
+    private static readonly string[] DocumentedKeys =
+    [
+        "rpe", "hrAvg", "hrMax", "calories", "hrv", "sleepScore", "recoveryScore",
+        "cadence", "elevationGain", "power", "weather", "terrain", "splits",
+    ];
+
+    // Reserved-but-unpopulated running-dynamics keys (DEC-072): named now so
+    // future HealthKit/Garmin ingestion is a zero-migration switch-on.
+    private static readonly string[] ReservedKeys =
+    [
+        "verticalOscillation", "groundContactTime", "strideLength",
+    ];
+
+    [Fact]
+    public void All_ContainsEveryDocumentedAndReservedKey()
+    {
+        // Assert
+        WorkoutMetricKeys.All.Should().Contain(DocumentedKeys);
+        WorkoutMetricKeys.All.Should().Contain(ReservedKeys);
+        WorkoutMetricKeys.All.Should().HaveCount(DocumentedKeys.Length + ReservedKeys.Length);
+    }
+
+    [Fact]
+    public void ConstSet_AndEnum_AreDriftFree()
+    {
+        // Arrange — derive the wire key for every enum member.
+        var enumKeys = Enum.GetValues<WorkoutMetricKey>()
+            .Select(WorkoutMetricKeys.ToWireKey)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // Assert — symmetric: no key appears in the const set but not the enum,
+        // and none appears in the enum but not the const set.
+        WorkoutMetricKeys.All.Should().BeEquivalentTo(enumKeys);
+    }
+
+    [Theory]
+    [InlineData(WorkoutMetricKey.Rpe, "rpe")]
+    [InlineData(WorkoutMetricKey.HrAvg, "hrAvg")]
+    [InlineData(WorkoutMetricKey.HrMax, "hrMax")]
+    [InlineData(WorkoutMetricKey.SleepScore, "sleepScore")]
+    [InlineData(WorkoutMetricKey.ElevationGain, "elevationGain")]
+    [InlineData(WorkoutMetricKey.VerticalOscillation, "verticalOscillation")]
+    public void ToWireKey_LowercasesFirstCharacterOfEnumName(WorkoutMetricKey key, string expected)
+    {
+        // Act
+        var actual = WorkoutMetricKeys.ToWireKey(key);
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Constants_MatchTheirEnumWireKeys()
+    {
+        // Assert — the ergonomic const strings stay locked to the enum-derived wire keys.
+        WorkoutMetricKeys.Rpe.Should().Be(WorkoutMetricKeys.ToWireKey(WorkoutMetricKey.Rpe));
+        WorkoutMetricKeys.HrAvg.Should().Be(WorkoutMetricKeys.ToWireKey(WorkoutMetricKey.HrAvg));
+        WorkoutMetricKeys.Splits.Should().Be(WorkoutMetricKeys.ToWireKey(WorkoutMetricKey.Splits));
+        WorkoutMetricKeys.StrideLength.Should().Be(WorkoutMetricKeys.ToWireKey(WorkoutMetricKey.StrideLength));
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Models/DurationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Models/DurationTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Training.Models;
+
+namespace RunCoach.Api.Tests.Modules.Training.Models;
+
+public class DurationTests
+{
+    [Fact]
+    public void FromMinutes_RoundTrip_PreservesTicksAndMinutes()
+    {
+        // Act
+        var actual = Duration.FromMinutes(25.0);
+
+        // Assert
+        actual.Ticks.Should().Be(TimeSpan.FromMinutes(25.0).Ticks);
+        actual.TotalMinutes.Should().Be(25.0);
+    }
+
+    [Fact]
+    public void FromTicks_RoundTrip_PreservesTicksAndTimeSpan()
+    {
+        // Arrange
+        var expectedTicks = TimeSpan.FromMinutes(42.5).Ticks;
+
+        // Act
+        var actual = Duration.FromTicks(expectedTicks);
+
+        // Assert
+        actual.Ticks.Should().Be(expectedTicks);
+        actual.ToTimeSpan().Should().Be(TimeSpan.FromMinutes(42.5));
+    }
+
+    [Fact]
+    public void FromSeconds_AndFromMinutes_AgreeOnTicks()
+    {
+        // Act
+        var fromSeconds = Duration.FromSeconds(600.0);
+        var fromMinutes = Duration.FromMinutes(10.0);
+
+        // Assert — record equality on the same tick count.
+        fromSeconds.Should().Be(fromMinutes);
+    }
+
+    [Fact]
+    public void FromMinutes_NegativeValue_ThrowsArgumentOutOfRangeException()
+    {
+        // Act
+        var act = () => Duration.FromMinutes(-1.0);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void FromTicks_NegativeValue_ThrowsArgumentOutOfRangeException()
+    {
+        // Act
+        var act = () => Duration.FromTicks(-1L);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Workouts/WorkoutLogRepositoryIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Workouts/WorkoutLogRepositoryIntegrationTests.cs
@@ -1,0 +1,316 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+using RunCoach.Api.Modules.Identity.Entities;
+using RunCoach.Api.Modules.Training.Models;
+using RunCoach.Api.Modules.Training.Workouts;
+using RunCoach.Api.Tests.Infrastructure;
+
+namespace RunCoach.Api.Tests.Modules.Training.Workouts;
+
+/// <summary>
+/// Integration tests for the <see cref="WorkoutLog"/> persistence foundation
+/// (slice-2b Unit 2 / PR2). Each test seeds a real Identity user, then round-trips
+/// a log through <see cref="IWorkoutLogRepository"/> against the Testcontainers
+/// Postgres with the <c>AddWorkoutLog</c> migration applied on fixture boot.
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public class WorkoutLogRepositoryIntegrationTests(RunCoachAppFactory factory)
+    : DbBackedIntegrationTestBase(factory)
+{
+    [Fact]
+    public async Task CreateAsync_MinimumPayload_RoundTripsAndLeavesOptionalsNull()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var userId = await SeedUserAsync();
+        var log = NewLog(userId, new DateOnly(2026, 6, 1));
+
+        // Act
+        await CreateAsync(log, ct);
+        var actual = await GetByIdAsync(log.WorkoutLogId, ct);
+
+        // Assert
+        actual.Should().NotBeNull();
+        actual!.Distance.Meters.Should().Be(5000.0);
+        actual.Duration.TotalMinutes.Should().Be(25.0);
+        actual.CompletionStatus.Should().Be(CompletionStatus.Complete);
+        actual.Metrics.Should().BeNull();
+        actual.Splits.Should().BeNull();
+        actual.Notes.Should().BeNull();
+        actual.Prescription.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_RichPayload_PersistsMetricsBagAndTypedSplits()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var userId = await SeedUserAsync();
+        var log = NewLog(userId, new DateOnly(2026, 6, 2));
+        log.Metrics = """{"hrAvg":142,"rpe":7,"cadence":178}""";
+        log.Splits =
+        [
+            new WorkoutSplit(1, 1000.0, 300.0, 300.0, 138),
+            new WorkoutSplit(2, 1000.0, 295.0, 295.0, 145),
+        ];
+
+        // Act
+        await CreateAsync(log, ct);
+        var actual = await GetByIdAsync(log.WorkoutLogId, ct);
+
+        // Assert — metrics jsonb round-trips by value (key order is not significant).
+        actual.Should().NotBeNull();
+        using var metrics = JsonDocument.Parse(actual!.Metrics!);
+        metrics.RootElement.GetProperty("hrAvg").GetInt32().Should().Be(142);
+        metrics.RootElement.GetProperty("rpe").GetInt32().Should().Be(7);
+        metrics.RootElement.GetProperty("cadence").GetInt32().Should().Be(178);
+
+        // Typed splits round-trip with their index/distance/duration/pace.
+        actual.Splits.Should().NotBeNull();
+        actual.Splits!.Should().HaveCount(2);
+        actual.Splits![0].Should().Be(new WorkoutSplit(1, 1000.0, 300.0, 300.0, 138));
+        actual.Splits![1].Should().Be(new WorkoutSplit(2, 1000.0, 295.0, 295.0, 145));
+    }
+
+    [Fact]
+    public async Task CreateAsync_NotesOnly_PersistsLongFreeformNoteWithoutCap()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var userId = await SeedUserAsync();
+        var notes = new string('x', 5000);
+        var log = NewLog(userId, new DateOnly(2026, 6, 3));
+        log.Notes = notes;
+
+        // Act
+        await CreateAsync(log, ct);
+        var actual = await GetByIdAsync(log.WorkoutLogId, ct);
+
+        // Assert
+        actual.Should().NotBeNull();
+        actual!.Notes.Should().Be(notes);
+        actual.Notes!.Length.Should().Be(5000);
+        actual.Metrics.Should().BeNull();
+        actual.Splits.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_OffPlan_PersistsWithNullPrescription()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var userId = await SeedUserAsync();
+        var log = NewLog(userId, new DateOnly(2026, 6, 4));
+
+        // Act — Prescription left unset (off-plan).
+        await CreateAsync(log, ct);
+        var actual = await GetByIdAsync(log.WorkoutLogId, ct);
+
+        // Assert
+        actual.Should().NotBeNull();
+        actual!.Prescription.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_OnPlan_PersistsPrescriptionSnapshotInRealColumns()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var userId = await SeedUserAsync();
+        var planId = Guid.NewGuid();
+        var log = NewLog(userId, new DateOnly(2026, 6, 5));
+        log.Prescription = new WorkoutPrescriptionSnapshot
+        {
+            SourcePlanId = planId,
+            WeekNumber = 2,
+            DayOfWeek = 4,
+            WorkoutType = WorkoutType.Tempo,
+            PrescribedDistance = Distance.FromKilometers(10.0),
+            PrescribedDuration = Duration.FromMinutes(50.0),
+            PrescribedPaceFast = Pace.FromSecondsPerKm(280.0),
+            PrescribedPaceSlow = Pace.FromSecondsPerKm(330.0),
+        };
+
+        // Act
+        await CreateAsync(log, ct);
+        var matches = await GetByPlannedWorkoutAsync(planId, 2, 4, ct);
+
+        // Assert — the coordinate query returns it, and value objects round-trip.
+        matches.Should().ContainSingle();
+        var prescription = matches[0].Prescription;
+        prescription.Should().NotBeNull();
+        prescription!.SourcePlanId.Should().Be(planId);
+        prescription.WorkoutType.Should().Be(WorkoutType.Tempo);
+        prescription.PrescribedDistance.Meters.Should().Be(10000.0);
+        prescription.PrescribedDuration.TotalMinutes.Should().Be(50.0);
+        prescription.PrescribedPace.Fast.SecondsPerKm.Should().Be(280.0);
+        prescription.PrescribedPace.Slow.SecondsPerKm.Should().Be(330.0);
+    }
+
+    [Fact]
+    public async Task GetByPlannedWorkout_ExcludesOffPlanLogs()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var userId = await SeedUserAsync();
+        var planId = Guid.NewGuid();
+        await CreateAsync(NewLog(userId, new DateOnly(2026, 6, 6)), ct); // off-plan (null prescription)
+
+        // Act
+        var matches = await GetByPlannedWorkoutAsync(planId, 2, 4, ct);
+
+        // Assert — a null-prescription row must never match a coordinate query.
+        matches.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetByUser_ReturnsLogsNewestFirstByKeyset()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var userId = await SeedUserAsync();
+        await CreateAsync(NewLog(userId, new DateOnly(2026, 6, 1)), ct);
+        await CreateAsync(NewLog(userId, new DateOnly(2026, 6, 8)), ct);
+        await CreateAsync(NewLog(userId, new DateOnly(2026, 6, 15)), ct);
+
+        // Act
+        var page = await GetByUserAsync(userId, cursor: null, limit: 10, ct);
+
+        // Assert
+        page.Select(w => w.OccurredOn).Should().Equal(
+            new DateOnly(2026, 6, 15),
+            new DateOnly(2026, 6, 8),
+            new DateOnly(2026, 6, 1));
+    }
+
+    [Fact]
+    public async Task GetByUser_KeysetCursor_PagesAcrossBoundaryWithoutSkipsOrDuplicates()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var userId = await SeedUserAsync();
+        await CreateAsync(NewLog(userId, new DateOnly(2026, 6, 1)), ct);
+        await CreateAsync(NewLog(userId, new DateOnly(2026, 6, 8)), ct);
+        await CreateAsync(NewLog(userId, new DateOnly(2026, 6, 15)), ct);
+
+        // Act — first page, then resume from its tail via a keyset cursor.
+        var page1 = await GetByUserAsync(userId, cursor: null, limit: 2, ct);
+        var tail = page1[^1];
+        var cursor = new WorkoutLogCursor(tail.OccurredOn, tail.WorkoutLogId);
+        var page2 = await GetByUserAsync(userId, cursor, limit: 2, ct);
+
+        // Assert — contiguous newest-first order, no skips and no duplicates.
+        page1.Select(w => w.OccurredOn).Should().Equal(
+            new DateOnly(2026, 6, 15), new DateOnly(2026, 6, 8));
+        page2.Select(w => w.OccurredOn).Should().Equal(new DateOnly(2026, 6, 1));
+        page1.Select(w => w.WorkoutLogId).Should().NotIntersectWith(page2.Select(w => w.WorkoutLogId));
+    }
+
+    [Theory]
+    [InlineData(CompletionStatus.Partial)]
+    [InlineData(CompletionStatus.Skipped)]
+    public async Task CreateAsync_NonDefaultCompletionStatus_RoundTrips(CompletionStatus status)
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var userId = await SeedUserAsync();
+        var log = NewLog(userId, new DateOnly(2026, 6, 9), status);
+
+        // Act
+        await CreateAsync(log, ct);
+        var actual = await GetByIdAsync(log.WorkoutLogId, ct);
+
+        // Assert — the non-zero enum values survive the integer column round-trip.
+        actual.Should().NotBeNull();
+        actual!.CompletionStatus.Should().Be(status);
+    }
+
+    [Fact]
+    public async Task GetByUser_KeysetCursor_SameDate_PagesViaIdTiebreakWithoutSkipsOrDuplicates()
+    {
+        // Arrange — three logs on the SAME day force the OccurredOn tie, so paging
+        // falls entirely to the WorkoutLogId tiebreak arm of the keyset predicate.
+        var ct = TestContext.Current.CancellationToken;
+        var userId = await SeedUserAsync();
+        var sameDate = new DateOnly(2026, 6, 10);
+        await CreateAsync(NewLog(userId, sameDate), ct);
+        await CreateAsync(NewLog(userId, sameDate), ct);
+        await CreateAsync(NewLog(userId, sameDate), ct);
+
+        // Act
+        var page1 = await GetByUserAsync(userId, cursor: null, limit: 2, ct);
+        var tail = page1[^1];
+        var cursor = new WorkoutLogCursor(tail.OccurredOn, tail.WorkoutLogId);
+        var page2 = await GetByUserAsync(userId, cursor, limit: 2, ct);
+
+        // Assert — clean partition: 2 + 1 distinct rows, no skips, no duplicates.
+        page1.Should().HaveCount(2);
+        page2.Should().HaveCount(1);
+        page1.Select(w => w.WorkoutLogId).Should().NotIntersectWith(page2.Select(w => w.WorkoutLogId));
+        page1.Concat(page2).Select(w => w.WorkoutLogId).Should().OnlyHaveUniqueItems().And.HaveCount(3);
+    }
+
+    private static WorkoutLog NewLog(
+        Guid userId, DateOnly occurredOn, CompletionStatus status = CompletionStatus.Complete)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new WorkoutLog
+        {
+            WorkoutLogId = Guid.NewGuid(),
+            UserId = userId,
+            TenantId = userId.ToString(),
+            OccurredOn = occurredOn,
+            Distance = Distance.FromMeters(5000.0),
+            Duration = Duration.FromMinutes(25.0),
+            CompletionStatus = status,
+            CreatedOn = now,
+            ModifiedOn = now,
+        };
+    }
+
+    private async Task CreateAsync(WorkoutLog log, CancellationToken ct)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IWorkoutLogRepository>();
+        await repo.CreateAsync(log, ct);
+    }
+
+    private async Task<WorkoutLog?> GetByIdAsync(Guid id, CancellationToken ct)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IWorkoutLogRepository>();
+        return await repo.GetByIdAsync(id, ct);
+    }
+
+    private async Task<IReadOnlyList<WorkoutLog>> GetByUserAsync(
+        Guid userId, WorkoutLogCursor? cursor, int limit, CancellationToken ct)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IWorkoutLogRepository>();
+        return await repo.GetByUserAsync(userId, cursor, limit, ct);
+    }
+
+    private async Task<IReadOnlyList<WorkoutLog>> GetByPlannedWorkoutAsync(
+        Guid sourcePlanId, int weekNumber, int dayOfWeek, CancellationToken ct)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IWorkoutLogRepository>();
+        return await repo.GetByPlannedWorkoutAsync(sourcePlanId, weekNumber, dayOfWeek, ct);
+    }
+
+    private async Task<Guid> SeedUserAsync()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var email = $"workoutlog-{Guid.NewGuid():N}@example.test";
+        var user = new ApplicationUser { Email = email, UserName = email };
+        var result = await users.CreateAsync(user, "Str0ngTestPassw0rd!");
+        result.Succeeded.Should().BeTrue(
+            because: $"seed must succeed — got [{string.Join(", ", result.Errors.Select(e => e.Code))}]");
+        return user.Id;
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Workouts/WorkoutLogValueConverterTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Workouts/WorkoutLogValueConverterTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Training.Models;
+using RunCoach.Api.Modules.Training.Workouts;
+
+namespace RunCoach.Api.Tests.Modules.Training.Workouts;
+
+/// <summary>
+/// Unit tests for the repository's first EF <c>ValueConverter</c>s (DEC-072).
+/// These exercise the converters directly through their model⇄provider
+/// delegates so a units mistake is caught without a database round-trip.
+/// </summary>
+public class WorkoutLogValueConverterTests
+{
+    [Fact]
+    public void DistanceConverter_RoundTrip_PreservesMeters()
+    {
+        // Arrange
+        var converter = new DistanceValueConverter();
+        var expected = Distance.FromMeters(5000.0);
+
+        // Act
+        var provider = (double)converter.ConvertToProvider(expected)!;
+        var actual = (Distance)converter.ConvertFromProvider(provider)!;
+
+        // Assert — stored as meters, round-trips with value semantics.
+        provider.Should().Be(5000.0);
+        actual.Meters.Should().Be(5000.0);
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void DurationConverter_RoundTrip_PreservesMinutesAsTicks()
+    {
+        // Arrange
+        var converter = new DurationValueConverter();
+        var expected = Duration.FromMinutes(25.0);
+
+        // Act
+        var provider = (long)converter.ConvertToProvider(expected)!;
+        var actual = (Duration)converter.ConvertFromProvider(provider)!;
+
+        // Assert — stored as ticks (NOT minutes), round-trips to 25 minutes.
+        provider.Should().Be(TimeSpan.FromMinutes(25.0).Ticks);
+        actual.TotalMinutes.Should().Be(25.0);
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void PaceConverter_RoundTrip_PreservesSecondsPerKm()
+    {
+        // Arrange
+        var converter = new PaceValueConverter();
+        var expected = Pace.FromSecondsPerKm(300.0);
+
+        // Act
+        var provider = (double)converter.ConvertToProvider(expected)!;
+        var actual = (Pace)converter.ConvertFromProvider(provider)!;
+
+        // Assert
+        provider.Should().Be(300.0);
+        actual.SecondsPerKm.Should().Be(300.0);
+    }
+}


### PR DESCRIPTION
## What & why

**PR2 of the slice-2b 8-PR strategy (Unit 2 — `WorkoutLog` persistence foundation).** Pure persistence: the EF Core entity, prescription snapshot, canonical metric keys, value converters, migration, and repository. **No endpoints, no LLM, no frontend** — those land in later PRs. Leaves `main` green with the entity unreferenced by any endpoint (fine per the PR strategy).

Implements spec `docs/specs/16-spec-slice-2b-workout-logging/` Unit 2; decisions **DEC-072** (metrics bag + canonical keys + first value converters) and **DEC-076** (server-authoritative prescription snapshot).

## What's included

- **`WorkoutLog`** EF entity (tenanted): `OccurredOn` + value-converted `Distance`/`Duration`, `CompletionStatus`, freeform `Notes` (no cap), an open `jsonb` `Metrics` bag, typed `jsonb` `Splits`, audit fields, and a nullable prescription snapshot.
- **`WorkoutPrescriptionSnapshot`** = **EF Core 10 optional complex type**, table-split to real columns (DEC-076): `SourcePlanId`/`WeekNumber`/`DayOfWeek` coordinate + frozen prescribed distance/duration/pace. Off-plan ⇒ `Prescription == null`. `SourcePlanId` is the ≥1 EF-required property an optional complex type needs to detect presence. `WorkoutType` is stored **by name** (`text`), not ordinal, so it survives enum reordering/insertion.
- **`WorkoutMetricKeys`** (`Modules/Training/Constants/`): single-sourced canonical keys — a `const` set + `WorkoutMetricKey` enum kept drift-free by a unit test (13 documented + 3 reserved keys, DEC-072).
- **First EF `ValueConverter`s** — `Distance`↔meters, `Duration`↔ticks, `Pace`↔sec/km — plus a new `Duration` value object (canonical ticks).
- **`WorkoutLogRepository`**: create, get-by-id, keyset `read-by-user` (newest-first by `OccurredOn` then id), and the `(SourcePlanId, WeekNumber, DayOfWeek)` coordinate query (naturally excludes off-plan rows).
- **Migration `AddWorkoutLog`** — `jsonb` columns, FK cascade to `AspNetUsers`, nullable table-split prescription columns, keyset index. Verified to apply to a real Postgres on the integration fixture.

## Testing (TDD)

- **Unit**: metric-key drift guard, `Duration`, and value-converter units-preservation tests.
- **Integration** (Testcontainers Postgres, migration applied on boot): min / rich / notes-only / off-plan / on-plan round-trips; the prescription value-object round-trip; keyset paging across a **date boundary** and a **same-date id tiebreak**; `CompletionStatus` non-default round-trip.
- **Full suite: 1169/1169 green.**

## Review

Ran a multi-agent adversarial review (EF-correctness, bugs, conventions/spec, tests, cross-file, type-design) with every finding blind-challenged. Applied 8 confirmed fixes: `WorkoutType` int→string persistence (data-integrity), dropped a data-coercion fallback in the splits converter, guarded `limit`, added `ILogger`/`[LoggerMessage]`, test-name convention, `CompletionStatus` + same-date keyset coverage, and a `CreateAsync`/Wolverine-handler doc warning.

## Follow-ups found (deferred to their first consumer, PR3+)

- A `WorkoutPrescriptionSnapshot` fast/slow pace-ordering construction guard — the construction site is PR3, which sources already-ordered plan paces.
- A read-only `Splits` surface — the whole EF entity is a conventionally-mutable POCO; revisit if a consumer needs structural immutability.

## Notes

- Backend-only; no controller/DTO touches the OpenAPI surface, so no codegen drift.
- The metric *labels/units* metadata lands with its Unit-5 consumer (PR5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workout logging system enables users to record completed runs with distance, duration, and completion status (complete/partial/skipped).
  * Comprehensive metrics tracking captures heart rate, pace, cadence, elevation, power, and recovery data.
  * Workout split recording allows detailed analysis of run segments.
  * Prescribed-versus-actual workout comparison lets users review how completed workouts align with training plan assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->