### PR TITLE
feat(slice-2b): workout-log history query endpoint with keyset paging

### DIFF
--- a/backend/openapi/swagger.json
+++ b/backend/openapi/swagger.json
@@ -868,6 +868,100 @@
           }
         ]
       }
+    },
+    "/api/v1/workouts/logs/query": {
+      "post": {
+        "tags": [
+          "WorkoutLogs"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryWorkoutLogsRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryWorkoutLogsRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryWorkoutLogsRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryWorkoutLogsResponseDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryWorkoutLogsResponseDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryWorkoutLogsResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": [ ],
+            "bearerAuth": [ ]
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -1638,6 +1732,40 @@
         },
         "additionalProperties": { }
       },
+      "QueryWorkoutLogsRequestDto": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "cursor": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueryWorkoutLogsResponseDto": {
+        "required": [
+          "logs"
+        ],
+        "type": "object",
+        "properties": {
+          "logs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkoutLogDto"
+            }
+          },
+          "nextCursor": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "RegeneratePlanRequestDto": {
         "required": [
           "idempotencyKey",
@@ -1863,6 +1991,54 @@
           "description": {
             "type": "string",
             "description": "Runner-supplied free-text description of constraints not captured by the day flags (e.g. 'no early mornings')."
+          }
+        },
+        "additionalProperties": false
+      },
+      "WorkoutLogDto": {
+        "required": [
+          "completionStatus",
+          "distanceMeters",
+          "durationSeconds",
+          "occurredOn",
+          "workoutLogId"
+        ],
+        "type": "object",
+        "properties": {
+          "workoutLogId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "occurredOn": {
+            "type": "string",
+            "format": "date"
+          },
+          "distanceMeters": {
+            "type": "number",
+            "format": "double"
+          },
+          "durationSeconds": {
+            "type": "number",
+            "format": "double"
+          },
+          "completionStatus": {
+            "$ref": "#/components/schemas/CompletionStatus"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "metrics": {
+            "type": "object",
+            "additionalProperties": { },
+            "nullable": true
+          },
+          "splits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkoutLogSplitDto"
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/IWorkoutLogService.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/IWorkoutLogService.cs
@@ -18,4 +18,15 @@ public interface IWorkoutLogService
     /// <exception cref="ArgumentException">A request value fails a domain invariant
     /// (e.g. a negative distance/duration or an invalid split).</exception>
     Task<Guid> CreateAsync(Guid userId, CreateWorkoutLogRequestDto request, CancellationToken ct);
+
+    /// <summary>
+    /// Returns one newest-first keyset page of <paramref name="userId"/>'s logs
+    /// (slice-2b Unit 4). <paramref name="cursor"/> is the prior page's tail (null
+    /// for the first page); <paramref name="requestedLimit"/> is clamped
+    /// server-side to a sane page-size bound. The response carries the DB-ordered,
+    /// DB-trimmed page plus the opaque <c>nextCursor</c> for the next (older) page,
+    /// or null when the page is the last one.
+    /// </summary>
+    Task<QueryWorkoutLogsResponseDto> QueryAsync(
+        Guid userId, WorkoutLogCursor? cursor, int? requestedLimit, CancellationToken ct);
 }

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/QueryWorkoutLogsRequestDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/QueryWorkoutLogsRequestDto.cs
@@ -1,0 +1,14 @@
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// Request body for <c>POST /api/v1/workouts/logs/query</c> (slice-2b Unit 4).
+/// Keyset paging only at MVP-0: an optional opaque <paramref name="Cursor"/> (a
+/// prior page's <c>nextCursor</c>; null/absent starts at the most recent log) and
+/// an optional <paramref name="Limit"/> page size (clamped server-side). Ordering
+/// is fixed newest-first (<c>OccurredOn</c> desc, id tiebreak). A filter block is
+/// intentionally deferred — the record grows additively when filter UI arrives, so
+/// adding it later is not a wire break.
+/// </summary>
+/// <param name="Limit">Requested page size; null applies the server default. Clamped to the server's [1, max] bound.</param>
+/// <param name="Cursor">Opaque keyset cursor from a prior page's <c>nextCursor</c>; null/empty starts at the newest log.</param>
+public sealed record QueryWorkoutLogsRequestDto(int? Limit, string? Cursor);

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/QueryWorkoutLogsResponseDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/QueryWorkoutLogsResponseDto.cs
@@ -1,0 +1,13 @@
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// Response for <c>POST /api/v1/workouts/logs/query</c>: one newest-first page of
+/// the runner's logs plus the opaque <paramref name="NextCursor"/> for the next
+/// (older) page. <paramref name="NextCursor"/> is null when the page is the last
+/// one — i.e. fewer rows than the requested page size were available.
+/// </summary>
+/// <param name="Logs">The page of logs, newest-first (<c>OccurredOn</c> desc, id tiebreak).</param>
+/// <param name="NextCursor">Opaque cursor to fetch the next older page, or null when there are no more.</param>
+public sealed record QueryWorkoutLogsResponseDto(
+    IReadOnlyList<WorkoutLogDto> Logs,
+    string? NextCursor);

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogCursorCodec.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogCursorCodec.cs
@@ -1,0 +1,72 @@
+using System.Globalization;
+using System.Text;
+
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// Encodes/decodes the keyset <see cref="WorkoutLogCursor"/> as an opaque base64
+/// token for the history-query wire contract (slice-2b Unit 4). The payload is the
+/// last page tail's <c>OccurredOn</c> (ISO <c>yyyy-MM-dd</c>) and
+/// <c>WorkoutLogId</c>, both load-bearing for the <c>OccurredOn DESC,
+/// WorkoutLogId DESC</c> keyset (the id breaks ties within a date), so a token
+/// that drops or corrupts either is rejected rather than silently mis-paging. The
+/// token is opaque: clients round-trip it verbatim and never parse it.
+/// </summary>
+public static class WorkoutLogCursorCodec
+{
+    private const char Separator = '|';
+    private const string DateFormat = "yyyy-MM-dd";
+
+    /// <summary>Encodes a cursor as an opaque base64 token.</summary>
+    public static string Encode(WorkoutLogCursor cursor)
+    {
+        var payload = string.Concat(
+            cursor.OccurredOn.ToString(DateFormat, CultureInfo.InvariantCulture),
+            Separator,
+            cursor.WorkoutLogId.ToString("D", CultureInfo.InvariantCulture));
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(payload));
+    }
+
+    /// <summary>
+    /// Attempts to decode an opaque token back into a <see cref="WorkoutLogCursor"/>.
+    /// Returns <see langword="false"/> for any malformed token — bad base64, the
+    /// wrong field shape, or an unparseable date/guid — so the caller can reject it
+    /// as a 400 rather than page from a corrupted anchor.
+    /// </summary>
+    public static bool TryDecode(string? token, out WorkoutLogCursor cursor)
+    {
+        cursor = default;
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(token);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        var payload = Encoding.UTF8.GetString(bytes);
+        var separatorIndex = payload.IndexOf(Separator, StringComparison.Ordinal);
+        if (separatorIndex <= 0 || separatorIndex == payload.Length - 1)
+        {
+            return false;
+        }
+
+        var datePart = payload[..separatorIndex];
+        var idPart = payload[(separatorIndex + 1)..];
+        if (!DateOnly.TryParseExact(datePart, DateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var occurredOn)
+            || !Guid.TryParseExact(idPart, "D", out var workoutLogId))
+        {
+            return false;
+        }
+
+        cursor = new WorkoutLogCursor(occurredOn, workoutLogId);
+        return true;
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogDto.cs
@@ -1,0 +1,21 @@
+using System.Text.Json;
+
+namespace RunCoach.Api.Modules.Training.Workouts;
+
+/// <summary>
+/// Read projection of a logged workout for the history surface (slice-2b Unit 4).
+/// Mirrors the actual-run fields the runner recorded: required core fields, the
+/// open optional-metrics bag (rehydrated from the entity's <c>jsonb</c> string),
+/// the freeform note, and the typed display-only splits. The server-authoritative
+/// prescription snapshot is intentionally not surfaced here at MVP-0 — it feeds
+/// Slice-3 deterministic adaptation server-side, not the raw history view.
+/// </summary>
+public sealed record WorkoutLogDto(
+    Guid WorkoutLogId,
+    DateOnly OccurredOn,
+    double DistanceMeters,
+    double DurationSeconds,
+    CompletionStatus CompletionStatus,
+    string? Notes,
+    IReadOnlyDictionary<string, JsonElement>? Metrics,
+    IReadOnlyList<WorkoutLogSplitDto>? Splits);

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogDto.cs
@@ -8,7 +8,7 @@ namespace RunCoach.Api.Modules.Training.Workouts;
 /// open optional-metrics bag (rehydrated from the entity's <c>jsonb</c> string),
 /// the freeform note, and the typed display-only splits. The server-authoritative
 /// prescription snapshot is intentionally not surfaced here at MVP-0 — it feeds
-/// Slice-3 deterministic adaptation server-side, not the raw history view.
+/// server-side deterministic adaptation, not the raw history view.
 /// </summary>
 public sealed record WorkoutLogDto(
     Guid WorkoutLogId,

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogService.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogService.cs
@@ -22,6 +22,12 @@ public sealed partial class WorkoutLogService(
     TimeProvider timeProvider,
     ILogger<WorkoutLogService> logger) : IWorkoutLogService
 {
+    /// <summary>Default page size applied when a query omits a limit.</summary>
+    private const int DefaultPageSize = 20;
+
+    /// <summary>Maximum page size; larger requested limits are clamped to this.</summary>
+    private const int MaxPageSize = 100;
+
     private readonly RunCoachDbContext _db = db;
     private readonly IWorkoutLogRepository _repository = repository;
     private readonly IDocumentStore _documentStore = documentStore;
@@ -59,6 +65,28 @@ public sealed partial class WorkoutLogService(
         return workoutLogId;
     }
 
+    /// <inheritdoc />
+    public async Task<QueryWorkoutLogsResponseDto> QueryAsync(
+        Guid userId, WorkoutLogCursor? cursor, int? requestedLimit, CancellationToken ct)
+    {
+        var limit = Math.Clamp(requestedLimit ?? DefaultPageSize, 1, MaxPageSize);
+
+        var logs = await _repository.GetByUserAsync(userId, cursor, limit, ct).ConfigureAwait(false);
+
+        // A full page means there may be more, so hand back the tail as the next
+        // cursor; a short or empty page is the last one. Detecting "more" by row
+        // count — rather than fetching limit+1 and trimming — keeps every returned
+        // row exactly as the DB ordered and trimmed it (no app-layer slicing), at
+        // the cost of one extra empty fetch when the total is an exact multiple of
+        // the page size.
+        var nextCursor = logs.Count == limit
+            ? WorkoutLogCursorCodec.Encode(new WorkoutLogCursor(logs[^1].OccurredOn, logs[^1].WorkoutLogId))
+            : null;
+
+        var dtos = logs.Select(MapToDto).ToList();
+        return new QueryWorkoutLogsResponseDto(dtos, nextCursor);
+    }
+
     private static string? SerializeMetrics(IReadOnlyDictionary<string, JsonElement>? metrics) =>
         metrics is { Count: > 0 } ? JsonSerializer.Serialize(metrics) : null;
 
@@ -66,6 +94,30 @@ public sealed partial class WorkoutLogService(
         splits is { Count: > 0 }
             ? splits
                 .Select(s => new WorkoutSplit(
+                    s.Index, s.DistanceMeters, s.DurationSeconds, s.PaceSecPerKm, s.AverageHeartRate))
+                .ToList()
+            : null;
+
+    private static WorkoutLogDto MapToDto(WorkoutLog log) =>
+        new(
+            WorkoutLogId: log.WorkoutLogId,
+            OccurredOn: log.OccurredOn,
+            DistanceMeters: log.Distance.Meters,
+            DurationSeconds: log.Duration.TotalSeconds,
+            CompletionStatus: log.CompletionStatus,
+            Notes: log.Notes,
+            Metrics: DeserializeMetrics(log.Metrics),
+            Splits: MapSplitsToDto(log.Splits));
+
+    private static Dictionary<string, JsonElement>? DeserializeMetrics(string? metrics) =>
+        string.IsNullOrEmpty(metrics)
+            ? null
+            : JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(metrics);
+
+    private static List<WorkoutLogSplitDto>? MapSplitsToDto(IReadOnlyList<WorkoutSplit>? splits) =>
+        splits is { Count: > 0 }
+            ? splits
+                .Select(s => new WorkoutLogSplitDto(
                     s.Index, s.DistanceMeters, s.DurationSeconds, s.PaceSecPerKm, s.AverageHeartRate))
                 .ToList()
             : null;

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogsController.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogsController.cs
@@ -8,9 +8,11 @@ using RunCoach.Api.Infrastructure;
 namespace RunCoach.Api.Modules.Training.Workouts;
 
 /// <summary>
-/// Slice-2b workout-logging endpoints. Every state-changing route is gated by
-/// both <see cref="AuthPolicies.CookieOrBearer"/> and
-/// <see cref="RequireAntiforgeryTokenAttribute"/> per the repo's DEC-055 contract.
+/// Slice-2b workout-logging endpoints. State-changing routes are gated by both
+/// <see cref="AuthPolicies.CookieOrBearer"/> and
+/// <see cref="RequireAntiforgeryTokenAttribute"/> per the repo's DEC-055 contract;
+/// the read-only history query requires authentication but no antiforgery token (a
+/// safe POST-for-query, DEC-055).
 /// </summary>
 [ApiController]
 [Route("api/v1/workouts/logs")]
@@ -22,6 +24,7 @@ public sealed partial class WorkoutLogsController(
     private const string MissingUserType = "https://runcoach.app/problems/missing-user-claim";
     private const string InvalidLogType = "https://runcoach.app/problems/invalid-workout-log";
     private const string InvalidIdempotencyKeyType = "https://runcoach.app/problems/invalid-idempotency-key";
+    private const string InvalidCursorType = "https://runcoach.app/problems/invalid-cursor";
 
     /// <summary>
     /// POST /api/v1/workouts/logs — persist a workout log with a
@@ -84,6 +87,55 @@ public sealed partial class WorkoutLogsController(
         }
     }
 
+    /// <summary>
+    /// POST /api/v1/workouts/logs/query — one newest-first keyset page of the
+    /// authenticated runner's logs (slice-2b Unit 4 / DEC-076 § C). A read, not a
+    /// mutation: authenticated but no antiforgery token (DEC-055). Sort, paging, and
+    /// the page-size limit all execute as a single SQL query; the response carries
+    /// an opaque <c>nextCursor</c> for the next (older) page, or null when last.
+    /// </summary>
+    /// <param name="request">The query body: optional page size and opaque cursor.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>200 with the page; 400 on a malformed cursor; 401 when unauthenticated.</returns>
+    [HttpPost("query")]
+    [ProducesResponseType(typeof(QueryWorkoutLogsResponseDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> QueryLogs(
+        [FromBody] QueryWorkoutLogsRequestDto request,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryGetUserId(out var userId))
+        {
+            LogQueryRejectedMissingUser(logger);
+            return MissingUserClaim();
+        }
+
+        WorkoutLogCursor? cursor = null;
+        if (!string.IsNullOrEmpty(request.Cursor))
+        {
+            if (!WorkoutLogCursorCodec.TryDecode(request.Cursor, out var decoded))
+            {
+                // A malformed cursor is client input — reject it at the boundary
+                // rather than paging from a corrupted anchor, mirroring the
+                // empty-idempotency-key guard on the create path.
+                LogQueryRejectedInvalidCursor(logger, userId);
+                return Problem(
+                    type: InvalidCursorType,
+                    title: "Invalid cursor",
+                    detail: "The supplied cursor is malformed; omit it to start from the most recent log.",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            cursor = decoded;
+        }
+
+        var page = await service.QueryAsync(userId, cursor, request.Limit, ct);
+        return Ok(page);
+    }
+
     [LoggerMessage(
         Level = LogLevel.Warning,
         Message = "Workout log create rejected: authenticated user id claim was missing or malformed.")]
@@ -99,6 +151,16 @@ public sealed partial class WorkoutLogsController(
         Message = "Workout log create rejected as invalid for user {UserId} with idempotency key {IdempotencyKey}.")]
     private static partial void LogCreateRejectedInvalid(
         ILogger logger, Guid userId, Guid idempotencyKey, Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Workout log query rejected: authenticated user id claim was missing or malformed.")]
+    private static partial void LogQueryRejectedMissingUser(ILogger logger);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Workout log query rejected for user {UserId}: the supplied cursor was malformed.")]
+    private static partial void LogQueryRejectedInvalidCursor(ILogger logger, Guid userId);
 
     private bool TryGetUserId(out Guid userId)
     {

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Workouts/WorkoutLogCursorCodecTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Workouts/WorkoutLogCursorCodecTests.cs
@@ -1,0 +1,85 @@
+using System.Text;
+using FluentAssertions;
+using RunCoach.Api.Modules.Training.Workouts;
+
+namespace RunCoach.Api.Tests.Modules.Training.Workouts;
+
+/// <summary>
+/// Unit tests for <see cref="WorkoutLogCursorCodec"/> — the opaque keyset-cursor
+/// token used by the history query endpoint (slice-2b Unit 4). Both the run date
+/// and the log id are load-bearing for the <c>OccurredOn DESC, WorkoutLogId DESC</c>
+/// keyset (the id breaks ties within a date), so a token that drops or corrupts
+/// either must be rejected rather than silently mis-page.
+/// </summary>
+public class WorkoutLogCursorCodecTests
+{
+    [Fact]
+    public void Encode_ThenDecode_RoundTripsBothComponents()
+    {
+        // Arrange
+        var expected = new WorkoutLogCursor(new DateOnly(2026, 6, 15), Guid.NewGuid());
+
+        // Act
+        var token = WorkoutLogCursorCodec.Encode(expected);
+        var decoded = WorkoutLogCursorCodec.TryDecode(token, out var actual);
+
+        // Assert
+        decoded.Should().BeTrue();
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Encode_ProducesANonEmptyOpaqueToken()
+    {
+        // Arrange
+        var cursor = new WorkoutLogCursor(new DateOnly(2026, 1, 2), Guid.NewGuid());
+
+        // Act
+        var token = WorkoutLogCursorCodec.Encode(cursor);
+
+        // Assert — opaque: not the bare id the client could hand-craft.
+        token.Should().NotBeNullOrWhiteSpace();
+        token.Should().NotContain(cursor.WorkoutLogId.ToString());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not base64 @@@")]
+    public void TryDecode_NullEmptyOrNonBase64_ReturnsFalse(string? token)
+    {
+        // Act
+        var decoded = WorkoutLogCursorCodec.TryDecode(token, out var cursor);
+
+        // Assert
+        decoded.Should().BeFalse();
+        cursor.Should().Be(default(WorkoutLogCursor));
+    }
+
+    [Fact]
+    public void TryDecode_ValidBase64ButMissingSeparator_ReturnsFalse()
+    {
+        // Arrange — well-formed base64 whose payload has no "date|id" shape.
+        var token = Convert.ToBase64String(Encoding.UTF8.GetBytes("2026-06-15"));
+
+        // Act
+        var decoded = WorkoutLogCursorCodec.TryDecode(token, out _);
+
+        // Assert
+        decoded.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryDecode_ValidBase64ButUnparseableDateAndGuid_ReturnsFalse()
+    {
+        // Arrange
+        var token = Convert.ToBase64String(Encoding.UTF8.GetBytes("not-a-date|not-a-guid"));
+
+        // Act
+        var decoded = WorkoutLogCursorCodec.TryDecode(token, out _);
+
+        // Assert
+        decoded.Should().BeFalse();
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Workouts/WorkoutLogServiceTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Workouts/WorkoutLogServiceTests.cs
@@ -1,0 +1,108 @@
+using Marten;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using RunCoach.Api.Modules.Training.Workouts;
+
+namespace RunCoach.Api.Tests.Modules.Training.Workouts;
+
+/// <summary>
+/// Unit tests for <see cref="WorkoutLogService.QueryAsync"/> page-size clamping
+/// (slice-2b Unit 4 / PR4). The clamp is load-bearing: its floor keeps a
+/// non-positive client limit from reaching the repository's
+/// <c>ThrowIfNegativeOrZero</c> guard (which would surface as an unhandled 500),
+/// and its ceiling is the only bound on the fetch size (the request DTO carries no
+/// range validation). Each test asserts the exact limit handed to the repository.
+/// </summary>
+public class WorkoutLogServiceTests
+{
+    private const int DefaultPageSize = 20;
+    private const int MaxPageSize = 100;
+
+    [Fact]
+    public async Task QueryAsync_NullLimit_AppliesDefaultPageSize()
+    {
+        // Arrange
+        var (service, repository) = CreateService();
+        var userId = Guid.NewGuid();
+        var ct = TestContext.Current.CancellationToken;
+
+        // Act
+        await service.QueryAsync(userId, cursor: null, requestedLimit: null, ct);
+
+        // Assert
+        await repository.Received(1).GetByUserAsync(
+            userId, Arg.Any<WorkoutLogCursor?>(), DefaultPageSize, Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public async Task QueryAsync_NonPositiveLimit_ClampsToOne(int requestedLimit)
+    {
+        // Arrange
+        var (service, repository) = CreateService();
+        var userId = Guid.NewGuid();
+        var ct = TestContext.Current.CancellationToken;
+
+        // Act
+        await service.QueryAsync(userId, cursor: null, requestedLimit, ct);
+
+        // Assert — clamped above the repo's ThrowIfNegativeOrZero guard.
+        await repository.Received(1).GetByUserAsync(
+            userId, Arg.Any<WorkoutLogCursor?>(), 1, Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(101)]
+    [InlineData(100_000)]
+    [InlineData(int.MaxValue)]
+    public async Task QueryAsync_LimitAboveMax_ClampsToMax(int requestedLimit)
+    {
+        // Arrange
+        var (service, repository) = CreateService();
+        var userId = Guid.NewGuid();
+        var ct = TestContext.Current.CancellationToken;
+
+        // Act
+        await service.QueryAsync(userId, cursor: null, requestedLimit, ct);
+
+        // Assert — the ceiling bounds the fetch the DTO does not.
+        await repository.Received(1).GetByUserAsync(
+            userId, Arg.Any<WorkoutLogCursor?>(), MaxPageSize, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryAsync_LimitWithinBounds_PassesThrough()
+    {
+        // Arrange
+        var (service, repository) = CreateService();
+        var userId = Guid.NewGuid();
+        var ct = TestContext.Current.CancellationToken;
+
+        // Act
+        await service.QueryAsync(userId, cursor: null, requestedLimit: 50, ct);
+
+        // Assert
+        await repository.Received(1).GetByUserAsync(
+            userId, Arg.Any<WorkoutLogCursor?>(), 50, Arg.Any<CancellationToken>());
+    }
+
+    private static (WorkoutLogService Service, IWorkoutLogRepository Repository) CreateService()
+    {
+        var repository = Substitute.For<IWorkoutLogRepository>();
+        repository
+            .GetByUserAsync(Arg.Any<Guid>(), Arg.Any<WorkoutLogCursor?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<WorkoutLog>>(new List<WorkoutLog>()));
+
+        // QueryAsync touches only the repository; the DbContext, Marten store, and
+        // TimeProvider serve CreateAsync's prescription resolution and are unused here.
+        var service = new WorkoutLogService(
+            db: null!,
+            repository: repository,
+            documentStore: Substitute.For<IDocumentStore>(),
+            timeProvider: TimeProvider.System,
+            logger: NullLogger<WorkoutLogService>.Instance);
+        return (service, repository);
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Workouts/WorkoutLogsControllerQueryIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Workouts/WorkoutLogsControllerQueryIntegrationTests.cs
@@ -20,8 +20,10 @@ namespace RunCoach.Api.Tests.Modules.Training.Workouts;
 /// Integration tests for <c>POST /api/v1/workouts/logs/query</c> (slice-2b Unit 4 /
 /// PR4), one per scenario in <c>history-query-endpoint.feature</c>. Drives the live
 /// HTTP + auth + DB-driven keyset query against the Testcontainers Postgres and
-/// asserts newest-first ordering, keyset paging across a page boundary, user
-/// scoping, and that the sort/limit execute in SQL (DEC-076 § C).
+/// asserts newest-first ordering, keyset paging across a page boundary, the
+/// exact-page-multiple cursor termination, the read projection of a rich log
+/// (notes/metrics/splits), user scoping, and that the sort/limit execute in SQL
+/// (DEC-076 § C).
 /// </summary>
 [Collection("Integration")]
 [Trait("Category", "Integration")]
@@ -86,6 +88,83 @@ public class WorkoutLogsControllerQueryIntegrationTests(RunCoachAppFactory facto
         returned.Select(l => l.WorkoutLogId).Should().OnlyHaveUniqueItems()
             .And.BeEquivalentTo(seededIds);
         returned.Select(l => l.OccurredOn).Should().BeInDescendingOrder();
+    }
+
+    [Fact]
+    public async Task Query_ExactPageMultiple_TerminatesWithEmptyTrailingPage()
+    {
+        // Arrange — four logs at limit 2: the total is an exact multiple of the page size,
+        // so the final full page cannot tell it is last without one more (empty) fetch.
+        var ct = TestContext.Current.CancellationToken;
+        var (client, userId) = await RegisterAndLoginAsync();
+        var seededIds = new List<Guid>();
+        foreach (var day in new[] { 1, 2, 3, 4 })
+        {
+            seededIds.Add(await SeedLogAsync(userId, new DateOnly(2026, 6, day), ct));
+        }
+
+        // Act — two full pages, then a terminal fetch on the second page's cursor.
+        var page1 = await QueryPageAsync(client, new QueryWorkoutLogsRequestDto(Limit: 2, Cursor: null), ct);
+        var page2 = await QueryPageAsync(client, new QueryWorkoutLogsRequestDto(Limit: 2, Cursor: page1.NextCursor), ct);
+        var page3 = await QueryPageAsync(client, new QueryWorkoutLogsRequestDto(Limit: 2, Cursor: page2.NextCursor), ct);
+
+        // Assert — the second full page still hands back a cursor (row count == limit); the
+        // terminal fetch returns zero rows and a null cursor.
+        page1.Logs.Should().HaveCount(2);
+        page2.Logs.Should().HaveCount(2);
+        page1.NextCursor.Should().NotBeNull();
+        page2.NextCursor.Should().NotBeNull(
+            because: "a full final page cannot know it is the last without one more fetch");
+        page3.Logs.Should().BeEmpty();
+        page3.NextCursor.Should().BeNull();
+
+        // Assert — the two full pages cover all four logs exactly once; the empty terminal
+        // page skips and duplicates nothing.
+        var returned = page1.Logs.Concat(page2.Logs).ToList();
+        returned.Select(l => l.WorkoutLogId).Should().OnlyHaveUniqueItems()
+            .And.BeEquivalentTo(seededIds);
+        returned.Select(l => l.OccurredOn).Should().BeInDescendingOrder();
+    }
+
+    [Fact]
+    public async Task Query_RichLog_EchoesNotesMetricsAndSplitsThroughTheReadProjection()
+    {
+        // Arrange — one log carrying every optional field: a freeform note, a metrics jsonb
+        // bag, and two typed splits. Exercises MapToDto / DeserializeMetrics / MapSplitsToDto,
+        // which the empty-seed scenarios never reach.
+        var ct = TestContext.Current.CancellationToken;
+        var (client, userId) = await RegisterAndLoginAsync();
+        const string notes = "Negative split, felt strong on the back half.";
+        var expectedSplits = new[]
+        {
+            new WorkoutLogSplitDto(1, 1000.0, 300.0, 300.0, 138),
+            new WorkoutLogSplitDto(2, 1000.0, 295.0, 295.0, 145),
+        };
+        var logId = await SeedRichLogAsync(
+            userId,
+            new DateOnly(2026, 6, 10),
+            notes,
+            """{"hrAvg":142,"rpe":7}""",
+            [
+                new WorkoutSplit(1, 1000.0, 300.0, 300.0, 138),
+                new WorkoutSplit(2, 1000.0, 295.0, 295.0, 145),
+            ],
+            ct);
+
+        // Act
+        var page = await QueryPageAsync(client, new QueryWorkoutLogsRequestDto(Limit: null, Cursor: null), ct);
+
+        // Assert — the read projection faithfully rehydrates every optional field.
+        var dto = page.Logs.Should().ContainSingle().Which;
+        dto.WorkoutLogId.Should().Be(logId);
+        dto.Notes.Should().Be(notes);
+
+        dto.Metrics.Should().NotBeNull();
+        dto.Metrics!["hrAvg"].GetInt32().Should().Be(142);
+        dto.Metrics["rpe"].GetInt32().Should().Be(7);
+
+        dto.Splits.Should().NotBeNull();
+        dto.Splits!.Should().Equal(expectedSplits);
     }
 
     [Fact]
@@ -298,6 +377,24 @@ public class WorkoutLogsControllerQueryIntegrationTests(RunCoachAppFactory facto
     private async Task<Guid> SeedLogAsync(Guid userId, DateOnly occurredOn, CancellationToken ct)
     {
         var log = NewLog(userId, occurredOn);
+        using var scope = Factory.Services.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<IWorkoutLogRepository>();
+        await repository.CreateAsync(log, ct);
+        return log.WorkoutLogId;
+    }
+
+    private async Task<Guid> SeedRichLogAsync(
+        Guid userId,
+        DateOnly occurredOn,
+        string notes,
+        string metricsJson,
+        IReadOnlyList<WorkoutSplit> splits,
+        CancellationToken ct)
+    {
+        var log = NewLog(userId, occurredOn);
+        log.Notes = notes;
+        log.Metrics = metricsJson;
+        log.Splits = [.. splits];
         using var scope = Factory.Services.CreateScope();
         var repository = scope.ServiceProvider.GetRequiredService<IWorkoutLogRepository>();
         await repository.CreateAsync(log, ct);

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Workouts/WorkoutLogsControllerQueryIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Workouts/WorkoutLogsControllerQueryIntegrationTests.cs
@@ -1,0 +1,327 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using RunCoach.Api.Infrastructure;
+using RunCoach.Api.Modules.Identity.Contracts;
+using RunCoach.Api.Modules.Identity.Entities;
+using RunCoach.Api.Modules.Training.Models;
+using RunCoach.Api.Modules.Training.Workouts;
+using RunCoach.Api.Tests.Infrastructure;
+
+namespace RunCoach.Api.Tests.Modules.Training.Workouts;
+
+/// <summary>
+/// Integration tests for <c>POST /api/v1/workouts/logs/query</c> (slice-2b Unit 4 /
+/// PR4), one per scenario in <c>history-query-endpoint.feature</c>. Drives the live
+/// HTTP + auth + DB-driven keyset query against the Testcontainers Postgres and
+/// asserts newest-first ordering, keyset paging across a page boundary, user
+/// scoping, and that the sort/limit execute in SQL (DEC-076 § C).
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public class WorkoutLogsControllerQueryIntegrationTests(RunCoachAppFactory factory)
+    : DbBackedIntegrationTestBase(factory)
+{
+    private const string StrongPassword = "Str0ngTestPassw0rd!";
+    private const string AntiforgeryCookieName = AuthCookieNames.Antiforgery;
+    private const string AntiforgeryRequestCookieName = AuthCookieNames.AntiforgeryRequest;
+    private const string AntiforgeryHeaderName = AuthCookieNames.AntiforgeryHeader;
+    private const string QueryLogPath = "/api/v1/workouts/logs/query";
+
+    private static readonly Uri BaseUri = new("https://localhost");
+
+    [Fact]
+    public async Task Query_NoCursor_ReturnsLogsNewestFirst()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var (client, userId) = await RegisterAndLoginAsync();
+        await SeedLogAsync(userId, new DateOnly(2026, 6, 1), ct);
+        await SeedLogAsync(userId, new DateOnly(2026, 6, 8), ct);
+        await SeedLogAsync(userId, new DateOnly(2026, 6, 15), ct);
+
+        // Act
+        var page = await QueryPageAsync(client, new QueryWorkoutLogsRequestDto(Limit: null, Cursor: null), ct);
+
+        // Assert
+        page.Logs.Should().HaveCount(3);
+        page.Logs.Select(l => l.OccurredOn).Should().ContainInOrder(
+            new DateOnly(2026, 6, 15), new DateOnly(2026, 6, 8), new DateOnly(2026, 6, 1));
+        page.NextCursor.Should().BeNull(because: "three logs is fewer than the default page size");
+    }
+
+    [Fact]
+    public async Task Query_KeysetPaging_CrossesPageBoundary_WithoutSkipsOrDuplicates()
+    {
+        // Arrange — five logs on distinct dates.
+        var ct = TestContext.Current.CancellationToken;
+        var (client, userId) = await RegisterAndLoginAsync();
+        var seededIds = new List<Guid>();
+        foreach (var day in new[] { 1, 2, 3, 4, 5 })
+        {
+            seededIds.Add(await SeedLogAsync(userId, new DateOnly(2026, 6, day), ct));
+        }
+
+        // Act — three pages of two, each using the prior page's cursor.
+        var page1 = await QueryPageAsync(client, new QueryWorkoutLogsRequestDto(Limit: 2, Cursor: null), ct);
+        var page2 = await QueryPageAsync(client, new QueryWorkoutLogsRequestDto(Limit: 2, Cursor: page1.NextCursor), ct);
+        var page3 = await QueryPageAsync(client, new QueryWorkoutLogsRequestDto(Limit: 2, Cursor: page2.NextCursor), ct);
+
+        // Assert — page sizes and cursor termination.
+        page1.Logs.Should().HaveCount(2);
+        page2.Logs.Should().HaveCount(2);
+        page3.Logs.Should().HaveCount(1);
+        page1.NextCursor.Should().NotBeNull();
+        page2.NextCursor.Should().NotBeNull();
+        page3.NextCursor.Should().BeNull(because: "the final short page exhausts the history");
+
+        // Assert — the three pages together cover all five logs exactly once, newest-first throughout.
+        var returned = page1.Logs.Concat(page2.Logs).Concat(page3.Logs).ToList();
+        returned.Select(l => l.WorkoutLogId).Should().OnlyHaveUniqueItems()
+            .And.BeEquivalentTo(seededIds);
+        returned.Select(l => l.OccurredOn).Should().BeInDescendingOrder();
+    }
+
+    [Fact]
+    public async Task Query_EmptyHistory_ReturnsNoLogsAndNullCursor()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var (client, _) = await RegisterAndLoginAsync();
+
+        // Act
+        var page = await QueryPageAsync(client, new QueryWorkoutLogsRequestDto(Limit: null, Cursor: null), ct);
+
+        // Assert
+        page.Logs.Should().BeEmpty();
+        page.NextCursor.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Query_ReturnsOnlyTheAuthenticatedRunnersOwnLogs()
+    {
+        // Arrange — runner A with two logs, runner B with three (overlapping dates).
+        var ct = TestContext.Current.CancellationToken;
+        var (clientA, userA) = await RegisterAndLoginAsync();
+        var (_, userB) = await RegisterAndLoginAsync();
+        var a1 = await SeedLogAsync(userA, new DateOnly(2026, 6, 1), ct);
+        var a2 = await SeedLogAsync(userA, new DateOnly(2026, 6, 2), ct);
+        await SeedLogAsync(userB, new DateOnly(2026, 6, 1), ct);
+        await SeedLogAsync(userB, new DateOnly(2026, 6, 2), ct);
+        await SeedLogAsync(userB, new DateOnly(2026, 6, 3), ct);
+
+        // Act
+        var page = await QueryPageAsync(clientA, new QueryWorkoutLogsRequestDto(Limit: null, Cursor: null), ct);
+
+        // Assert — only A's two logs, never B's.
+        page.Logs.Select(l => l.WorkoutLogId).Should().BeEquivalentTo(new[] { a1, a2 });
+    }
+
+    [Fact]
+    public async Task Query_OrderingAndLimit_ExecuteInSql_NotInTheApplicationLayer()
+    {
+        // Arrange — three logs; capture the SQL the repository the endpoint delegates to emits.
+        var ct = TestContext.Current.CancellationToken;
+        var userId = await SeedUserAsync();
+        await SeedLogAsync(userId, new DateOnly(2026, 6, 1), ct);
+        await SeedLogAsync(userId, new DateOnly(2026, 6, 8), ct);
+        await SeedLogAsync(userId, new DateOnly(2026, 6, 15), ct);
+
+        var capturedSql = new List<string>();
+        var options = new DbContextOptionsBuilder<RunCoachDbContext>()
+            .UseNpgsql(Factory.ConnectionString)
+            .LogTo(capturedSql.Add, new[] { RelationalEventId.CommandExecuted })
+            .Options;
+
+        // Act — the exact GetByUserAsync the query service calls, with a limit below the row count.
+        await using var db = new RunCoachDbContext(options);
+        var repository = new WorkoutLogRepository(db, NullLogger<WorkoutLogRepository>.Instance);
+        var page = await repository.GetByUserAsync(userId, cursor: null, limit: 2, ct);
+
+        // Assert — the DB returned only two rows, newest-first: it did the trimming and sorting.
+        page.Should().HaveCount(2);
+        page.Select(w => w.OccurredOn).Should().ContainInOrder(
+            new DateOnly(2026, 6, 15), new DateOnly(2026, 6, 8));
+
+        var selectSql = capturedSql.Should().Contain(
+            sql => sql.Contains("\"WorkoutLog\"", StringComparison.Ordinal)
+                && sql.Contains("ORDER BY", StringComparison.Ordinal)).Which;
+        selectSql.Should().Contain("\"OccurredOn\" DESC")
+            .And.Contain("\"WorkoutLogId\" DESC")
+            .And.Contain("LIMIT");
+    }
+
+    [Fact]
+    public async Task Query_MalformedCursor_Returns400()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var (client, _) = await RegisterAndLoginAsync();
+
+        // Act
+        using var response = await PostQueryAsync(
+            client, new QueryWorkoutLogsRequestDto(Limit: null, Cursor: "not-a-valid-cursor!!"), ct);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Query_Unauthenticated_Returns401()
+    {
+        // Arrange — a client that never registered or logged in.
+        var ct = TestContext.Current.CancellationToken;
+        var (client, _) = CreateCookieClient(Factory);
+
+        // Act
+        using var response = await PostQueryAsync(
+            client, new QueryWorkoutLogsRequestDto(Limit: null, Cursor: null), ct);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private static async Task<QueryWorkoutLogsResponseDto> QueryPageAsync(
+        HttpClient client, QueryWorkoutLogsRequestDto request, CancellationToken ct)
+    {
+        using var response = await PostQueryAsync(client, request, ct);
+        response.StatusCode.Should().Be(
+            HttpStatusCode.OK, because: $"query must succeed — got {(int)response.StatusCode}");
+        var body = await response.Content.ReadFromJsonAsync<QueryWorkoutLogsResponseDto>(cancellationToken: ct);
+        body.Should().NotBeNull();
+        return body!;
+    }
+
+    private static async Task<HttpResponseMessage> PostQueryAsync(
+        HttpClient client, QueryWorkoutLogsRequestDto dto, CancellationToken ct)
+    {
+        // A read: no antiforgery token (DEC-055). The auth cookie rides on the handler.
+        using var request = new HttpRequestMessage(HttpMethod.Post, QueryLogPath)
+        {
+            Content = JsonContent.Create(dto),
+        };
+        return await client.SendAsync(request, ct);
+    }
+
+    private static WorkoutLog NewLog(Guid userId, DateOnly occurredOn)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new WorkoutLog
+        {
+            WorkoutLogId = Guid.NewGuid(),
+            UserId = userId,
+            TenantId = userId.ToString(),
+            IdempotencyKey = Guid.NewGuid(),
+            OccurredOn = occurredOn,
+            Distance = Distance.FromMeters(5000.0),
+            Duration = Duration.FromMinutes(25.0),
+            CompletionStatus = CompletionStatus.Complete,
+            CreatedOn = now,
+            ModifiedOn = now,
+        };
+    }
+
+    private static (HttpClient Client, CookieContainer Container) CreateCookieClient(RunCoachAppFactory factory)
+    {
+        var container = new CookieContainer();
+        var client = factory.CreateDefaultClient(new CookieContainerHandler(container));
+        client.BaseAddress = BaseUri;
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        return (client, container);
+    }
+
+    private static async Task<Guid> RegisterAsync(
+        HttpClient client, CookieContainer container, string email, string password)
+    {
+        var token = await PrimeAntiforgeryAsync(client, container);
+        using var request = BuildRequest(HttpMethod.Post, "/api/v1/auth/register", token);
+        request.Content = JsonContent.Create(new RegisterRequestDto(email, password));
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(
+            HttpStatusCode.Created, because: $"register helper must succeed — got {(int)response.StatusCode}");
+        var body = await response.Content.ReadFromJsonAsync<AuthResponseDto>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        body.Should().NotBeNull();
+        return body!.UserId;
+    }
+
+    private static async Task LoginAsync(
+        HttpClient client, CookieContainer container, string email, string password)
+    {
+        var token = await PrimeAntiforgeryAsync(client, container);
+        using var request = BuildRequest(HttpMethod.Post, "/api/v1/auth/login", token);
+        request.Content = JsonContent.Create(new LoginRequestDto(email, password));
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(
+            HttpStatusCode.OK, because: $"login helper must succeed — got {(int)response.StatusCode}");
+    }
+
+    private static async Task<string> PrimeAntiforgeryAsync(HttpClient client, CookieContainer container)
+    {
+        using var response = await client.GetAsync("/api/v1/auth/xsrf", TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        var requestCookie = GetCookie(container, AntiforgeryRequestCookieName);
+        requestCookie.Should().NotBeNull("/xsrf must issue the SPA-readable request token cookie");
+        GetCookie(container, AntiforgeryCookieName).Should().NotBeNull(
+            "the framework antiforgery cookie must also be set");
+        return requestCookie!.Value;
+    }
+
+    private static HttpRequestMessage BuildRequest(HttpMethod method, string path, string antiforgeryToken)
+    {
+        var request = new HttpRequestMessage(method, path);
+        request.Headers.Add(AntiforgeryHeaderName, antiforgeryToken);
+        return request;
+    }
+
+    private static Cookie? GetCookie(CookieContainer container, string name)
+    {
+        foreach (Cookie cookie in container.GetCookies(BaseUri))
+        {
+            if (string.Equals(cookie.Name, name, StringComparison.Ordinal))
+            {
+                return cookie;
+            }
+        }
+
+        return null;
+    }
+
+    private static string GenerateEmail() => $"workoutlog-query-{Guid.NewGuid():N}@example.test";
+
+    private async Task<Guid> SeedLogAsync(Guid userId, DateOnly occurredOn, CancellationToken ct)
+    {
+        var log = NewLog(userId, occurredOn);
+        using var scope = Factory.Services.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<IWorkoutLogRepository>();
+        await repository.CreateAsync(log, ct);
+        return log.WorkoutLogId;
+    }
+
+    private async Task<Guid> SeedUserAsync()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var email = GenerateEmail();
+        var user = new ApplicationUser { Email = email, UserName = email };
+        var result = await users.CreateAsync(user, StrongPassword);
+        result.Succeeded.Should().BeTrue(
+            because: $"seed must succeed — got [{string.Join(", ", result.Errors.Select(e => e.Code))}]");
+        return user.Id;
+    }
+
+    private async Task<(HttpClient Client, Guid UserId)> RegisterAndLoginAsync()
+    {
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        var userId = await RegisterAsync(client, container, email, StrongPassword);
+        await LoginAsync(client, container, email, StrongPassword);
+        return (client, userId);
+    }
+}

--- a/frontend/src/app/api/generated/rtk/api.ts
+++ b/frontend/src/app/api/generated/rtk/api.ts
@@ -95,6 +95,16 @@ const injectedRtkApi = api.injectEndpoints({
         body: queryArg.createWorkoutLogRequestDto,
       }),
     }),
+    postApiV1WorkoutsLogsQuery: build.mutation<
+      PostApiV1WorkoutsLogsQueryApiResponse,
+      PostApiV1WorkoutsLogsQueryApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/v1/workouts/logs/query`,
+        method: 'POST',
+        body: queryArg.queryWorkoutLogsRequestDto,
+      }),
+    }),
   }),
   overrideExisting: false,
 })
@@ -136,6 +146,10 @@ export type PostApiV1PlanRegenerateApiArg = {
 export type PostApiV1WorkoutsLogsApiResponse = /** status 201 Created */ CreateWorkoutLogResponseDto
 export type PostApiV1WorkoutsLogsApiArg = {
   createWorkoutLogRequestDto: CreateWorkoutLogRequestDto
+}
+export type PostApiV1WorkoutsLogsQueryApiResponse = /** status 200 OK */ QueryWorkoutLogsResponseDto
+export type PostApiV1WorkoutsLogsQueryApiArg = {
+  queryWorkoutLogsRequestDto: QueryWorkoutLogsRequestDto
 }
 export type AuthResponseDto = {
   userId: string
@@ -447,6 +461,26 @@ export type CreateWorkoutLogRequestDto = {
   } | null
   splits?: WorkoutLogSplitDto[] | null
 }
+export type WorkoutLogDto = {
+  workoutLogId: string
+  occurredOn: string
+  distanceMeters: number
+  durationSeconds: number
+  completionStatus: CompletionStatus
+  notes?: string | null
+  metrics?: {
+    [key: string]: any
+  } | null
+  splits?: WorkoutLogSplitDto[] | null
+}
+export type QueryWorkoutLogsResponseDto = {
+  logs: WorkoutLogDto[]
+  nextCursor?: string | null
+}
+export type QueryWorkoutLogsRequestDto = {
+  limit?: number | null
+  cursor?: string | null
+}
 export const {
   useGetApiV1AuthXsrfQuery,
   usePostApiV1AuthRegisterMutation,
@@ -460,4 +494,5 @@ export const {
   useGetApiV1PlanCurrentQuery,
   usePostApiV1PlanRegenerateMutation,
   usePostApiV1WorkoutsLogsMutation,
+  usePostApiV1WorkoutsLogsQueryMutation,
 } = injectedRtkApi

--- a/frontend/src/app/api/generated/zod/workout-logs/workout-logs.ts
+++ b/frontend/src/app/api/generated/zod/workout-logs/workout-logs.ts
@@ -28,3 +28,34 @@ export const PostApiV1WorkoutsLogsBody = zod.strictObject({
 })
 
 export const PostApiV1WorkoutsLogsResponse = zod.void()
+
+export const PostApiV1WorkoutsLogsQueryBody = zod.strictObject({
+  limit: zod.number().nullish(),
+  cursor: zod.string().nullish(),
+})
+
+export const PostApiV1WorkoutsLogsQueryResponse = zod.strictObject({
+  logs: zod.array(
+    zod.strictObject({
+      workoutLogId: zod.uuid(),
+      occurredOn: zod.iso.date(),
+      distanceMeters: zod.number(),
+      durationSeconds: zod.number(),
+      completionStatus: zod.union([zod.literal(0), zod.literal(1), zod.literal(2)]),
+      notes: zod.string().nullish(),
+      metrics: zod.record(zod.string(), zod.unknown()).nullish(),
+      splits: zod
+        .array(
+          zod.strictObject({
+            index: zod.number(),
+            distanceMeters: zod.number(),
+            durationSeconds: zod.number(),
+            paceSecPerKm: zod.number(),
+            averageHeartRate: zod.number().nullish(),
+          }),
+        )
+        .nullish(),
+    }),
+  ),
+  nextCursor: zod.string().nullish(),
+})


### PR DESCRIPTION
> Re-opened for review. This is the same change as #149, which was auto-merged on green without review and then reverted (#150). **Left open — not auto-merged.**

## What

Slice 2b **PR4 / Unit 4** — the DB-driven workout-log history query endpoint (DEC-076 § C). Adds `POST /api/v1/workouts/logs/query`: a newest-first, keyset-paginated read where sort, paging, and the page-size limit all execute as a **single SQL query** (no app-layer sort/filter/page). The response carries an opaque cursor for the next (older) page.

Reuses the existing `WorkoutLogRepository.GetByUserAsync` keyset method (`OccurredOn DESC, WorkoutLogId DESC`, `LIMIT`, user-scoped, `AsNoTracking`) shipped in PR2 — verbatim.

## Changes

- **`WorkoutLogCursorCodec`** — opaque base64 `(OccurredOn, WorkoutLogId)` token; both components are load-bearing for the keyset tiebreak, so a token that drops/corrupts either is rejected (→ 400).
- **`WorkoutLogService.QueryAsync`** — clamps the page size to `[1, 100]` (default 20), builds the next cursor when a full page is returned, and maps `WorkoutLog` → `WorkoutLogDto`.
- **`WorkoutLogsController.QueryLogs`** — `[HttpPost("query")]`, auth required, **no antiforgery** (a read, DEC-055), user-scoped via the auth claim; malformed cursor → 400 `ProblemDetails`.
- **DTOs** — `QueryWorkoutLogsRequestDto` (`limit?`, `cursor?`), `QueryWorkoutLogsResponseDto` (`logs`, `nextCursor`), `WorkoutLogDto`.
- Regenerated `swagger.json` + RTK/Zod codegen (drift gate green).

## Scope decisions (intentional deviations from the 2b spec prose)

- `WorkoutLogDto` **omits the prescription snapshot** — it feeds Slice-3 adaptation server-side, not the raw MVP-0 history view.
- The request DTO **defers the "shaped-but-unused filter block"** — the record extends additively when filter UI lands, so adding it later is not a wire break.

## Tests (25)

- `WorkoutLogCursorCodecTests` (unit) — round-trip + malformed/empty/non-base64 rejection.
- `WorkoutLogServiceTests` (unit) — page-size clamp bounds (default, floor, ceiling, passthrough).
- `WorkoutLogsControllerQueryIntegrationTests` — the eight `history-query-endpoint.feature` scenarios: newest-first, keyset paging across a boundary (no skips/dupes), exact-page-multiple termination (the last full page hands back a cursor; the trailing fetch is empty), rich-log read projection (notes/metrics/splits round-trip through `MapToDto`), empty history, per-user isolation, executed-SQL pushdown (`ORDER BY … DESC … LIMIT` via a captured EF command), and 401; plus malformed-cursor → 400.

Local: full backend suite green + all 25 new tests green; frontend build + 383 tests green; OpenAPI codegen drift gate green.

## Review follow-up (deep-review on #151)

Addressed all four deep-review suggestions (commit `cac20a2`): added the rich-log read-projection test (medium) and the exact-page-multiple termination test (low), dropped the `Slice-3` forward reference from `WorkoutLogDto`'s XML doc (low), and reconciled the contested filter-block finding by amending the Unit 4 spec to record the deferral — the request DTO grows additively when filter UI lands, so deferring avoids dead public-API surface (low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workout log history query functionality enabling users to browse their past workout records.
  * Implemented cursor-based pagination for efficient browsing without retrieving all history at once.
  * Supports customizable page sizes with built-in limits to maintain performance.
  * Requires authentication to ensure users only access their own workout history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
