### PR TITLE
feat(slice-2b): inject recent logged workouts into the coaching context

### DIFF
--- a/backend/src/RunCoach.Api/Modules/Coaching/ContextAssembler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/ContextAssembler.cs
@@ -214,7 +214,7 @@ public sealed partial class ContextAssembler : IContextAssembler
 
         // Build section content for token replacement.
         var startSections = BuildStartSections(input);
-        var middleSections = BuildMiddleSections(input.TrainingHistory);
+        var middleSections = BuildMiddleSections(input.TrainingHistory, input.RecentLoggedWorkouts);
         var endSections = BuildEndSections(input.ConversationHistory, input.CurrentUserMessage);
 
         // Use the static system prompt from YAML (contains zero athlete data).
@@ -579,13 +579,15 @@ public sealed partial class ContextAssembler : IContextAssembler
     /// Builds the MIDDLE sections: training history.
     /// Variable content in the lower attention zone.
     /// </summary>
-    private List<PromptSection> BuildMiddleSections(ImmutableArray<WorkoutSummary> trainingHistory)
+    private List<PromptSection> BuildMiddleSections(
+        ImmutableArray<WorkoutSummary> trainingHistory,
+        ImmutableArray<LoggedWorkoutDetail> recentLogs)
     {
         var sections = new List<PromptSection>();
 
-        if (trainingHistory.Length > 0)
+        if (trainingHistory.Length > 0 || !recentLogs.IsDefaultOrEmpty)
         {
-            sections.Add(BuildTrainingHistorySection(trainingHistory, useLayer2Only: false));
+            sections.Add(BuildTrainingHistorySection(trainingHistory, recentLogs, useLayer2Only: false));
         }
 
         return sections;
@@ -636,11 +638,12 @@ public sealed partial class ContextAssembler : IContextAssembler
         var currentEnd = endSections;
 
         // Step 1: Reduce training history to Layer 2 only (weekly summaries).
-        if (input.TrainingHistory.Length > 0)
+        // Logged workouts stay as compact one-liners — they are not collapsed.
+        if (input.TrainingHistory.Length > 0 || !input.RecentLoggedWorkouts.IsDefaultOrEmpty)
         {
             currentMiddle =
             [
-                BuildTrainingHistorySection(input.TrainingHistory, useLayer2Only: true),
+                BuildTrainingHistorySection(input.TrainingHistory, input.RecentLoggedWorkouts, useLayer2Only: true),
             ];
         }
 
@@ -666,16 +669,17 @@ public sealed partial class ContextAssembler : IContextAssembler
 
         // Step 3: Remove relevant plan context (not used in POC 1, skip).
 
-        // Step 4: Reduce training history to most recent 2 weeks only.
-        if (input.TrainingHistory.Length > 0)
+        // Step 4: Reduce training history to most recent 2 weeks only. Logged
+        // workouts are a bounded recent window already, so they are retained.
+        if (input.TrainingHistory.Length > 0 || !input.RecentLoggedWorkouts.IsDefaultOrEmpty)
         {
             var twoWeeksAgo = DateOnly.FromDateTime(_timeProvider.GetUtcNow().DateTime).AddDays(-14);
             var recentHistory = input.TrainingHistory
                 .Where(w => w.Date >= twoWeeksAgo)
                 .ToImmutableArray();
 
-            currentMiddle = recentHistory.Length > 0
-                ? [BuildTrainingHistorySection(recentHistory, useLayer2Only: true)]
+            currentMiddle = recentHistory.Length > 0 || !input.RecentLoggedWorkouts.IsDefaultOrEmpty
+                ? [BuildTrainingHistorySection(recentHistory, input.RecentLoggedWorkouts, useLayer2Only: true)]
                 : [];
         }
 
@@ -861,48 +865,65 @@ public sealed partial class ContextAssembler : IContextAssembler
     /// </summary>
     private PromptSection BuildTrainingHistorySection(
         ImmutableArray<WorkoutSummary> history,
+        ImmutableArray<LoggedWorkoutDetail> recentLogs,
         bool useLayer2Only)
     {
-        if (history.Length == 0)
+        var hasLogs = !recentLogs.IsDefaultOrEmpty;
+        if (history.Length == 0 && !hasLogs)
         {
             return new PromptSection("training_history", string.Empty, 0);
         }
 
         var sb = new StringBuilder();
-        var sorted = history.OrderByDescending(w => w.Date).ToList();
 
-        if (useLayer2Only)
+        // Recent real logs render first as compact Layer-1 one-liners (newest
+        // first). They are never collapsed into weekly summaries — they are the
+        // high-value detail this block exists to inject (DEC-076).
+        if (hasLogs)
         {
-            // Layer 2: weekly summaries only.
-            var weeks = GroupByWeek(sorted).Take(MaxLayer2Weeks);
-            foreach (var week in weeks)
+            foreach (var log in recentLogs.OrderByDescending(l => l.OccurredOn))
             {
-                sb.AppendLine(FormatWeekSummary(week));
+                sb.AppendLine(RecentLogFormatter.FormatWorkoutDetail(log));
             }
         }
-        else
+
+        if (history.Length > 0)
         {
-            // Layer 1 for recent weeks, Layer 2 for older weeks.
-            var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().DateTime);
-            var layer1Cutoff = today.AddDays(-7 * MaxLayer1Weeks);
+            var sorted = history.OrderByDescending(w => w.Date).ToList();
 
-            var recentWorkouts = sorted.Where(w => w.Date >= layer1Cutoff).ToList();
-            var olderWorkouts = sorted.Where(w => w.Date < layer1Cutoff).ToList();
-
-            if (recentWorkouts.Count > 0)
+            if (useLayer2Only)
             {
-                foreach (var workout in recentWorkouts)
-                {
-                    sb.AppendLine(FormatWorkoutDetail(workout));
-                }
-            }
-
-            if (olderWorkouts.Count > 0)
-            {
-                var olderWeeks = GroupByWeek(olderWorkouts).Take(MaxLayer2Weeks);
-                foreach (var week in olderWeeks)
+                // Layer 2: weekly summaries only.
+                var weeks = GroupByWeek(sorted).Take(MaxLayer2Weeks);
+                foreach (var week in weeks)
                 {
                     sb.AppendLine(FormatWeekSummary(week));
+                }
+            }
+            else
+            {
+                // Layer 1 for recent weeks, Layer 2 for older weeks.
+                var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().DateTime);
+                var layer1Cutoff = today.AddDays(-7 * MaxLayer1Weeks);
+
+                var recentWorkouts = sorted.Where(w => w.Date >= layer1Cutoff).ToList();
+                var olderWorkouts = sorted.Where(w => w.Date < layer1Cutoff).ToList();
+
+                if (recentWorkouts.Count > 0)
+                {
+                    foreach (var workout in recentWorkouts)
+                    {
+                        sb.AppendLine(FormatWorkoutDetail(workout));
+                    }
+                }
+
+                if (olderWorkouts.Count > 0)
+                {
+                    var olderWeeks = GroupByWeek(olderWorkouts).Take(MaxLayer2Weeks);
+                    foreach (var week in olderWeeks)
+                    {
+                        sb.AppendLine(FormatWeekSummary(week));
+                    }
                 }
             }
         }

--- a/backend/src/RunCoach.Api/Modules/Coaching/ContextAssembler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/ContextAssembler.cs
@@ -50,6 +50,9 @@ namespace RunCoach.Api.Modules.Coaching;
 ///   - <c>UserPreferences.Constraints</c> (user_profile section)
 ///   - <c>RaceGoal.RaceName</c> (goal_state section)
 ///   - <c>WorkoutSummary.Notes</c> (training_history section)
+///   - <c>LoggedWorkoutDetail.Notes</c> (training_history section, via <see cref="RecentLogFormatter"/>)
+///   - free-text <c>LoggedWorkoutDetail.Metrics</c> values, e.g. weather/terrain
+///     (training_history section, via <see cref="RecentLogFormatter"/>)
 ///   - <c>ConversationTurn.UserMessage</c> (conversation_history section)
 ///   - <c>ContextAssemblerInput.CurrentUserMessage</c> (current_user_message section)
 ///
@@ -887,50 +890,64 @@ public sealed partial class ContextAssembler : IContextAssembler
             }
         }
 
-        if (history.Length > 0)
-        {
-            var sorted = history.OrderByDescending(w => w.Date).ToList();
-
-            if (useLayer2Only)
-            {
-                // Layer 2: weekly summaries only.
-                var weeks = GroupByWeek(sorted).Take(MaxLayer2Weeks);
-                foreach (var week in weeks)
-                {
-                    sb.AppendLine(FormatWeekSummary(week));
-                }
-            }
-            else
-            {
-                // Layer 1 for recent weeks, Layer 2 for older weeks.
-                var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().DateTime);
-                var layer1Cutoff = today.AddDays(-7 * MaxLayer1Weeks);
-
-                var recentWorkouts = sorted.Where(w => w.Date >= layer1Cutoff).ToList();
-                var olderWorkouts = sorted.Where(w => w.Date < layer1Cutoff).ToList();
-
-                if (recentWorkouts.Count > 0)
-                {
-                    foreach (var workout in recentWorkouts)
-                    {
-                        sb.AppendLine(FormatWorkoutDetail(workout));
-                    }
-                }
-
-                if (olderWorkouts.Count > 0)
-                {
-                    var olderWeeks = GroupByWeek(olderWorkouts).Take(MaxLayer2Weeks);
-                    foreach (var week in olderWeeks)
-                    {
-                        sb.AppendLine(FormatWeekSummary(week));
-                    }
-                }
-            }
-        }
+        AppendLegacyHistory(sb, history, useLayer2Only);
 
         var content = sb.ToString().TrimEnd();
 
         return new PromptSection("training_history", content, EstimateTokens(content));
+    }
+
+    /// <summary>
+    /// Appends the legacy <see cref="WorkoutSummary"/> history to <paramref name="sb"/>:
+    /// Layer-1 per-workout detail for recent weeks and Layer-2 weekly summaries for
+    /// older weeks, or Layer-2 summaries only when <paramref name="useLayer2Only"/> is
+    /// set. No-op when <paramref name="history"/> is empty. Recent logged workouts are
+    /// rendered separately by the caller and are never collapsed here.
+    /// </summary>
+    private void AppendLegacyHistory(
+        StringBuilder sb,
+        ImmutableArray<WorkoutSummary> history,
+        bool useLayer2Only)
+    {
+        if (history.Length == 0)
+        {
+            return;
+        }
+
+        var sorted = history.OrderByDescending(w => w.Date).ToList();
+
+        if (useLayer2Only)
+        {
+            // Layer 2: weekly summaries only.
+            var weeks = GroupByWeek(sorted).Take(MaxLayer2Weeks);
+            foreach (var week in weeks)
+            {
+                sb.AppendLine(FormatWeekSummary(week));
+            }
+
+            return;
+        }
+
+        // Layer 1 for recent weeks, Layer 2 for older weeks.
+        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().DateTime);
+        var layer1Cutoff = today.AddDays(-7 * MaxLayer1Weeks);
+
+        var recentWorkouts = sorted.Where(w => w.Date >= layer1Cutoff).ToList();
+        var olderWorkouts = sorted.Where(w => w.Date < layer1Cutoff).ToList();
+
+        foreach (var workout in recentWorkouts)
+        {
+            sb.AppendLine(FormatWorkoutDetail(workout));
+        }
+
+        if (olderWorkouts.Count > 0)
+        {
+            var olderWeeks = GroupByWeek(olderWorkouts).Take(MaxLayer2Weeks);
+            foreach (var week in olderWeeks)
+            {
+                sb.AppendLine(FormatWeekSummary(week));
+            }
+        }
     }
 
     private PromptSection BuildConversationHistorySection(ImmutableArray<ConversationTurn> turns)

--- a/backend/src/RunCoach.Api/Modules/Coaching/Models/ContextAssemblerInput.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Models/ContextAssemblerInput.cs
@@ -14,4 +14,16 @@ public sealed record ContextAssemblerInput(
     TrainingPaces TrainingPaces,
     ImmutableArray<WorkoutSummary> TrainingHistory,
     ImmutableArray<ConversationTurn> ConversationHistory,
-    string CurrentUserMessage);
+    string CurrentUserMessage)
+{
+    /// <summary>
+    /// Gets the recent real logged workouts (DEC-076 / slice-2b Unit 5),
+    /// rendered into the training-history block as compact Layer-1 one-liners
+    /// with inlined metrics + notes. Defaults to empty so existing callers
+    /// (test profiles supplying only <see cref="TrainingHistory"/>) produce
+    /// byte-identical prompts. A bounded recent window — the caller supplies
+    /// only the logs worth surfacing; they are never collapsed into weekly
+    /// summaries.
+    /// </summary>
+    public ImmutableArray<LoggedWorkoutDetail> RecentLoggedWorkouts { get; init; } = [];
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/RecentLogFormatter.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/RecentLogFormatter.cs
@@ -1,0 +1,136 @@
+using System.Globalization;
+using RunCoach.Api.Modules.Training.Constants;
+using RunCoach.Api.Modules.Training.Models;
+
+namespace RunCoach.Api.Modules.Coaching;
+
+/// <summary>
+/// Renders a recent logged workout (<see cref="LoggedWorkoutDetail"/>) as a
+/// compact, single-line Layer-1 entry for the coaching training-history block
+/// (DEC-076 / slice-2b brainstorm D). Shape:
+/// <c>date | type | dist km | dur min | pace/km | &lt;metrics&gt; | &lt;note&gt;</c>.
+/// Present metrics are inlined with labels/units from the shared
+/// <see cref="WorkoutMetricKeys.Metadata"/> source; effort signals (HR, RPE)
+/// render first and, when none are present, an explicit
+/// <see cref="NoEffortSignalsMarker"/> is emitted; peripheral and contextual
+/// metrics are silently omitted when absent. The note is collapsed to a single
+/// line so the entry never spans multiple lines (the assembler is a Layer-1
+/// compression engine — verbose multi-line blocks would fight the token
+/// budget's truncation cascade).
+/// </summary>
+internal static class RecentLogFormatter
+{
+    /// <summary>
+    /// Marker emitted when a logged workout records neither heart rate nor RPE
+    /// — the absence of effort signal is itself coaching signal (DEC-076).
+    /// </summary>
+    internal const string NoEffortSignalsMarker = "(no HR/RPE)";
+
+    private const string FieldSeparator = " | ";
+
+    /// <summary>
+    /// Renders a single logged workout as a compact one-line training-history
+    /// entry. The output never contains a line break.
+    /// </summary>
+    internal static string FormatWorkoutDetail(LoggedWorkoutDetail log)
+    {
+        ArgumentNullException.ThrowIfNull(log);
+
+        var fields = new List<string>
+        {
+            log.OccurredOn.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            log.WorkoutType,
+            string.Create(CultureInfo.InvariantCulture, $"{FormatKilometers(log.Distance)} km"),
+            string.Create(CultureInfo.InvariantCulture, $"{FormatMinutes(log.Duration)} min"),
+        };
+
+        var pace = FormatPace(log.Distance, log.Duration);
+        if (pace is not null)
+        {
+            fields.Add(pace);
+        }
+
+        // Metrics segment is always present — at minimum the "(no HR/RPE)" marker.
+        fields.Add(FormatMetrics(log.Metrics));
+
+        if (!string.IsNullOrWhiteSpace(log.Notes))
+        {
+            fields.Add(ToSingleLine(log.Notes));
+        }
+
+        return string.Join(FieldSeparator, fields);
+    }
+
+    private static string FormatKilometers(Distance distance) =>
+        distance.Kilometers.ToString("0.##", CultureInfo.InvariantCulture);
+
+    private static string FormatMinutes(Duration duration) =>
+        ((int)Math.Round(duration.TotalMinutes, MidpointRounding.AwayFromZero))
+            .ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Renders the pace as <c>m:ss/km</c> (or <c>h:mm:ss/km</c>), or null when
+    /// distance/duration cannot yield a meaningful pace (e.g. a skipped run).
+    /// </summary>
+    private static string? FormatPace(Distance distance, Duration duration)
+    {
+        if (distance.Kilometers <= 0 || duration.TotalSeconds <= 0)
+        {
+            return null;
+        }
+
+        var ts = Pace.FromSecondsPerKm(duration.TotalSeconds / distance.Kilometers).ToTimeSpan();
+        var clock = ts.TotalHours >= 1
+            ? ts.ToString(@"h\:mm\:ss", CultureInfo.InvariantCulture)
+            : ts.ToString(@"m\:ss", CultureInfo.InvariantCulture);
+        return string.Create(CultureInfo.InvariantCulture, $"{clock}/km");
+    }
+
+    /// <summary>
+    /// Builds the comma-joined metrics segment: present metrics in
+    /// <see cref="WorkoutMetricKeys.DisplayOrder"/>, effort signals first, with
+    /// the <see cref="NoEffortSignalsMarker"/> substituted when no effort signal
+    /// is present. Unknown-to-metadata keys are skipped.
+    /// </summary>
+    private static string FormatMetrics(IReadOnlyDictionary<string, string> metrics)
+    {
+        var effort = new List<string>();
+        var other = new List<string>();
+
+        foreach (var key in WorkoutMetricKeys.DisplayOrder)
+        {
+            if (!metrics.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            var meta = WorkoutMetricKeys.Metadata[key];
+            var safeValue = ToSingleLine(value);
+            var rendered = meta.Unit.Length == 0
+                ? string.Create(CultureInfo.InvariantCulture, $"{meta.Label} {safeValue}")
+                : string.Create(CultureInfo.InvariantCulture, $"{meta.Label} {safeValue} {meta.Unit}");
+
+            if (meta.Category == MetricCategory.Effort)
+            {
+                effort.Add(rendered);
+            }
+            else
+            {
+                other.Add(rendered);
+            }
+        }
+
+        if (effort.Count == 0)
+        {
+            effort.Add(NoEffortSignalsMarker);
+        }
+
+        return string.Join(", ", effort.Concat(other));
+    }
+
+    /// <summary>
+    /// Collapses any line breaks to single spaces so a freeform note (or
+    /// free-text metric) cannot split the one-liner across multiple lines.
+    /// </summary>
+    private static string ToSingleLine(string text) => text.ReplaceLineEndings(" ").Trim();
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/RecentLogFormatter.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/RecentLogFormatter.cs
@@ -39,7 +39,7 @@ internal static class RecentLogFormatter
         var fields = new List<string>
         {
             log.OccurredOn.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-            log.WorkoutType,
+            ToSingleLine(log.WorkoutType),
             string.Create(CultureInfo.InvariantCulture, $"{FormatKilometers(log.Distance)} km"),
             string.Create(CultureInfo.InvariantCulture, $"{FormatMinutes(log.Duration)} min"),
         };

--- a/backend/src/RunCoach.Api/Modules/Training/Constants/MetricCategory.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Constants/MetricCategory.cs
@@ -1,0 +1,30 @@
+namespace RunCoach.Api.Modules.Training.Constants;
+
+/// <summary>
+/// Coaching-relevance category for a workout metric, used by the LLM-context
+/// formatter to decide rendering policy (DEC-076 / slice-2b brainstorm D):
+/// effort signals drive an explicit absence marker when missing, peripheral
+/// and contextual metrics are silently omitted when absent.
+/// </summary>
+public enum MetricCategory
+{
+    /// <summary>
+    /// Effort / intensity signals (heart rate, RPE). Their <em>absence</em> is
+    /// itself coaching signal, so the formatter emits an explicit
+    /// "(no HR/RPE)" marker when none are present.
+    /// </summary>
+    Effort = 0,
+
+    /// <summary>
+    /// Biomechanical detail (cadence, power, elevation gain, running dynamics).
+    /// Rendered when present; silently omitted when absent (their absence is
+    /// not coaching signal).
+    /// </summary>
+    Peripheral = 1,
+
+    /// <summary>
+    /// Surrounding context (calories, HRV, sleep / recovery scores, weather,
+    /// terrain). Rendered when present; silently omitted when absent.
+    /// </summary>
+    Contextual = 2,
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Constants/WorkoutMetricKeys.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Constants/WorkoutMetricKeys.cs
@@ -1,4 +1,5 @@
 using System.Collections.Frozen;
+using System.Collections.Immutable;
 
 namespace RunCoach.Api.Modules.Training.Constants;
 
@@ -75,6 +76,49 @@ public static class WorkoutMetricKeys
         Cadence, ElevationGain, Power, Weather, Terrain, Splits,
         VerticalOscillation, GroundContactTime, StrideLength,
     }.ToFrozenSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Per-metric display metadata (label + compact-display unit + coaching
+    /// category) for the scalar metrics carried in the open bag. The single
+    /// source the LLM-context formatter (<c>RecentLogFormatter</c>) and the
+    /// frontend metric-meta map read, so prompt and UI labels cannot drift
+    /// (DEC-072 / DEC-076). Keyed by wire key. Excludes <see cref="Splits"/>,
+    /// which is persisted in its own typed column rather than as a scalar bag
+    /// value. Kept drift-free against <see cref="All"/> by
+    /// <c>WorkoutMetricMetadataTests</c>.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, WorkoutMetricMetadata> Metadata =
+        new Dictionary<string, WorkoutMetricMetadata>(StringComparer.Ordinal)
+        {
+            [HrAvg] = new("HR", string.Empty, MetricCategory.Effort),
+            [HrMax] = new("HR max", string.Empty, MetricCategory.Effort),
+            [Rpe] = new("RPE", string.Empty, MetricCategory.Effort),
+            [Cadence] = new("cadence", "spm", MetricCategory.Peripheral),
+            [Power] = new("power", "W", MetricCategory.Peripheral),
+            [ElevationGain] = new("elev gain", "m", MetricCategory.Peripheral),
+            [VerticalOscillation] = new("vert osc", "cm", MetricCategory.Peripheral),
+            [GroundContactTime] = new("GCT", "ms", MetricCategory.Peripheral),
+            [StrideLength] = new("stride", "m", MetricCategory.Peripheral),
+            [Calories] = new("calories", "kcal", MetricCategory.Contextual),
+            [Hrv] = new("HRV", "ms", MetricCategory.Contextual),
+            [SleepScore] = new("sleep", string.Empty, MetricCategory.Contextual),
+            [RecoveryScore] = new("recovery", string.Empty, MetricCategory.Contextual),
+            [Weather] = new("weather", string.Empty, MetricCategory.Contextual),
+            [Terrain] = new("terrain", string.Empty, MetricCategory.Contextual),
+        }.ToFrozenDictionary(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The fixed order in which present scalar metrics render inside a compact
+    /// coaching one-liner: effort signals (HR, RPE) first, then peripheral,
+    /// then contextual. Deterministic so assembled prompts and tests are
+    /// stable across runs. Contains exactly the keys of <see cref="Metadata"/>.
+    /// </summary>
+    public static readonly ImmutableArray<string> DisplayOrder =
+    [
+        HrAvg, HrMax, Rpe,
+        Cadence, Power, ElevationGain, VerticalOscillation, GroundContactTime, StrideLength,
+        Calories, Hrv, SleepScore, RecoveryScore, Weather, Terrain,
+    ];
 
     /// <summary>
     /// Derives the wire key for a <see cref="WorkoutMetricKey"/> by lower-casing

--- a/backend/src/RunCoach.Api/Modules/Training/Constants/WorkoutMetricMetadata.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Constants/WorkoutMetricMetadata.cs
@@ -1,0 +1,19 @@
+namespace RunCoach.Api.Modules.Training.Constants;
+
+/// <summary>
+/// Display metadata for a single scalar workout metric: the human label and
+/// compact-display unit used when the metric is inlined into a coaching
+/// one-liner, plus its <see cref="MetricCategory"/>. Single-sourced on
+/// <see cref="WorkoutMetricKeys.Metadata"/> so the LLM-context formatter and
+/// the frontend metric-meta map render identical labels and cannot drift
+/// (DEC-072 / DEC-076).
+/// </summary>
+/// <param name="Label">
+/// The human label printed before the value (e.g. <c>"HR"</c>, <c>"cadence"</c>).
+/// </param>
+/// <param name="Unit">
+/// The compact-display unit printed after the value (e.g. <c>"spm"</c>,
+/// <c>"W"</c>), or the empty string when no unit is shown (HR, RPE, scores).
+/// </param>
+/// <param name="Category">The coaching-relevance category.</param>
+public sealed record WorkoutMetricMetadata(string Label, string Unit, MetricCategory Category);

--- a/backend/src/RunCoach.Api/Modules/Training/Models/LoggedWorkoutDetail.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Models/LoggedWorkoutDetail.cs
@@ -1,0 +1,32 @@
+namespace RunCoach.Api.Modules.Training.Models;
+
+/// <summary>
+/// A recent logged workout in the shape the coaching <c>ContextAssembler</c>
+/// needs to render a compact Layer-1 one-liner (DEC-076 / slice-2b brainstorm
+/// D). Distinct from the test-profile <see cref="WorkoutSummary"/>: it carries
+/// the open metrics bag and freeform note from a real <c>WorkoutLog</c>, and
+/// its rendering inlines present metrics with an explicit "(no HR/RPE)" absence
+/// marker. Decoupled from the EF entity — the live mapping (entity → this view)
+/// lands with the Slice 3/4 consumer that wires recent logs into the prompt.
+/// </summary>
+/// <param name="OccurredOn">The local date the run took place.</param>
+/// <param name="WorkoutType">
+/// The workout type label shown in the one-liner (e.g. "Easy", "Tempo"); a
+/// generic label such as "Run" for off-plan logs with no prescribed type.
+/// </param>
+/// <param name="Distance">The distance covered.</param>
+/// <param name="Duration">The elapsed running duration.</param>
+/// <param name="Metrics">
+/// Present metrics as canonical wire key → display value (e.g.
+/// <c>{ "hrAvg": "148", "rpe": "7" }</c>). Only keys with
+/// <see cref="Training.Constants.WorkoutMetricKeys.Metadata"/> render; absent
+/// effort signals (HR/RPE) drive the "(no HR/RPE)" marker.
+/// </param>
+/// <param name="Notes">Freeform "what happened" note, or null/blank when none.</param>
+public sealed record LoggedWorkoutDetail(
+    DateOnly OccurredOn,
+    string WorkoutType,
+    Distance Distance,
+    Duration Duration,
+    IReadOnlyDictionary<string, string> Metrics,
+    string? Notes);

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ContextAssemblerTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ContextAssemblerTests.cs
@@ -1622,6 +1622,81 @@ public class ContextAssemblerTests
 
         // Layer-2 truncation behaviour preserved: legacy history collapsed to a weekly summary.
         history.Content.Should().Contain("Week of", because: "the overflow cascade still collapses legacy history");
+
+        // The never-reduce-logs trade-off must not silently blow the budget: even
+        // with all eight logged workouts retained at full Layer-1 detail, the
+        // cascade still brings the assembled prompt within TotalTokenBudget.
+        actualPrompt.EstimatedTokenCount.Should().BeLessThanOrEqualTo(
+            TokenBudget,
+            because: "retaining all logged workouts must not push the assembled prompt over budget");
+    }
+
+    [Fact]
+    public async Task AssembleAsync_MultipleLoggedWorkouts_RenderNewestFirst()
+    {
+        // Arrange — two logs with distinct dates, deliberately supplied oldest-first
+        // so a dropped/flipped sort would surface. Ordering depends only on
+        // OccurredOn, so real time in the SUT is irrelevant here.
+        var older = new LoggedWorkoutDetail(
+            new DateOnly(2026, 5, 20),
+            "Easy",
+            Distance.FromKilometers(6),
+            Duration.FromMinutes(36),
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            "OLDERLOG steady");
+        var newer = new LoggedWorkoutDetail(
+            new DateOnly(2026, 6, 1),
+            "Tempo",
+            Distance.FromKilometers(8),
+            Duration.FromMinutes(40),
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            "NEWERLOG controlled");
+        var input = BuildLeeInput() with { RecentLoggedWorkouts = [older, newer] };
+
+        // Act
+        var actualPrompt = await _sut.AssembleAsync(input, TestContext.Current.CancellationToken);
+
+        // Assert — the newest workout's marker precedes the oldest in the rendered block.
+        var history = actualPrompt.MiddleSections.First(s => s.Key == "training_history");
+        var newerIndex = history.Content.IndexOf("NEWERLOG", StringComparison.Ordinal);
+        var olderIndex = history.Content.IndexOf("OLDERLOG", StringComparison.Ordinal);
+        newerIndex.Should().BeGreaterThanOrEqualTo(0, because: "the newest logged workout must render");
+        olderIndex.Should().BeGreaterThan(
+            newerIndex,
+            because: "logged workouts render newest-first (OrderByDescending OccurredOn)");
+    }
+
+    [Fact]
+    public async Task AssembleAsync_LoggedWorkoutWithLegacyHistory_RendersBothInLayer1()
+    {
+        // Arrange — pin time so the legacy summary lands in the Layer-1 (per-workout)
+        // window and no overflow cascade triggers, exercising the happy path where
+        // logged workouts and legacy WorkoutSummary history co-exist.
+        var fakeNow = new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        var fakeTime = new FakeTimeProvider(fakeNow);
+        var store = CreateMockPromptStore();
+        var sut = new ContextAssembler(store, fakeTime, NullLogger<ContextAssembler>.Instance);
+
+        var legacy = ImmutableArray.Create(
+            new WorkoutSummary(new DateOnly(2026, 5, 30), "Fartlek", 9m, 47, TimeSpan.FromMinutes(5.1), null));
+        var log = new LoggedWorkoutDetail(
+            new DateOnly(2026, 5, 31),
+            "Tempo",
+            Distance.FromKilometers(8),
+            Duration.FromMinutes(40),
+            new Dictionary<string, string>(StringComparer.Ordinal) { [WorkoutMetricKeys.Rpe] = "7" },
+            "LOGGEDTEMPO controlled");
+        var input = BuildLeeInput() with { TrainingHistory = legacy, RecentLoggedWorkouts = [log] };
+
+        // Act
+        var actualPrompt = await sut.AssembleAsync(input, TestContext.Current.CancellationToken);
+
+        // Assert — the log augments rather than replaces legacy history: both appear.
+        var history = actualPrompt.MiddleSections.First(s => s.Key == "training_history");
+        history.Content.Should().Contain("LOGGEDTEMPO", because: "the logged workout renders");
+        history.Content.Should().Contain(
+            "Fartlek",
+            because: "legacy WorkoutSummary history still renders alongside logged workouts in the Layer-1 path");
     }
 
     // ================================================================

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ContextAssemblerTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ContextAssemblerTests.cs
@@ -7,6 +7,7 @@ using NSubstitute;
 using RunCoach.Api.Modules.Coaching;
 using RunCoach.Api.Modules.Coaching.Models;
 using RunCoach.Api.Modules.Coaching.Prompts;
+using RunCoach.Api.Modules.Training.Constants;
 using RunCoach.Api.Modules.Training.Models;
 using RunCoach.Api.Tests.Modules.Training.Profiles;
 
@@ -1522,6 +1523,105 @@ public class ContextAssemblerTests
         // Assert
         await act.Should().ThrowAsync<FileNotFoundException>()
             .WithMessage("*coaching-system*");
+    }
+
+    // ================================================================
+    // Recent logged-workout injection (slice-2b Unit 5 / DEC-076)
+    // ================================================================
+    [Fact]
+    public async Task AssembleAsync_WithRecentLoggedWorkout_RendersNoteAndMetricsInTrainingHistory()
+    {
+        // Arrange — a profile plus one real logged workout carrying a note + metrics.
+        const string loggedNote = "tempo felt controlled, slight headwind";
+        var log = new LoggedWorkoutDetail(
+            new DateOnly(2026, 6, 1),
+            "Tempo",
+            Distance.FromKilometers(8),
+            Duration.FromMinutes(40),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [WorkoutMetricKeys.HrAvg] = "152",
+                [WorkoutMetricKeys.Rpe] = "7",
+            },
+            loggedNote);
+        var input = BuildLeeInput() with { RecentLoggedWorkouts = [log] };
+
+        // Act
+        var actualPrompt = await _sut.AssembleAsync(input, TestContext.Current.CancellationToken);
+
+        // Assert — the logged workout's note + metric values reach the training-history block.
+        var history = actualPrompt.MiddleSections.First(s => s.Key == "training_history");
+        history.Content.Should().Contain(loggedNote);
+        history.Content.Should().Contain("HR 152");
+        history.Content.Should().Contain("RPE 7");
+    }
+
+    [Fact]
+    public async Task AssembleAsync_RecentLoggedWorkoutWithoutEffortSignals_EmitsAbsenceMarker()
+    {
+        // Arrange — a bare log (distance + duration only) surfaces the "(no HR/RPE)" signal.
+        var log = new LoggedWorkoutDetail(
+            new DateOnly(2026, 6, 1),
+            "Easy",
+            Distance.FromKilometers(6),
+            Duration.FromMinutes(36),
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            Notes: null);
+        var input = BuildLeeInput() with { RecentLoggedWorkouts = [log] };
+
+        // Act
+        var actualPrompt = await _sut.AssembleAsync(input, TestContext.Current.CancellationToken);
+
+        // Assert
+        var history = actualPrompt.MiddleSections.First(s => s.Key == "training_history");
+        history.Content.Should().Contain(RecentLogFormatter.NoEffortSignalsMarker);
+    }
+
+    [Fact]
+    public async Task AssembleAsync_ManyLoggedWorkoutsOverBudget_RendersOneLinersAndPreservesCascade()
+    {
+        // Arrange — pin time so the legacy Layer-1/Layer-2 split is deterministic.
+        // A huge conversation forces the overflow cascade; legacy history must
+        // still collapse to weekly summaries (Layer-2), while each logged workout
+        // stays a single compact line (never a multi-line block).
+        var fakeNow = new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        var fakeTime = new FakeTimeProvider(fakeNow);
+        var store = CreateMockPromptStore();
+        var sut = new ContextAssembler(store, fakeTime, NullLogger<ContextAssembler>.Instance);
+
+        // Legacy history within the Layer-1 window (collapses to "Week of …" under pressure).
+        var legacy = ImmutableArray.Create(
+            new WorkoutSummary(new DateOnly(2026, 5, 30), "Tempo", 10m, 48, TimeSpan.FromMinutes(4.8), null),
+            new WorkoutSummary(new DateOnly(2026, 5, 28), "Easy", 8m, 44, TimeSpan.FromMinutes(5.5), null));
+
+        var logs = Enumerable.Range(0, 8)
+            .Select(i => new LoggedWorkoutDetail(
+                new DateOnly(2026, 5, 30).AddDays(-i),
+                "Easy",
+                Distance.FromKilometers(8),
+                Duration.FromMinutes(44),
+                new Dictionary<string, string>(StringComparer.Ordinal) { [WorkoutMetricKeys.Rpe] = "5" },
+                $"LOGMARKER{i} steady aerobic effort, nothing notable"))
+            .ToImmutableArray();
+
+        var input = BuildOverflowStep4Input(legacy) with { RecentLoggedWorkouts = logs };
+
+        // Act
+        var actualPrompt = await sut.AssembleAsync(input, TestContext.Current.CancellationToken);
+
+        // Assert
+        var history = actualPrompt.MiddleSections.First(s => s.Key == "training_history");
+        var lines = history.Content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        // No multi-line per-workout blocks: each logged workout sits on exactly one line.
+        foreach (var i in Enumerable.Range(0, 8))
+        {
+            lines.Count(l => l.Contains($"LOGMARKER{i}", StringComparison.Ordinal))
+                .Should().Be(1, because: "each logged workout must render as a single compact line");
+        }
+
+        // Layer-2 truncation behaviour preserved: legacy history collapsed to a weekly summary.
+        history.Content.Should().Contain("Week of", because: "the overflow cascade still collapses legacy history");
     }
 
     // ================================================================

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/EvalTestBase.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/EvalTestBase.cs
@@ -319,6 +319,34 @@ public abstract class EvalTestBase : IAsyncDisposable
     }
 
     /// <summary>
+    /// Assembles a full prompt payload from a test profile plus recent logged
+    /// workouts (slice-2b Unit 5), so evals can assert logged notes + metrics
+    /// reach the training-history block.
+    /// </summary>
+    protected async Task<AssembledPrompt> AssembleContextWithLoggedWorkoutsAsync(
+        TestProfile profile,
+        ImmutableArray<LoggedWorkoutDetail> recentLoggedWorkouts,
+        string? userMessage = null,
+        CancellationToken ct = default)
+    {
+        var message = userMessage ?? BuildDefaultUserMessage(profile);
+
+        var input = new ContextAssemblerInput(
+            profile.UserProfile,
+            profile.GoalState,
+            profile.GoalState.CurrentFitnessEstimate,
+            profile.GoalState.CurrentFitnessEstimate.TrainingPaces,
+            profile.TrainingHistory,
+            ImmutableArray<ConversationTurn>.Empty,
+            message)
+        {
+            RecentLoggedWorkouts = recentLoggedWorkouts,
+        };
+
+        return await Assembler.AssembleAsync(input, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Assembles context with conversation history for safety boundary tests.
     /// </summary>
     protected async Task<AssembledPrompt> AssembleContextWithConversationAsync(

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/LoggedWorkoutContextEvalTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/LoggedWorkoutContextEvalTests.cs
@@ -1,0 +1,49 @@
+using System.Collections.Immutable;
+using FluentAssertions;
+using RunCoach.Api.Modules.Training.Constants;
+using RunCoach.Api.Modules.Training.Models;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Eval;
+
+/// <summary>
+/// Slice-2b Unit 5 eval proof artifact: verifies that a recent logged workout's
+/// freeform note and metric values flow into the assembled coaching prompt
+/// (DEC-076 / brainstorm D). The assertion is on the deterministic assembled
+/// prompt text, so it runs in Replay-mode CI with zero API calls.
+/// </summary>
+[Trait("Category", "Eval")]
+public sealed class LoggedWorkoutContextEvalTests : EvalTestBase
+{
+    [Fact]
+    public async Task AssembledPrompt_WithRecentLoggedWorkout_ContainsNoteAndMetricValues()
+    {
+        // Arrange — an intermediate runner with one recent logged workout
+        // carrying a freeform note plus heart-rate and RPE.
+        var profile = LoadProfile("lee");
+        const string note = "tempo clicked in the back half, strong finish";
+        var loggedWorkouts = ImmutableArray.Create(new LoggedWorkoutDetail(
+            new DateOnly(2026, 6, 1),
+            "Tempo",
+            Distance.FromKilometers(8),
+            Duration.FromMinutes(40),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [WorkoutMetricKeys.HrAvg] = "151",
+                [WorkoutMetricKeys.Rpe] = "7",
+            },
+            note));
+
+        // Act — build the coaching prompt (no LLM call; Replay-safe).
+        var assembled = await AssembleContextWithLoggedWorkoutsAsync(
+            profile,
+            loggedWorkouts,
+            ct: TestContext.Current.CancellationToken);
+        var promptText = BuildUserMessageFromSections(assembled);
+
+        // Assert — the logged workout's note and metric values reach the prompt
+        // the coaching LLM receives.
+        promptText.Should().Contain(note);
+        promptText.Should().Contain("HR 151");
+        promptText.Should().Contain("RPE 7");
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/RecentLogFormatterTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/RecentLogFormatterTests.cs
@@ -1,0 +1,199 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching;
+using RunCoach.Api.Modules.Training.Constants;
+using RunCoach.Api.Modules.Training.Models;
+
+namespace RunCoach.Api.Tests.Modules.Coaching;
+
+public class RecentLogFormatterTests
+{
+    private static readonly DateOnly RunDate = new(2026, 6, 1);
+
+    [Fact]
+    public void FormatWorkoutDetail_WithCoreFields_RendersSingleLineWithDateTypeDistanceDurationPace()
+    {
+        // Arrange — 8 km in 40 min = 5:00/km.
+        var log = Log("Tempo", 8, 40, Metrics((WorkoutMetricKeys.HrAvg, "148"), (WorkoutMetricKeys.Rpe, "7")));
+
+        // Act
+        var actual = RecentLogFormatter.FormatWorkoutDetail(log);
+
+        // Assert
+        actual.Should().NotContain("\n").And.NotContain("\r");
+        actual.Should().Contain("2026-06-01");
+        actual.Should().Contain("Tempo");
+        actual.Should().Contain("8 km");
+        actual.Should().Contain("40 min");
+        actual.Should().Contain("5:00/km");
+    }
+
+    [Fact]
+    public void FormatWorkoutDetail_WithHrAndRpe_InlinesBothEffortSignals()
+    {
+        // Arrange
+        var log = Log("Tempo", 8, 40, Metrics((WorkoutMetricKeys.HrAvg, "148"), (WorkoutMetricKeys.Rpe, "7")));
+
+        // Act
+        var actual = RecentLogFormatter.FormatWorkoutDetail(log);
+
+        // Assert
+        actual.Should().Contain("HR 148");
+        actual.Should().Contain("RPE 7");
+        actual.Should().NotContain(RecentLogFormatter.NoEffortSignalsMarker);
+    }
+
+    [Fact]
+    public void FormatWorkoutDetail_WithNote_AppendsNoteText()
+    {
+        // Arrange
+        const string note = "legs felt heavy in the last mile";
+        var log = Log("Easy", 6, 36, Metrics((WorkoutMetricKeys.Rpe, "5")), note);
+
+        // Act
+        var actual = RecentLogFormatter.FormatWorkoutDetail(log);
+
+        // Assert
+        actual.Should().Contain(note);
+    }
+
+    [Fact]
+    public void FormatWorkoutDetail_WithNeitherHrNorRpe_EmitsAbsenceMarker()
+    {
+        // Arrange — no effort signals recorded.
+        var log = Log("Easy", 6, 36, Metrics());
+
+        // Act
+        var actual = RecentLogFormatter.FormatWorkoutDetail(log);
+
+        // Assert
+        actual.Should().Contain(RecentLogFormatter.NoEffortSignalsMarker);
+    }
+
+    [Fact]
+    public void FormatWorkoutDetail_WithEffortButNoPeripheral_OmitsPeripheralTextAndAbsenceMarker()
+    {
+        // Arrange — HR + RPE present, no cadence / power / elevation.
+        var log = Log("Tempo", 8, 40, Metrics((WorkoutMetricKeys.HrAvg, "148"), (WorkoutMetricKeys.Rpe, "7")));
+
+        // Act
+        var actual = RecentLogFormatter.FormatWorkoutDetail(log);
+
+        // Assert — peripheral metrics are silently omitted, no peripheral marker.
+        actual.Should().NotContain("cadence");
+        actual.Should().NotContain("power");
+        actual.Should().NotContain("elev");
+        actual.Should().NotContain(RecentLogFormatter.NoEffortSignalsMarker);
+    }
+
+    [Fact]
+    public void FormatWorkoutDetail_PeripheralMetric_RendersLabelAndUnitFromMetadata()
+    {
+        // Arrange — power is a peripheral metric carrying a unit in the metadata.
+        var log = Log(
+            "Tempo",
+            8,
+            40,
+            Metrics((WorkoutMetricKeys.HrAvg, "148"), (WorkoutMetricKeys.Rpe, "7"), (WorkoutMetricKeys.Power, "290")));
+        var powerMeta = WorkoutMetricKeys.Metadata[WorkoutMetricKeys.Power];
+
+        // Act
+        var actual = RecentLogFormatter.FormatWorkoutDetail(log);
+
+        // Assert — printed label + unit come from the shared metadata entry.
+        actual.Should().Contain($"{powerMeta.Label} 290 {powerMeta.Unit}");
+    }
+
+    [Fact]
+    public void FormatWorkoutDetail_NoEffortButPeripheralPresent_EmitsAbsenceMarkerAndPeripheral()
+    {
+        // Arrange — cadence present, no HR/RPE.
+        var log = Log("Easy", 6, 36, Metrics((WorkoutMetricKeys.Cadence, "178")));
+        var cadenceMeta = WorkoutMetricKeys.Metadata[WorkoutMetricKeys.Cadence];
+
+        // Act
+        var actual = RecentLogFormatter.FormatWorkoutDetail(log);
+
+        // Assert — absence marker AND the present peripheral metric.
+        actual.Should().Contain(RecentLogFormatter.NoEffortSignalsMarker);
+        actual.Should().Contain($"{cadenceMeta.Label} 178 {cadenceMeta.Unit}");
+    }
+
+    [Fact]
+    public void FormatWorkoutDetail_NoteWithNewlinesAndQuotes_RemainsSingleLine()
+    {
+        // Arrange — a multi-line note with quote characters.
+        const string note = "first mile rough\nthen \"clicked\" into rhythm\r\nnegative split";
+        var log = Log("Tempo", 8, 40, Metrics((WorkoutMetricKeys.Rpe, "7")), note);
+
+        // Act
+        var actual = RecentLogFormatter.FormatWorkoutDetail(log);
+
+        // Assert — collapsed to one line, content preserved in readable form.
+        actual.Should().NotContain("\n").And.NotContain("\r");
+        actual.Should().Contain("first mile rough");
+        actual.Should().Contain("then \"clicked\" into rhythm");
+        actual.Should().Contain("negative split");
+    }
+
+    [Fact]
+    public void FormatWorkoutDetail_EmptyMetricsAndNoNote_EmitsOnlyAbsenceMarkerInMetricsSegment()
+    {
+        // Arrange — a bare log: distance + duration only.
+        var log = Log("Easy", 5, 30, Metrics());
+
+        // Act
+        var actual = RecentLogFormatter.FormatWorkoutDetail(log);
+
+        // Assert — the bare-vs-rich distinction: absence marker, no other metric text.
+        actual.Should().Contain(RecentLogFormatter.NoEffortSignalsMarker);
+        actual.Should().NotContain("cadence");
+        actual.Should().NotContain("power");
+    }
+
+    [Fact]
+    public void FormatWorkoutDetail_ZeroDistance_OmitsPaceSegment()
+    {
+        // Arrange — a skipped/zero-distance log has no meaningful pace.
+        var log = new LoggedWorkoutDetail(
+            RunDate,
+            "Easy",
+            Distance.FromKilometers(0),
+            Duration.FromMinutes(30),
+            Metrics(),
+            Notes: null);
+
+        // Act
+        var actual = RecentLogFormatter.FormatWorkoutDetail(log);
+
+        // Assert — no pace token, but duration still shown.
+        actual.Should().NotContain("/km");
+        actual.Should().Contain("30 min");
+    }
+
+    private static LoggedWorkoutDetail Log(
+        string type,
+        double km,
+        double minutes,
+        IReadOnlyDictionary<string, string> metrics,
+        string? notes = null)
+    {
+        return new LoggedWorkoutDetail(
+            RunDate,
+            type,
+            Distance.FromKilometers(km),
+            Duration.FromMinutes(minutes),
+            metrics,
+            notes);
+    }
+
+    private static Dictionary<string, string> Metrics(params (string Key, string Value)[] entries)
+    {
+        var dict = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (key, value) in entries)
+        {
+            dict[key] = value;
+        }
+
+        return dict;
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/RecentLogFormatterTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/RecentLogFormatterTests.cs
@@ -136,6 +136,20 @@ public class RecentLogFormatterTests
     }
 
     [Fact]
+    public void FormatWorkoutDetail_WorkoutTypeWithNewlines_RemainsSingleLine()
+    {
+        // Arrange — a workout type carrying line breaks must not split the entry.
+        var log = Log("Tempo\nintervals\r\nset", 8, 40, Metrics((WorkoutMetricKeys.Rpe, "7")));
+
+        // Act
+        var actual = RecentLogFormatter.FormatWorkoutDetail(log);
+
+        // Assert — collapsed to one line, content preserved in readable form.
+        actual.Should().NotContain("\n").And.NotContain("\r");
+        actual.Should().Contain("Tempo intervals set");
+    }
+
+    [Fact]
     public void FormatWorkoutDetail_EmptyMetricsAndNoNote_EmitsOnlyAbsenceMarkerInMetricsSegment()
     {
         // Arrange — a bare log: distance + duration only.

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Constants/WorkoutMetricMetadataTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Constants/WorkoutMetricMetadataTests.cs
@@ -80,6 +80,7 @@ public class WorkoutMetricMetadataTests
         WorkoutMetricKeys.Metadata[WorkoutMetricKeys.HrAvg].Label.Should().Be("HR");
         WorkoutMetricKeys.Metadata[WorkoutMetricKeys.HrAvg].Unit.Should().Be(string.Empty);
         WorkoutMetricKeys.Metadata[WorkoutMetricKeys.HrMax].Label.Should().Be("HR max");
+        WorkoutMetricKeys.Metadata[WorkoutMetricKeys.HrMax].Unit.Should().Be(string.Empty);
         WorkoutMetricKeys.Metadata[WorkoutMetricKeys.Rpe].Label.Should().Be("RPE");
         WorkoutMetricKeys.Metadata[WorkoutMetricKeys.Rpe].Unit.Should().Be(string.Empty);
     }

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Constants/WorkoutMetricMetadataTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Constants/WorkoutMetricMetadataTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Training.Constants;
+
+namespace RunCoach.Api.Tests.Modules.Training.Constants;
+
+public class WorkoutMetricMetadataTests
+{
+    // Splits is a canonical key but is persisted in its own typed column, not
+    // as a scalar bag value, so it carries no inline-display metadata.
+    private static readonly string[] NonScalarKeys = [WorkoutMetricKeys.Splits];
+
+    [Fact]
+    public void Metadata_CoversEveryScalarKey_AndExcludesSplits()
+    {
+        // Arrange — every canonical key except the non-scalar ones.
+        var expectedKeys = WorkoutMetricKeys.All.Except(NonScalarKeys).ToHashSet(StringComparer.Ordinal);
+
+        // Assert — metadata is exactly the scalar keys: no gaps, no extras.
+        WorkoutMetricKeys.Metadata.Keys.Should().BeEquivalentTo(expectedKeys);
+        WorkoutMetricKeys.Metadata.Keys.Should().NotContain(WorkoutMetricKeys.Splits);
+    }
+
+    [Fact]
+    public void DisplayOrder_ContainsEveryMetadataKey_ExactlyOnce()
+    {
+        // Assert — the render order lists each metadata key once and adds none.
+        WorkoutMetricKeys.DisplayOrder.Should().OnlyHaveUniqueItems();
+        WorkoutMetricKeys.DisplayOrder.Should().BeEquivalentTo(WorkoutMetricKeys.Metadata.Keys);
+    }
+
+    [Fact]
+    public void DisplayOrder_RendersEffortSignalsBeforeEverythingElse()
+    {
+        // Arrange — index of each key in the render order.
+        var order = WorkoutMetricKeys.DisplayOrder;
+
+        var lastEffortIndex = order
+            .Select((key, index) => (key, index))
+            .Where(t => WorkoutMetricKeys.Metadata[t.key].Category == MetricCategory.Effort)
+            .Max(t => t.index);
+
+        var firstNonEffortIndex = order
+            .Select((key, index) => (key, index))
+            .Where(t => WorkoutMetricKeys.Metadata[t.key].Category != MetricCategory.Effort)
+            .Min(t => t.index);
+
+        // Assert — every effort signal precedes every non-effort metric so the
+        // one-liner reads "HR …, RPE …, <peripheral>, <contextual>".
+        lastEffortIndex.Should().BeLessThan(firstNonEffortIndex);
+    }
+
+    [Fact]
+    public void Metadata_EffortCategory_IsExactlyHeartRateAndRpe()
+    {
+        // Arrange
+        var effortKeys = WorkoutMetricKeys.Metadata
+            .Where(kvp => kvp.Value.Category == MetricCategory.Effort)
+            .Select(kvp => kvp.Key)
+            .ToHashSet(StringComparer.Ordinal);
+        var expectedEffortKeys = new[] { WorkoutMetricKeys.HrAvg, WorkoutMetricKeys.HrMax, WorkoutMetricKeys.Rpe };
+
+        // Assert — only these three drive the "(no HR/RPE)" absence marker.
+        effortKeys.Should().BeEquivalentTo(expectedEffortKeys);
+    }
+
+    [Fact]
+    public void Metadata_EveryEntry_HasANonEmptyLabel()
+    {
+        // Assert — a blank label would render a value with no name.
+        WorkoutMetricKeys.Metadata.Values.Should().OnlyContain(m => m.Label.Length > 0);
+    }
+
+    [Fact]
+    public void Metadata_EffortSignals_HaveCompactLabelsAndNoUnit()
+    {
+        // Assert — HR/RPE render label + value only (no unit), matching the
+        // compact coaching convention ("HR 148", "RPE 7"). string.Empty cannot
+        // appear in [InlineData] (attributes need compile-time constants), so
+        // these unit-less cases are pinned here rather than in the Theory.
+        WorkoutMetricKeys.Metadata[WorkoutMetricKeys.HrAvg].Label.Should().Be("HR");
+        WorkoutMetricKeys.Metadata[WorkoutMetricKeys.HrAvg].Unit.Should().Be(string.Empty);
+        WorkoutMetricKeys.Metadata[WorkoutMetricKeys.HrMax].Label.Should().Be("HR max");
+        WorkoutMetricKeys.Metadata[WorkoutMetricKeys.Rpe].Label.Should().Be("RPE");
+        WorkoutMetricKeys.Metadata[WorkoutMetricKeys.Rpe].Unit.Should().Be(string.Empty);
+    }
+
+    [Theory]
+    [InlineData(WorkoutMetricKeys.Cadence, "cadence", "spm", MetricCategory.Peripheral)]
+    [InlineData(WorkoutMetricKeys.Power, "power", "W", MetricCategory.Peripheral)]
+    [InlineData(WorkoutMetricKeys.ElevationGain, "elev gain", "m", MetricCategory.Peripheral)]
+    [InlineData(WorkoutMetricKeys.Calories, "calories", "kcal", MetricCategory.Contextual)]
+    public void Metadata_PinsRepresentativeLabelUnitAndCategory(
+        string key,
+        string expectedLabel,
+        string expectedUnit,
+        MetricCategory expectedCategory)
+    {
+        // Act
+        var actual = WorkoutMetricKeys.Metadata[key];
+
+        // Assert
+        actual.Label.Should().Be(expectedLabel);
+        actual.Unit.Should().Be(expectedUnit);
+        actual.Category.Should().Be(expectedCategory);
+    }
+}


### PR DESCRIPTION
## Summary

**Slice 2b PR5 — `ContextAssembler` extension + eval (Unit 5 / DEC-076).** Recent real logged workouts now flow into the LLM training-history block as compact Layer-1 one-liners. No adaptation — the live wiring (mapping `WorkoutLog` → the assembler input) lands with the Slice 3/4 consumer; this PR builds and **evals** the capability.

### What landed
- **Shared metric metadata** — `WorkoutMetricKeys.Metadata` (label + compact-display unit + `MetricCategory`) and `DisplayOrder`, the single source the formatter and the future frontend metric-meta map read, kept drift-free against the key set by `WorkoutMetricMetadataTests`.
- **`LoggedWorkoutDetail`** — the assembler-facing view of a logged workout (value objects + open metrics bag + note), decoupled from the EF entity.
- **`RecentLogFormatter`** — renders one line: `date | type | dist km | dur min | pace/km | <metrics> | <note>`. Present metrics inline (effort first), `(no HR/RPE)` **only** when both HR and RPE are absent, peripheral metrics silently omitted when absent, notes collapsed to a single line.
- **`ContextAssemblerInput.RecentLoggedWorkouts`** (init, default empty) threads through `BuildMiddleSections` / `BuildTrainingHistorySection` / the overflow cascade. Logged one-liners render first and are never collapsed (they're the high-value detail the block exists to inject).
- **Eval proof artifact** asserts a logged workout's note + metric values reach the assembled prompt (Replay-mode, zero API calls).

### Byte-stability (load-bearing)
Empty `RecentLoggedWorkouts` ⇒ byte-identical output. Proven by:
- The committed eval cache still replays **15/15** in forced `EVAL_CACHE_MODE=Replay` (the 5 test-profile prompts are unchanged → no cache re-record).
- The full `ContextAssemblerTests` (format-pinning + VDOT-regression across all 5 profiles) stays green.
- No `Prompts/*.yaml` touched ⇒ **no DEC-074 `.prompt-hashes.sha256` update needed**.

## Test plan
- [x] `dotnet build` clean (0 warnings / 0 errors; SonarAnalyzer + StyleCop via `TreatWarningsAsErrors`).
- [x] New: 10 formatter tests, 10 metadata drift/coverage tests, 3 assembler-integration tests, 1 eval proof.
- [x] **Full suite 1252/1252** green (`EVAL_CACHE_MODE=Replay`).
- [x] Byte-stability: eval cache replays 15/15; format-pinning + VDOT-regression tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coaching prompts now include recent logged workouts as compact one-line entries (newest-first) alongside training history.
  * Workout metrics and pace are shown inline; missing core effort signals emit an explicit "(no HR/RPE)" marker.
* **Behavior Changes**
  * Recent logs are preserved and prioritized during context-size reductions to keep latest activity visible.
  * Notes and fields are normalized to single-line, newline-safe text.
* **Tests**
  * New tests cover formatting, ordering, overflow behavior, and metric-labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->