### PR TITLE
feat(slice-2b): workout-log /log route and logging form (PR6b)

### DIFF
--- a/frontend/src/app/api/api-slice.ts
+++ b/frontend/src/app/api/api-slice.ts
@@ -7,6 +7,6 @@ import { baseQueryWith401Handler } from '~/api/base-query'
 export const apiSlice = createApi({
   reducerPath: 'api',
   baseQuery: baseQueryWith401Handler,
-  tagTypes: ['Auth', 'Onboarding', 'Plan'],
+  tagTypes: ['Auth', 'Onboarding', 'Plan', 'WorkoutLog'],
   endpoints: () => ({}),
 })

--- a/frontend/src/app/api/generated/index.ts
+++ b/frontend/src/app/api/generated/index.ts
@@ -33,6 +33,7 @@ import { z } from 'zod'
 
 import { PostApiV1AuthRegisterBody } from './zod/auth/auth'
 import { PostApiV1OnboardingTurnsResponse } from './zod/onboarding/onboarding'
+import { PostApiV1WorkoutsLogsBody } from './zod/workout-logs/workout-logs'
 
 // Auth schemas — migrated piecewise. RegisterRequest is the first; T03.2
 // extends to OnboardingProgressDto + SuggestedInputType.
@@ -51,6 +52,17 @@ export type OnboardingProgressDto = z.infer<typeof onboardingProgressSchema>
 
 export const suggestedInputTypeSchema = PostApiV1OnboardingTurnsResponse.shape.suggestedInputType
 export type SuggestedInputType = z.infer<typeof suggestedInputTypeSchema>
+
+// Workout-log schemas (slice-2b). The create-request body is the drift seam
+// the `/log` form derives from via `.pick().extend()` (DEC-075): the form keeps
+// `occurredOn`'s ISO-date format and `completionStatus`'s `0|1|2` enum honest
+// against the backend contract, and a backend rename surfaces here as a TS
+// error during `npm run codegen:check`.
+export const createWorkoutLogRequestSchema = PostApiV1WorkoutsLogsBody
+export type CreateWorkoutLogRequest = z.infer<typeof createWorkoutLogRequestSchema>
+
+export const completionStatusSchema = createWorkoutLogRequestSchema.shape.completionStatus
+export type CompletionStatus = z.infer<typeof completionStatusSchema>
 
 /**
  * `as const` enum-shaped object paired with {@link SuggestedInputType}
@@ -87,3 +99,26 @@ type _SuggestedInputTypeExhaustive = _SuggestedInputTypeUnionMinusConst extends 
 // Exported to satisfy `noUnusedLocals`; the assignment fails if a new backend
 // variant widens `SuggestedInputType` without a matching entry in the const above.
 export const _suggestedInputTypeExhaustivenessGuard: _SuggestedInputTypeExhaustive = true
+
+/**
+ * `as const` enum-shaped object paired with {@link CompletionStatus} so the
+ * logging form and history surfaces read `CompletionStatus.Complete` instead of
+ * the magic integer `0`. Values mirror the C# `CompletionStatus` enum on the
+ * wire (no `JsonStringEnumConverter`); the Zod union above enforces the same
+ * `0 | 1 | 2` set at the validation seam. Kept in lockstep with the backend by
+ * the same bidirectional guard used for {@link SuggestedInputType}.
+ */
+export const CompletionStatus = {
+  Complete: 0,
+  Partial: 1,
+  Skipped: 2,
+} as const satisfies Record<string, CompletionStatus>
+
+// Exhaustiveness guard — union ⊆ const direction (mirrors the SuggestedInputType
+// guard above): a new backend `completionStatus` literal that widens the
+// Zod-inferred union without a matching const entry resolves this to `never`,
+// failing the build.
+type _CompletionStatusConstMembers = (typeof CompletionStatus)[keyof typeof CompletionStatus]
+type _CompletionStatusUnionMinusConst = Exclude<CompletionStatus, _CompletionStatusConstMembers>
+type _CompletionStatusExhaustive = _CompletionStatusUnionMinusConst extends never ? true : never
+export const _completionStatusExhaustivenessGuard: _CompletionStatusExhaustive = true

--- a/frontend/src/app/api/generated/index.ts
+++ b/frontend/src/app/api/generated/index.ts
@@ -61,6 +61,12 @@ export type SuggestedInputType = z.infer<typeof suggestedInputTypeSchema>
 export const createWorkoutLogRequestSchema = PostApiV1WorkoutsLogsBody
 export type CreateWorkoutLogRequest = z.infer<typeof createWorkoutLogRequestSchema>
 
+// The create response has no Zod schema to derive from — Swashbuckle emits no
+// 201 body schema, so the generated Zod response is `z.void()`. Re-export the
+// generated RTK *type* (type-only, so the rtk module's runtime self-injection is
+// not pulled in) so the response wire shape stays generated, not hand-mirrored.
+export type { CreateWorkoutLogResponseDto } from './rtk/api'
+
 export const completionStatusSchema = createWorkoutLogRequestSchema.shape.completionStatus
 export type CompletionStatus = z.infer<typeof completionStatusSchema>
 

--- a/frontend/src/app/api/generated/index.ts
+++ b/frontend/src/app/api/generated/index.ts
@@ -17,9 +17,10 @@
  * schemas. The named-component extractions below pull the sub-schemas via
  * Zod's `.shape` accessor so a backend rename of (say)
  * `OnboardingProgressDto.completedTopics` → `OnboardingProgressDto.completed`
- * surfaces here as a TypeScript error during `npm run codegen:check`. That
- * regression class is exactly what Slice 1 bug #4 shipped undetected and
- * what DEC-066 exists to prevent.
+ * is caught by `codegen:check` as a generated-output drift (git-diff) failure;
+ * the resulting broken `.shape` access then surfaces as a TypeScript error
+ * under `npm run build`. That regression class is exactly what Slice 1 bug #4
+ * shipped undetected and what DEC-066 exists to prevent.
  *
  * Drift is caught bidirectionally for `SuggestedInputType`:
  *   - const ⊆ union: enforced by `satisfies Record<string, SuggestedInputType>`
@@ -56,8 +57,9 @@ export type SuggestedInputType = z.infer<typeof suggestedInputTypeSchema>
 // Workout-log schemas (slice-2b). The create-request body is the drift seam
 // the `/log` form derives from via `.pick().extend()` (DEC-075): the form keeps
 // `occurredOn`'s ISO-date format and `completionStatus`'s `0|1|2` enum honest
-// against the backend contract, and a backend rename surfaces here as a TS
-// error during `npm run codegen:check`.
+// against the backend contract. A backend rename is caught by `codegen:check`
+// as a generated-output drift (git-diff) failure; the resulting broken `.shape`
+// access then surfaces as a TypeScript error under `npm run build`.
 export const createWorkoutLogRequestSchema = PostApiV1WorkoutsLogsBody
 export type CreateWorkoutLogRequest = z.infer<typeof createWorkoutLogRequestSchema>
 

--- a/frontend/src/app/api/workout-log.api.spec.ts
+++ b/frontend/src/app/api/workout-log.api.spec.ts
@@ -1,0 +1,70 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiSlice } from '~/api/api-slice'
+import type { CreateWorkoutLogRequest } from '~/api/generated'
+import { workoutLogApi } from './workout-log.api'
+
+// Dispatch the endpoint thunk directly with `fetch` stubbed at the global level
+// so the `query: (body) => ({...})` factory actually executes (the page spec
+// mocks the hook and never reaches the factory). Mirrors plan.api.spec.ts.
+const OriginalRequest = globalThis.Request
+class PatchedRequest extends OriginalRequest {
+  constructor(input: RequestInfo | URL, init?: RequestInit) {
+    if (typeof input === 'string' && input.startsWith('/')) {
+      super(new URL(input, 'https://localhost:5173').toString(), init)
+      return
+    }
+    super(input, init)
+  }
+}
+
+const jsonResponse = (body: Record<string, unknown>, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const makeStore = () =>
+  configureStore({
+    reducer: { [apiSlice.reducerPath]: apiSlice.reducer },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(apiSlice.middleware),
+  })
+
+const SAMPLE_BODY: CreateWorkoutLogRequest = {
+  idempotencyKey: '00000000-0000-0000-0000-00000000abcd',
+  occurredOn: '2026-06-06',
+  distanceMeters: 5000,
+  durationSeconds: 1800,
+  completionStatus: 0,
+  metrics: { rpe: 6, hrAvg: 142 },
+}
+
+describe('workoutLogApi.createWorkoutLog query factory', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({ workoutLogId: 'log-1' }, 201))
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('Request', PatchedRequest)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('issues a POST to /api/v1/workouts/logs with the supplied body', async () => {
+    const store = makeStore()
+    const result = await store.dispatch(
+      workoutLogApi.endpoints.createWorkoutLog.initiate(SAMPLE_BODY),
+    )
+
+    expect(result.data).toEqual({ workoutLogId: 'log-1' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const request = fetchMock.mock.calls[0][0] as Request
+    expect(request).toBeInstanceOf(Request)
+    expect(request.method).toBe('POST')
+    expect(request.url).toContain('/api/v1/workouts/logs')
+    const sentBody = await request.clone().json()
+    expect(sentBody).toEqual(SAMPLE_BODY)
+  })
+})

--- a/frontend/src/app/api/workout-log.api.ts
+++ b/frontend/src/app/api/workout-log.api.ts
@@ -1,0 +1,41 @@
+import { apiSlice } from '~/api/api-slice'
+import type { CreateWorkoutLogRequest } from '~/api/generated'
+
+/**
+ * Response shape returned by `POST /api/v1/workouts/logs`. Mirrors
+ * `RunCoach.Api.Modules.Training.Workouts.CreateWorkoutLogResponseDto`. The
+ * server replies `201 Created` with the persisted log's id; the generated Zod
+ * response schema is `z.void()` (Swashbuckle emits no 201 body schema), so this
+ * hand-mirrored type is the source of truth for the mutation's response generic.
+ */
+export interface CreateWorkoutLogResponseDto {
+  workoutLogId: string
+}
+
+// Workout-log endpoints are injected into the root `apiSlice` so every request
+// shares the same cookie + antiforgery base query (the X-XSRF-TOKEN header is
+// added automatically for mutations by `base-query.ts`). URL segments are
+// relative to the global `/api` prefix supplied by the base query — the
+// generated RTK endpoint uses the full `/api/v1/...` path and is intentionally
+// unused at runtime (it would double the prefix); this hand-written wrapper is
+// the consumed surface (the auth/plan/onboarding convention).
+//
+// `createWorkoutLog` invalidates the `WorkoutLog` tag so any mounted
+// workout-history query refetches after a successful log (the history surface
+// lands in PR7). The client-generated `idempotencyKey` rides inside the body
+// (DEC-077), exactly like `regeneratePlan`.
+export const workoutLogApi = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    createWorkoutLog: builder.mutation<CreateWorkoutLogResponseDto, CreateWorkoutLogRequest>({
+      query: (body) => ({
+        url: '/v1/workouts/logs',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: ['WorkoutLog'],
+    }),
+  }),
+})
+
+/** Auto-generated RTK Query hook for the workout-log create endpoint. */
+export const { useCreateWorkoutLogMutation } = workoutLogApi

--- a/frontend/src/app/api/workout-log.api.ts
+++ b/frontend/src/app/api/workout-log.api.ts
@@ -1,16 +1,5 @@
 import { apiSlice } from '~/api/api-slice'
-import type { CreateWorkoutLogRequest } from '~/api/generated'
-
-/**
- * Response shape returned by `POST /api/v1/workouts/logs`. Mirrors
- * `RunCoach.Api.Modules.Training.Workouts.CreateWorkoutLogResponseDto`. The
- * server replies `201 Created` with the persisted log's id; the generated Zod
- * response schema is `z.void()` (Swashbuckle emits no 201 body schema), so this
- * hand-mirrored type is the source of truth for the mutation's response generic.
- */
-export interface CreateWorkoutLogResponseDto {
-  workoutLogId: string
-}
+import type { CreateWorkoutLogRequest, CreateWorkoutLogResponseDto } from '~/api/generated'
 
 // Workout-log endpoints are injected into the root `apiSlice` so every request
 // shares the same cookie + antiforgery base query (the X-XSRF-TOKEN header is

--- a/frontend/src/app/modules/app/app.component.tsx
+++ b/frontend/src/app/modules/app/app.component.tsx
@@ -9,6 +9,7 @@ import { AppErrorBoundary } from '~/error-boundary/app-error-boundary'
 import { useGlobalErrorReporter } from '~/error-boundary/use-global-error-reporter'
 import { RequireAuth } from '~/modules/auth/components/require-auth.component'
 import { useAuthBootstrap, useAuthBroadcastListener } from '~/modules/auth/hooks/auth.hooks'
+import { LogPage } from '~/modules/logging/pages/log.page'
 import { OnboardingPage } from '~/modules/onboarding/pages/onboarding.page'
 import { HomePage } from '~/modules/plan/pages/home.page'
 import { SettingsPage } from '~/modules/settings/pages/settings.page'
@@ -154,6 +155,16 @@ const AppShell = () => {
             <RequireAuth>
               <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
                 <HomePage />
+              </OnboardingRedirectGuard>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/log"
+          element={
+            <RequireAuth>
+              <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
+                <LogPage />
               </OnboardingRedirectGuard>
             </RequireAuth>
           }

--- a/frontend/src/app/modules/logging/components/completion-status-field.component.tsx
+++ b/frontend/src/app/modules/logging/components/completion-status-field.component.tsx
@@ -1,0 +1,55 @@
+import type { FieldPath } from 'react-hook-form'
+
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Label } from '@/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { CompletionStatus } from '~/api/generated'
+import type {
+  WorkoutLogFormControl,
+  WorkoutLogFormFields,
+} from '~/modules/logging/schemas/workout-log-form.schema'
+
+const COMPLETION_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: String(CompletionStatus.Complete), label: 'Completed' },
+  { value: String(CompletionStatus.Partial), label: 'Partial' },
+  { value: String(CompletionStatus.Skipped), label: 'Skipped' },
+]
+
+export interface CompletionStatusFieldProps {
+  control: WorkoutLogFormControl
+  name: FieldPath<WorkoutLogFormFields>
+}
+
+/**
+ * Radio selector for how fully the workout was completed. Values are the
+ * `CompletionStatus` wire integers carried as strings in form state; the schema
+ * coerces them back to the `0|1|2` union. Defaults to "Completed".
+ */
+export const CompletionStatusField = ({ control, name }: CompletionStatusFieldProps) => (
+  <FormField
+    control={control}
+    name={name}
+    render={({ field }) => (
+      <FormItem>
+        <FormLabel>Completion</FormLabel>
+        <FormControl>
+          <RadioGroup
+            value={field.value}
+            onValueChange={field.onChange}
+            className="flex flex-wrap gap-x-6 gap-y-2"
+          >
+            {COMPLETION_OPTIONS.map((option) => (
+              <div key={option.value} className="flex items-center gap-2">
+                <RadioGroupItem value={option.value} id={`completion-status-${option.value}`} />
+                <Label htmlFor={`completion-status-${option.value}`} className="font-normal">
+                  {option.label}
+                </Label>
+              </div>
+            ))}
+          </RadioGroup>
+        </FormControl>
+        <FormMessage />
+      </FormItem>
+    )}
+  />
+)

--- a/frontend/src/app/modules/logging/components/log-form.component.tsx
+++ b/frontend/src/app/modules/logging/components/log-form.component.tsx
@@ -1,0 +1,106 @@
+import type { UseFormReturn } from 'react-hook-form'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import type {
+  WorkoutLogFormFields,
+  WorkoutLogFormValues,
+} from '~/modules/logging/schemas/workout-log-form.schema'
+import { CompletionStatusField } from './completion-status-field.component'
+import { LogNumericField } from './log-numeric-field.component'
+import { MoreDetailsSection } from './more-details-section.component'
+
+export interface LogFormProps {
+  form: UseFormReturn<WorkoutLogFormFields, unknown, WorkoutLogFormValues>
+  onSubmit: (values: WorkoutLogFormValues) => void | Promise<void>
+  isLoading: boolean
+  formAlert: string | null
+}
+
+/**
+ * Presentational workout-log form: core fields (date, distance, duration,
+ * completion, notes) always visible, optional metrics behind "More details".
+ * The container owns `useForm` + the create mutation + navigation; this renders
+ * the field stack and gates submit on validity / in-flight state.
+ */
+export const LogForm = ({ form, onSubmit, isLoading, formAlert }: LogFormProps) => {
+  const isSubmitDisabled = !form.formState.isValid || form.formState.isSubmitting || isLoading
+
+  return (
+    <Form {...form}>
+      <form
+        noValidate
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-5"
+        data-testid="log-form"
+      >
+        {formAlert !== null ? (
+          <p
+            role="alert"
+            data-testid="log-form-alert"
+            className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {formAlert}
+          </p>
+        ) : null}
+
+        <FormField
+          control={form.control}
+          name="occurredOn"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Date</FormLabel>
+              <FormControl>
+                <Input type="date" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <LogNumericField control={form.control} name="distanceKm" label="Distance (km)" autoFocus />
+        <LogNumericField control={form.control} name="durationMinutes" label="Duration (minutes)" />
+
+        <CompletionStatusField control={form.control} name="completionStatus" />
+
+        <FormField
+          control={form.control}
+          name="notes"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>How did it go?</FormLabel>
+              <FormControl>
+                <Textarea
+                  rows={3}
+                  placeholder="Anything worth remembering — how you felt, weather, terrain…"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <MoreDetailsSection control={form.control} />
+
+        <Button
+          type="submit"
+          disabled={isSubmitDisabled}
+          className="w-full"
+          data-testid="log-form-submit"
+        >
+          {isLoading ? 'Saving…' : 'Save workout'}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/frontend/src/app/modules/logging/components/log-numeric-field.component.tsx
+++ b/frontend/src/app/modules/logging/components/log-numeric-field.component.tsx
@@ -1,0 +1,50 @@
+import type { FieldPath } from 'react-hook-form'
+
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import type {
+  WorkoutLogFormControl,
+  WorkoutLogFormFields,
+} from '~/modules/logging/schemas/workout-log-form.schema'
+
+export interface LogNumericFieldProps {
+  control: WorkoutLogFormControl
+  name: FieldPath<WorkoutLogFormFields>
+  label: string
+  autoFocus?: boolean
+}
+
+/**
+ * A labeled numeric field for the workout-log form. Uses
+ * `type="text" inputMode="decimal"` (DEC-075 — avoids the `<input type=number>`
+ * spinbutton + locale-decimal footguns) and binds the raw string straight into
+ * RHF state; the empty → `undefined` coercion and range validation live in the
+ * Zod schema, so this component stays a dumb controlled input. Wired through the
+ * shared `FormMessage`, whose `role="alert"` announces validation errors.
+ */
+export const LogNumericField = ({
+  control,
+  name,
+  label,
+  autoFocus = false,
+}: LogNumericFieldProps) => (
+  <FormField
+    control={control}
+    name={name}
+    render={({ field }) => (
+      <FormItem>
+        <FormLabel>{label}</FormLabel>
+        <FormControl>
+          <Input
+            type="text"
+            inputMode="decimal"
+            autoComplete="off"
+            autoFocus={autoFocus}
+            {...field}
+          />
+        </FormControl>
+        <FormMessage />
+      </FormItem>
+    )}
+  />
+)

--- a/frontend/src/app/modules/logging/components/more-details-section.component.tsx
+++ b/frontend/src/app/modules/logging/components/more-details-section.component.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+import { ChevronDownIcon } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { FORM_METRIC_KEYS, metricFieldLabel } from '~/modules/logging/metric-meta'
+import type { WorkoutLogFormControl } from '~/modules/logging/schemas/workout-log-form.schema'
+import { LogNumericField } from './log-numeric-field.component'
+
+export interface MoreDetailsSectionProps {
+  control: WorkoutLogFormControl
+}
+
+/**
+ * The optional-metrics section of the log form, behind a "More details"
+ * collapsible (default closed, DEC-075). The metric fields are ALWAYS part of
+ * the form (seeded in `defaultValues`); collapsing them only hides the DOM —
+ * `shouldUnregister: false` retains their values, so a filled-then-collapsed
+ * metric still submits. Each field maps to a canonical `metrics` bag key
+ * (`FORM_METRIC_KEYS`) with its label from the shared metric-meta map.
+ */
+export const MoreDetailsSection = ({ control }: MoreDetailsSectionProps) => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="flex flex-col gap-3">
+      <CollapsibleTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          className="w-full justify-between px-3"
+          data-testid="log-more-details-trigger"
+        >
+          More details
+          <ChevronDownIcon
+            aria-hidden="true"
+            className={`size-4 transition-transform duration-200 ease-out motion-reduce:transition-none ${
+              open ? 'rotate-180' : ''
+            }`}
+          />
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="flex flex-col gap-4 data-[state=open]:animate-in data-[state=closed]:animate-out motion-reduce:animate-none">
+        {FORM_METRIC_KEYS.map((key) => (
+          <LogNumericField key={key} control={control} name={key} label={metricFieldLabel(key)} />
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/frontend/src/app/modules/logging/metric-meta.ts
+++ b/frontend/src/app/modules/logging/metric-meta.ts
@@ -8,7 +8,9 @@
  * contract, so they mirror the backend verbatim. Labels here are UI-facing
  * (e.g. `hrAvg → "Avg HR"`) and are intentionally friendlier than the compact
  * labels the backend `WorkoutMetricKeys.Metadata` uses for LLM one-liners
- * (`"HR"`); the two maps share the same key set, not the same label strings.
+ * (`"HR"`). The frontend map is a subset of the backend `Metadata` key set
+ * (which also reserves `verticalOscillation`, `groundContactTime`,
+ * `strideLength`); the two use different label strings.
  */
 export interface WorkoutMetricMeta {
   /** UI-facing label (e.g. "Avg HR"). */

--- a/frontend/src/app/modules/logging/metric-meta.ts
+++ b/frontend/src/app/modules/logging/metric-meta.ts
@@ -1,0 +1,58 @@
+/**
+ * Frontend metric-meta map (DEC-072 / DEC-075). The single place UI labels +
+ * units for the open `WorkoutLog.metrics` bag live, so the log form (PR6b) and
+ * the history list (PR7) render identical wording and cannot drift.
+ *
+ * Keys are the canonical lower-camel wire keys from the backend
+ * `RunCoach.Api.Modules.Training.Constants.WorkoutMetricKeys` — they ARE the
+ * contract, so they mirror the backend verbatim. Labels here are UI-facing
+ * (e.g. `hrAvg → "Avg HR"`) and are intentionally friendlier than the compact
+ * labels the backend `WorkoutMetricKeys.Metadata` uses for LLM one-liners
+ * (`"HR"`); the two maps share the same key set, not the same label strings.
+ */
+export interface WorkoutMetricMeta {
+  /** UI-facing label (e.g. "Avg HR"). */
+  label: string
+  /** Display unit suffix, or `''` for unitless metrics (e.g. RPE). */
+  unit: string
+}
+
+export const WORKOUT_METRIC_META = {
+  rpe: { label: 'RPE', unit: '' },
+  hrAvg: { label: 'Avg HR', unit: 'bpm' },
+  hrMax: { label: 'Max HR', unit: 'bpm' },
+  calories: { label: 'Calories', unit: 'kcal' },
+  hrv: { label: 'HRV', unit: 'ms' },
+  sleepScore: { label: 'Sleep score', unit: '' },
+  recoveryScore: { label: 'Recovery score', unit: '' },
+  cadence: { label: 'Cadence', unit: 'spm' },
+  elevationGain: { label: 'Elevation gain', unit: 'm' },
+  power: { label: 'Power', unit: 'W' },
+  weather: { label: 'Weather', unit: '' },
+  terrain: { label: 'Terrain', unit: '' },
+} as const satisfies Record<string, WorkoutMetricMeta>
+
+/** Canonical metric key (lower-camel wire key). */
+export type WorkoutMetricKey = keyof typeof WORKOUT_METRIC_META
+
+/**
+ * The scalar numeric metrics surfaced as optional fields in the `/log` form's
+ * "More details" section at MVP-0 — the self-reportable effort + intensity
+ * signals. Device-sourced metrics (cadence, power, hrv, sleep/recovery) and the
+ * free-text contextual ones (weather, terrain) are accepted by the data model
+ * but not yet form fields; they bolt on without a migration (DEC-072).
+ */
+export const FORM_METRIC_KEYS = [
+  'rpe',
+  'hrAvg',
+  'hrMax',
+  'elevationGain',
+] as const satisfies readonly WorkoutMetricKey[]
+
+export type FormMetricKey = (typeof FORM_METRIC_KEYS)[number]
+
+/** Composes the display label with its unit suffix, e.g. "Avg HR (bpm)". */
+export const metricFieldLabel = (key: WorkoutMetricKey): string => {
+  const { label, unit } = WORKOUT_METRIC_META[key]
+  return unit.length > 0 ? `${label} (${unit})` : label
+}

--- a/frontend/src/app/modules/logging/pages/log.page.spec.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.spec.tsx
@@ -9,23 +9,33 @@ import type { CreateWorkoutLogRequest } from '~/api/generated'
 import { toIsoDateOnly } from '~/modules/logging/schemas/workout-log-form.schema'
 
 // vi.mock is hoisted above imports, so the mock fns must come from vi.hoisted.
-const { createWorkoutLogTrigger, createWorkoutLogUnwrap, mutationStateRef, navigateMock } =
-  vi.hoisted(() => {
-    const createWorkoutLogUnwrap = vi.fn()
-    return {
-      createWorkoutLogUnwrap,
-      // Typed via the generic so `mock.calls[0][0]` is a CreateWorkoutLogRequest;
-      // the impl ignores the body (no unused param).
-      createWorkoutLogTrigger: vi.fn<
-        (body: CreateWorkoutLogRequest) => { unwrap: () => Promise<{ workoutLogId: string }> }
-      >(() => ({ unwrap: createWorkoutLogUnwrap })),
-      mutationStateRef: { isLoading: false },
-      navigateMock: vi.fn(),
-    }
-  })
+const {
+  createWorkoutLogTrigger,
+  createWorkoutLogUnwrap,
+  mutationStateRef,
+  navigateMock,
+  reportClientErrorMock,
+} = vi.hoisted(() => {
+  const createWorkoutLogUnwrap = vi.fn()
+  return {
+    createWorkoutLogUnwrap,
+    // Typed via the generic so `mock.calls[0][0]` is a CreateWorkoutLogRequest;
+    // the impl ignores the body (no unused param).
+    createWorkoutLogTrigger: vi.fn<
+      (body: CreateWorkoutLogRequest) => { unwrap: () => Promise<{ workoutLogId: string }> }
+    >(() => ({ unwrap: createWorkoutLogUnwrap })),
+    mutationStateRef: { isLoading: false },
+    navigateMock: vi.fn(),
+    reportClientErrorMock: vi.fn(),
+  }
+})
 
 vi.mock('~/api/workout-log.api', () => ({
   useCreateWorkoutLogMutation: () => [createWorkoutLogTrigger, mutationStateRef],
+}))
+
+vi.mock('~/error-boundary/report-client-error', () => ({
+  reportClientError: reportClientErrorMock,
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -67,6 +77,7 @@ describe('LogPage', () => {
     createWorkoutLogUnwrap.mockResolvedValue({ workoutLogId: 'log-1' })
     mutationStateRef.isLoading = false
     navigateMock.mockReset()
+    reportClientErrorMock.mockReset()
     vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-0000-0000-00000000abcd')
   })
 
@@ -145,14 +156,21 @@ describe('LogPage', () => {
     expect(createWorkoutLogTrigger.mock.calls[0][0].metrics).toEqual({ hrAvg: 150 })
   })
 
-  it('shows a form-level alert and does not navigate when the create fails', async () => {
-    createWorkoutLogUnwrap.mockRejectedValue(new Error('boom'))
+  it('shows a form-level alert, reports the error, and does not navigate when the create fails', async () => {
+    const failure = new Error('boom')
+    createWorkoutLogUnwrap.mockRejectedValue(failure)
     const { user } = renderPage()
     await fillCoreFields(user)
     await clickSave(user)
 
     expect(await screen.findByTestId('log-form-alert')).toHaveTextContent(/could not save/i)
     expect(navigateMock).not.toHaveBeenCalled()
+    // The handled rejection is invisible to the global reporter + error boundary,
+    // so the submit handler forwards it explicitly (keeps backend failures observable).
+    expect(reportClientErrorMock).toHaveBeenCalledWith({
+      kind: 'unhandled-rejection',
+      error: failure,
+    })
   })
 
   it('reuses the same idempotency key across a retry after a transient failure', async () => {

--- a/frontend/src/app/modules/logging/pages/log.page.spec.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.spec.tsx
@@ -1,0 +1,191 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { toast } from 'sonner'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Toaster } from '@/components/ui/sonner'
+import type { CreateWorkoutLogRequest } from '~/api/generated'
+import { toIsoDateOnly } from '~/modules/logging/schemas/workout-log-form.schema'
+
+// vi.mock is hoisted above imports, so the mock fns must come from vi.hoisted.
+const { createWorkoutLogTrigger, createWorkoutLogUnwrap, mutationStateRef, navigateMock } =
+  vi.hoisted(() => {
+    const createWorkoutLogUnwrap = vi.fn()
+    return {
+      createWorkoutLogUnwrap,
+      // Typed via the generic so `mock.calls[0][0]` is a CreateWorkoutLogRequest;
+      // the impl ignores the body (no unused param).
+      createWorkoutLogTrigger: vi.fn<
+        (body: CreateWorkoutLogRequest) => { unwrap: () => Promise<{ workoutLogId: string }> }
+      >(() => ({ unwrap: createWorkoutLogUnwrap })),
+      mutationStateRef: { isLoading: false },
+      navigateMock: vi.fn(),
+    }
+  })
+
+vi.mock('~/api/workout-log.api', () => ({
+  useCreateWorkoutLogMutation: () => [createWorkoutLogTrigger, mutationStateRef],
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+// Component under test imported after the mocks.
+import LogPage from './log.page'
+
+const renderPage = () => {
+  const user = userEvent.setup()
+  const utils = render(
+    <MemoryRouter initialEntries={['/log']}>
+      <LogPage />
+      {/* App-wide toast outlet (mounted outside the route tree in production);
+          included here so the success toast actually renders. */}
+      <Toaster />
+    </MemoryRouter>,
+  )
+  return { user, ...utils }
+}
+
+const fillCoreFields = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.type(screen.getByLabelText('Distance (km)'), '5')
+  await user.type(screen.getByLabelText('Duration (minutes)'), '30')
+}
+
+const clickSave = async (user: ReturnType<typeof userEvent.setup>) => {
+  const submit = screen.getByTestId('log-form-submit')
+  await waitFor(() => expect(submit).toBeEnabled())
+  await user.click(submit)
+}
+
+describe('LogPage', () => {
+  beforeEach(() => {
+    createWorkoutLogTrigger.mockClear()
+    createWorkoutLogUnwrap.mockReset()
+    createWorkoutLogUnwrap.mockResolvedValue({ workoutLogId: 'log-1' })
+    mutationStateRef.isLoading = false
+    navigateMock.mockReset()
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-0000-0000-00000000abcd')
+  })
+
+  afterEach(() => {
+    toast.dismiss()
+    vi.restoreAllMocks()
+  })
+
+  it('renders the core fields with optional metrics collapsed by default', () => {
+    renderPage()
+    expect(screen.getByLabelText('Date')).toBeInTheDocument()
+    expect(screen.getByLabelText('Distance (km)')).toBeInTheDocument()
+    expect(screen.getByLabelText('Duration (minutes)')).toBeInTheDocument()
+    const moreDetails = screen.getByRole('button', { name: /more details/i })
+    expect(moreDetails).toHaveAttribute('aria-expanded', 'false')
+    // Optional metrics are not in the DOM until "More details" is expanded.
+    expect(screen.queryByLabelText('RPE')).toBeNull()
+  })
+
+  it('defaults the occurred-on date to today', () => {
+    renderPage()
+    const dateInput = screen.getByLabelText('Date') as HTMLInputElement
+    expect(dateInput.value).toBe(toIsoDateOnly(new Date()))
+  })
+
+  it('shows an inline role=alert error for a missing distance and does not submit', async () => {
+    renderPage()
+    const form = document.querySelector('form') as HTMLFormElement
+    fireEvent.submit(form)
+
+    const message = await screen.findByText('Enter a distance in km.')
+    expect(message).toHaveAttribute('role', 'alert')
+    expect(createWorkoutLogTrigger).not.toHaveBeenCalled()
+  })
+
+  it('submits a minimum payload, shows a success toast, and navigates home', async () => {
+    const { user } = renderPage()
+    await fillCoreFields(user)
+    await clickSave(user)
+
+    await waitFor(() => expect(createWorkoutLogTrigger).toHaveBeenCalledTimes(1))
+    expect(createWorkoutLogTrigger).toHaveBeenCalledWith({
+      idempotencyKey: '00000000-0000-0000-0000-00000000abcd',
+      occurredOn: toIsoDateOnly(new Date()),
+      distanceMeters: 5000,
+      durationSeconds: 1800,
+      completionStatus: 0,
+    })
+    expect(await screen.findByText('Workout logged')).toBeInTheDocument()
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/', { replace: true }))
+  })
+
+  it('omits a blank optional metric (rpe) while including a filled one (hrAvg)', async () => {
+    const { user } = renderPage()
+    await fillCoreFields(user)
+    await user.click(screen.getByRole('button', { name: /more details/i }))
+    await user.type(screen.getByLabelText('Avg HR (bpm)'), '150')
+    // RPE deliberately left blank.
+    await clickSave(user)
+
+    await waitFor(() => expect(createWorkoutLogTrigger).toHaveBeenCalledTimes(1))
+    expect(createWorkoutLogTrigger.mock.calls[0][0].metrics).toEqual({ hrAvg: 150 })
+  })
+
+  it('still submits a metric that was filled then collapsed (shouldUnregister: false)', async () => {
+    const { user } = renderPage()
+    await fillCoreFields(user)
+    const moreDetails = screen.getByRole('button', { name: /more details/i })
+    await user.click(moreDetails)
+    await user.type(screen.getByLabelText('Avg HR (bpm)'), '150')
+    await user.click(moreDetails)
+    await waitFor(() => expect(moreDetails).toHaveAttribute('aria-expanded', 'false'))
+    await clickSave(user)
+
+    await waitFor(() => expect(createWorkoutLogTrigger).toHaveBeenCalledTimes(1))
+    expect(createWorkoutLogTrigger.mock.calls[0][0].metrics).toEqual({ hrAvg: 150 })
+  })
+
+  it('shows a form-level alert and does not navigate when the create fails', async () => {
+    createWorkoutLogUnwrap.mockRejectedValue(new Error('boom'))
+    const { user } = renderPage()
+    await fillCoreFields(user)
+    await clickSave(user)
+
+    expect(await screen.findByTestId('log-form-alert')).toHaveTextContent(/could not save/i)
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it('reuses the same idempotency key across a retry after a transient failure', async () => {
+    // Incrementing UUID stub: a per-submit randomUUID() would produce different
+    // keys and fail the assertion; useMemo pins it to one value per mounted form.
+    let callCount = 0
+    vi.spyOn(crypto, 'randomUUID').mockImplementation(
+      () =>
+        `00000000-0000-0000-0000-${String(++callCount).padStart(12, '0')}` as ReturnType<
+          typeof crypto.randomUUID
+        >,
+    )
+    createWorkoutLogUnwrap
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValue({ workoutLogId: 'log-1' })
+
+    const { user } = renderPage()
+    await fillCoreFields(user)
+    await clickSave(user)
+    expect(await screen.findByTestId('log-form-alert')).toBeInTheDocument()
+    await clickSave(user)
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled())
+    expect(createWorkoutLogTrigger).toHaveBeenCalledTimes(2)
+    const [first, second] = createWorkoutLogTrigger.mock.calls
+    expect(first[0].idempotencyKey).toBe(second[0].idempotencyKey)
+  })
+
+  it('disables the submit button and shows progress copy while creating', () => {
+    mutationStateRef.isLoading = true
+    renderPage()
+    const submit = screen.getByTestId('log-form-submit')
+    expect(submit).toBeDisabled()
+    expect(submit).toHaveTextContent(/saving/i)
+  })
+})

--- a/frontend/src/app/modules/logging/pages/log.page.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { toast } from 'sonner'
 
 import { useCreateWorkoutLogMutation } from '~/api/workout-log.api'
+import { reportClientError } from '~/error-boundary/report-client-error'
 import { LogForm } from '~/modules/logging/components/log-form.component'
 import {
   makeDefaultWorkoutLogFormFields,
@@ -43,7 +44,16 @@ const LogPage = () => {
       await createWorkoutLog(toCreateWorkoutLogRequest(values, idempotencyKey)).unwrap()
       toast.success('Workout logged')
       navigate('/', { replace: true })
-    } catch {
+    } catch (error) {
+      // The awaited `.unwrap()` rejection is a *handled* rejection, so neither
+      // `useGlobalErrorReporter` (window `unhandledrejection`) nor
+      // `AppErrorBoundary` (render-phase throw) sees it. Forward it to the
+      // fire-and-forget client error reporter so a "could not save" the user
+      // reports still leaves a diagnostic trail.
+      reportClientError({
+        kind: 'unhandled-rejection',
+        error: error instanceof Error ? error : new Error(String(error)),
+      })
       setFormAlert('We could not save your workout. Please try again in a moment.')
     }
   }

--- a/frontend/src/app/modules/logging/pages/log.page.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.tsx
@@ -1,0 +1,66 @@
+import { useMemo, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { toast } from 'sonner'
+
+import { useCreateWorkoutLogMutation } from '~/api/workout-log.api'
+import { LogForm } from '~/modules/logging/components/log-form.component'
+import {
+  makeDefaultWorkoutLogFormFields,
+  toCreateWorkoutLogRequest,
+  workoutLogFormSchema,
+  type WorkoutLogFormFields,
+  type WorkoutLogFormValues,
+} from '~/modules/logging/schemas/workout-log-form.schema'
+
+/**
+ * The `/log` route — a mobile-first workout-logging form. Owns the form state,
+ * the create mutation, and post-submit navigation. Create is pessimistic
+ * (DEC-075): await success → success toast → navigate home; the mutation
+ * invalidates the `WorkoutLog` tag so history (PR7) refetches. `OccurredOn`
+ * defaults to today; the prescription snapshot is resolved server-side, so the
+ * form never sends prescribed values (DEC-076).
+ */
+const LogPage = () => {
+  const navigate = useNavigate()
+  const [createWorkoutLog, { isLoading }] = useCreateWorkoutLogMutation()
+  const [formAlert, setFormAlert] = useState<string | null>(null)
+  // One key per mounted form so a retry after a transient failure reuses it and
+  // the server dedupes rather than double-logging (DEC-077).
+  const idempotencyKey = useMemo(() => crypto.randomUUID(), [])
+
+  const form = useForm<WorkoutLogFormFields, unknown, WorkoutLogFormValues>({
+    resolver: zodResolver(workoutLogFormSchema),
+    mode: 'onChange',
+    shouldUnregister: false,
+    defaultValues: makeDefaultWorkoutLogFormFields(),
+  })
+
+  const onSubmit = async (values: WorkoutLogFormValues): Promise<void> => {
+    setFormAlert(null)
+    try {
+      await createWorkoutLog(toCreateWorkoutLogRequest(values, idempotencyKey)).unwrap()
+      toast.success('Workout logged')
+      navigate('/', { replace: true })
+    } catch {
+      setFormAlert('We could not save your workout. Please try again in a moment.')
+    }
+  }
+
+  return (
+    <main
+      className="mx-auto flex min-h-screen w-full max-w-md flex-col gap-6 bg-background px-4 py-8"
+      data-testid="log-page"
+    >
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold text-foreground">Log a workout</h1>
+        <p className="text-sm text-muted-foreground">Record what you actually ran.</p>
+      </header>
+      <LogForm form={form} onSubmit={onSubmit} isLoading={isLoading} formAlert={formAlert} />
+    </main>
+  )
+}
+
+export default LogPage
+export { LogPage }

--- a/frontend/src/app/modules/logging/schemas/workout-log-form.schema.spec.ts
+++ b/frontend/src/app/modules/logging/schemas/workout-log-form.schema.spec.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  makeDefaultWorkoutLogFormFields,
+  toCreateWorkoutLogRequest,
+  toIsoDateOnly,
+  workoutLogFormSchema,
+  type WorkoutLogFormFields,
+} from './workout-log-form.schema'
+
+// Local-time Date so toIsoDateOnly is timezone-stable on CI.
+const FIXED_DATE = new Date(2026, 5, 6)
+
+const fields = (overrides: Partial<WorkoutLogFormFields> = {}): WorkoutLogFormFields => ({
+  ...makeDefaultWorkoutLogFormFields(FIXED_DATE),
+  ...overrides,
+})
+
+describe('toIsoDateOnly', () => {
+  it('formats a date as local YYYY-MM-DD (not UTC)', () => {
+    expect(toIsoDateOnly(new Date(2026, 0, 5))).toBe('2026-01-05')
+  })
+})
+
+describe('makeDefaultWorkoutLogFormFields', () => {
+  it('defaults occurredOn to the given date and completion to Complete, everything else blank', () => {
+    expect(makeDefaultWorkoutLogFormFields(FIXED_DATE)).toEqual({
+      occurredOn: '2026-06-06',
+      completionStatus: '0',
+      distanceKm: '',
+      durationMinutes: '',
+      notes: '',
+      rpe: '',
+      hrAvg: '',
+      hrMax: '',
+      elevationGain: '',
+    })
+  })
+})
+
+describe('workoutLogFormSchema', () => {
+  it('accepts a minimum payload (distance + duration only) with optional metrics undefined', () => {
+    const result = workoutLogFormSchema.safeParse(
+      fields({ distanceKm: '5', durationMinutes: '30' }),
+    )
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data).toMatchObject({
+      occurredOn: '2026-06-06',
+      completionStatus: 0,
+      distanceKm: 5,
+      durationMinutes: 30,
+    })
+    expect(result.data.rpe).toBeUndefined()
+    expect(result.data.hrAvg).toBeUndefined()
+    expect(result.data.notes).toBeUndefined()
+  })
+
+  it('resolves a blank optional numeric to undefined, never 0 or NaN', () => {
+    const parsed = workoutLogFormSchema.parse(
+      fields({ distanceKm: '5', durationMinutes: '30', rpe: '   ' }),
+    )
+    expect(parsed.rpe).toBeUndefined()
+  })
+
+  it('keeps an explicit 0 (elevation gain) as 0 rather than dropping it', () => {
+    const parsed = workoutLogFormSchema.parse(
+      fields({ distanceKm: '5', durationMinutes: '30', elevationGain: '0' }),
+    )
+    expect(parsed.elevationGain).toBe(0)
+  })
+
+  it('coerces the completion status string to its numeric enum value', () => {
+    const parsed = workoutLogFormSchema.parse(
+      fields({ completionStatus: '1', distanceKm: '5', durationMinutes: '30' }),
+    )
+    expect(parsed.completionStatus).toBe(1)
+  })
+
+  it('requires distance when the workout is not Skipped', () => {
+    const result = workoutLogFormSchema.safeParse(fields({ distanceKm: '', durationMinutes: '30' }))
+
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error.issues.some((issue) => issue.path[0] === 'distanceKm')).toBe(true)
+  })
+
+  it('rejects a zero distance for a completed run (must be greater than zero)', () => {
+    const result = workoutLogFormSchema.safeParse(
+      fields({ distanceKm: '0', durationMinutes: '30' }),
+    )
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a non-numeric distance', () => {
+    const result = workoutLogFormSchema.safeParse(
+      fields({ distanceKm: 'abc', durationMinutes: '30' }),
+    )
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an RPE outside 1–10', () => {
+    const result = workoutLogFormSchema.safeParse(
+      fields({ distanceKm: '5', durationMinutes: '30', rpe: '11' }),
+    )
+    expect(result.success).toBe(false)
+  })
+
+  it('allows a Skipped workout to omit distance and duration', () => {
+    const result = workoutLogFormSchema.safeParse(
+      fields({ completionStatus: '2', distanceKm: '', durationMinutes: '' }),
+    )
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.completionStatus).toBe(2)
+    expect(result.data.distanceKm).toBeUndefined()
+    expect(result.data.durationMinutes).toBeUndefined()
+  })
+})
+
+describe('toCreateWorkoutLogRequest', () => {
+  it('maps km→meters, minutes→seconds, trims notes, and builds the metrics bag from present values', () => {
+    const parsed = workoutLogFormSchema.parse(
+      fields({
+        distanceKm: '5',
+        durationMinutes: '30',
+        notes: '  felt strong  ',
+        rpe: '6',
+        hrAvg: '142',
+      }),
+    )
+
+    expect(toCreateWorkoutLogRequest(parsed, 'idem-1')).toEqual({
+      idempotencyKey: 'idem-1',
+      occurredOn: '2026-06-06',
+      distanceMeters: 5000,
+      durationSeconds: 1800,
+      completionStatus: 0,
+      notes: 'felt strong',
+      metrics: { rpe: 6, hrAvg: 142 },
+    })
+  })
+
+  it('omits notes and metrics entirely when none are provided', () => {
+    const parsed = workoutLogFormSchema.parse(fields({ distanceKm: '5', durationMinutes: '30' }))
+    const body = toCreateWorkoutLogRequest(parsed, 'idem-1')
+
+    expect(body.notes).toBeUndefined()
+    expect(body.metrics).toBeUndefined()
+    expect(Object.keys(body)).toEqual([
+      'idempotencyKey',
+      'occurredOn',
+      'distanceMeters',
+      'durationSeconds',
+      'completionStatus',
+    ])
+  })
+
+  it('sends zero distance/duration for a Skipped workout with blank fields', () => {
+    const parsed = workoutLogFormSchema.parse(
+      fields({ completionStatus: '2', distanceKm: '', durationMinutes: '' }),
+    )
+    const body = toCreateWorkoutLogRequest(parsed, 'idem-1')
+
+    expect(body.distanceMeters).toBe(0)
+    expect(body.durationSeconds).toBe(0)
+    expect(body.completionStatus).toBe(2)
+  })
+})

--- a/frontend/src/app/modules/logging/schemas/workout-log-form.schema.spec.ts
+++ b/frontend/src/app/modules/logging/schemas/workout-log-form.schema.spec.ts
@@ -168,4 +168,18 @@ describe('toCreateWorkoutLogRequest', () => {
     expect(body.durationSeconds).toBe(0)
     expect(body.completionStatus).toBe(2)
   })
+
+  it('passes typed distance/duration through for a Skipped workout (WYSIWYG, not zeroed)', () => {
+    // The distance/duration inputs stay rendered when Skipped is selected, so a
+    // typed value remains visible to the user; the mapper ships what they see
+    // rather than silently zeroing it. Pins the deliberate pass-through semantics.
+    const parsed = workoutLogFormSchema.parse(
+      fields({ completionStatus: '2', distanceKm: '5', durationMinutes: '30' }),
+    )
+    const body = toCreateWorkoutLogRequest(parsed, 'idem-1')
+
+    expect(body.distanceMeters).toBe(5000)
+    expect(body.durationSeconds).toBe(1800)
+    expect(body.completionStatus).toBe(2)
+  })
 })

--- a/frontend/src/app/modules/logging/schemas/workout-log-form.schema.ts
+++ b/frontend/src/app/modules/logging/schemas/workout-log-form.schema.ts
@@ -1,0 +1,174 @@
+import type { Control } from 'react-hook-form'
+import { z } from 'zod'
+
+import {
+  CompletionStatus,
+  completionStatusSchema,
+  createWorkoutLogRequestSchema,
+  type CreateWorkoutLogRequest,
+} from '~/api/generated'
+import { FORM_METRIC_KEYS } from '~/modules/logging/metric-meta'
+
+// DEC-075 form conventions. The `/log` form holds every field as a STRING (the
+// natural shape of `<input>` values), and the schema transforms each into the
+// validated, typed output the submit handler consumes — so `z.input` is the
+// loose string form and `z.output` is the strict typed form (the
+// `useForm<Input, any, Output>` shape DEC-075 mandates). Blank optional numerics
+// resolve to `undefined`, never `0`/`NaN`: the empty check runs BEFORE `Number`,
+// so we never hit the `Number('') === 0` / `z.coerce.number()` footgun.
+
+interface NumericFieldOptions {
+  min: number
+  max: number
+  /** When true, `min` is a strict lower bound (value must be > min, not >= min). */
+  minExclusive?: boolean
+  label: string
+}
+
+const lowerBoundPhrase = ({ min, minExclusive }: NumericFieldOptions): string => {
+  if (!minExclusive) return `at least ${min}`
+  return min === 0 ? 'greater than zero' : `greater than ${min}`
+}
+
+const rangeMessage = (options: NumericFieldOptions): string =>
+  `Enter a ${options.label} ${lowerBoundPhrase(options)} and at most ${options.max}.`
+
+/**
+ * A string-backed numeric form field. Blank → `undefined` (the field is optional
+ * at this level; required-ness for distance/duration is enforced by the
+ * form-level refine below so it can depend on completion status). A non-blank
+ * value must parse to a finite number within the configured range.
+ */
+const numericField = (options: NumericFieldOptions) =>
+  z
+    .string()
+    .superRefine((raw, ctx) => {
+      const value = raw.trim()
+      if (value === '') return
+      const parsed = Number(value)
+      if (!Number.isFinite(parsed)) {
+        ctx.addIssue({ code: 'custom', message: `Enter a valid ${options.label}.` })
+        return
+      }
+      const tooLow = options.minExclusive ? parsed <= options.min : parsed < options.min
+      if (tooLow || parsed > options.max) {
+        ctx.addIssue({ code: 'custom', message: rangeMessage(options) })
+      }
+    })
+    .transform((raw) => {
+      const value = raw.trim()
+      return value === '' ? undefined : Number(value)
+    })
+
+// The form schema is DERIVED from the generated request body via `.pick().extend()`
+// (DEC-075, the first such derivation in the repo). Picking `occurredOn` keeps
+// its ISO-date format honest against the backend; `completionStatus` is rebuilt
+// off the generated `0|1|2` union (via `completionStatusSchema`) so the enum
+// can't drift. The remaining fields are UI-shaped (km / minutes rather than the
+// wire's meters / seconds, plus the self-reportable optional metrics) and are
+// mapped down to the wire contract by `toCreateWorkoutLogRequest`.
+export const workoutLogFormSchema = createWorkoutLogRequestSchema
+  .pick({ occurredOn: true })
+  .extend({
+    completionStatus: z
+      .string()
+      .transform((raw) => Number(raw))
+      .pipe(completionStatusSchema),
+    distanceKm: numericField({ min: 0, minExclusive: true, max: 1000, label: 'distance in km' }),
+    durationMinutes: numericField({
+      min: 0,
+      minExclusive: true,
+      max: 1440,
+      label: 'duration in minutes',
+    }),
+    notes: z.string().transform((raw) => {
+      const value = raw.trim()
+      return value.length === 0 ? undefined : value
+    }),
+    rpe: numericField({ min: 1, max: 10, label: 'RPE' }),
+    hrAvg: numericField({ min: 1, max: 300, label: 'average heart rate' }),
+    hrMax: numericField({ min: 1, max: 300, label: 'maximum heart rate' }),
+    elevationGain: numericField({ min: 0, max: 100000, label: 'elevation gain' }),
+  })
+  .superRefine((values, ctx) => {
+    // Distance + duration are required for a Complete/Partial run but optional
+    // for a Skipped one (it resolves to 0 m / 0 s on the wire). Spec § Unit 6
+    // open-question resolution.
+    if (values.completionStatus === CompletionStatus.Skipped) return
+    if (values.distanceKm === undefined) {
+      ctx.addIssue({ code: 'custom', path: ['distanceKm'], message: 'Enter a distance in km.' })
+    }
+    if (values.durationMinutes === undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['durationMinutes'],
+        message: 'Enter a duration in minutes.',
+      })
+    }
+  })
+
+/** Form state shape (every field a string — the raw `<input>` value). */
+export type WorkoutLogFormFields = z.input<typeof workoutLogFormSchema>
+
+/** Validated, typed output handed to the submit handler. */
+export type WorkoutLogFormValues = z.output<typeof workoutLogFormSchema>
+
+/**
+ * The form's `control` type. Spelled out with all three RHF generics because
+ * input (strings) ≠ output (coerced) — field components take this concrete
+ * alias rather than a `Control<TValues>` default that would collapse the
+ * transformed generic back to the string fields.
+ */
+export type WorkoutLogFormControl = Control<WorkoutLogFormFields, unknown, WorkoutLogFormValues>
+
+/** Local-calendar `YYYY-MM-DD` (never UTC — `toISOString` would shift the date). */
+export const toIsoDateOnly = (date: Date): string => {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+/** Fresh form defaults: today's date, Complete status, every other field blank. */
+export const makeDefaultWorkoutLogFormFields = (
+  today: Date = new Date(),
+): WorkoutLogFormFields => ({
+  occurredOn: toIsoDateOnly(today),
+  completionStatus: String(CompletionStatus.Complete),
+  distanceKm: '',
+  durationMinutes: '',
+  notes: '',
+  rpe: '',
+  hrAvg: '',
+  hrMax: '',
+  elevationGain: '',
+})
+
+/**
+ * Maps validated form values down to the wire contract: km → meters, minutes →
+ * seconds, present optional metrics into the open `metrics` bag (absent ones
+ * omitted entirely — never sent as `0`). The `idempotencyKey` is supplied by the
+ * caller so it stays stable across retries of the same logical submit (DEC-077).
+ */
+export const toCreateWorkoutLogRequest = (
+  values: WorkoutLogFormValues,
+  idempotencyKey: string,
+): CreateWorkoutLogRequest => {
+  const metrics: Record<string, number> = {}
+  for (const key of FORM_METRIC_KEYS) {
+    const value = values[key]
+    if (value !== undefined) {
+      metrics[key] = value
+    }
+  }
+
+  return {
+    idempotencyKey,
+    occurredOn: values.occurredOn,
+    distanceMeters: (values.distanceKm ?? 0) * 1000,
+    durationSeconds: (values.durationMinutes ?? 0) * 60,
+    completionStatus: values.completionStatus,
+    ...(values.notes !== undefined ? { notes: values.notes } : {}),
+    ...(Object.keys(metrics).length > 0 ? { metrics } : {}),
+  }
+}

--- a/frontend/src/app/modules/logging/schemas/workout-log-form.schema.ts
+++ b/frontend/src/app/modules/logging/schemas/workout-log-form.schema.ts
@@ -149,6 +149,12 @@ export const makeDefaultWorkoutLogFormFields = (
  * seconds, present optional metrics into the open `metrics` bag (absent ones
  * omitted entirely — never sent as `0`). The `idempotencyKey` is supplied by the
  * caller so it stays stable across retries of the same logical submit (DEC-077).
+ *
+ * Distance/duration are pass-through, not status-gated: a Skipped workout that
+ * still carries a typed distance/duration sends those values unchanged. The
+ * fields stay rendered on every status (they are never reset or hidden when
+ * Skipped is selected), so this is WYSIWYG — the visible value is what ships.
+ * Only a blank field resolves to the `0` wire fallback.
  */
 export const toCreateWorkoutLogRequest = (
   values: WorkoutLogFormValues,

--- a/frontend/src/app/modules/plan/components/today-card.component.spec.tsx
+++ b/frontend/src/app/modules/plan/components/today-card.component.spec.tsx
@@ -1,7 +1,17 @@
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
-import { TodayCard } from './today-card.component'
+import { TodayCard, type TodayCardProps } from './today-card.component'
 import { buildPlanFixture, fixtureWeekOneWorkouts } from './plan-display.fixture'
+
+// TodayCard renders a <Link> in its workout variant, so every render needs a
+// Router context.
+const renderCard = (props: TodayCardProps) =>
+  render(
+    <MemoryRouter>
+      <TodayCard {...props} />
+    </MemoryRouter>,
+  )
 
 describe('TodayCard', () => {
   // Local Sunday April 2026-04-26 = day-of-week 0; test seed dates here
@@ -14,13 +24,11 @@ describe('TodayCard', () => {
 
   it('renders the workout variant when today is a run day', () => {
     const plan = buildPlanFixture()
-    render(
-      <TodayCard
-        currentWeek={plan.mesoWeeks[0]}
-        workouts={fixtureWeekOneWorkouts()}
-        today={monday}
-      />,
-    )
+    renderCard({
+      currentWeek: plan.mesoWeeks[0],
+      workouts: fixtureWeekOneWorkouts(),
+      today: monday,
+    })
     const card = screen.getByTestId('today-card')
     expect(card.dataset.variant).toBe('workout')
     expect(screen.getByRole('heading', { name: 'Easy aerobic shakeout' })).toBeInTheDocument()
@@ -28,15 +36,25 @@ describe('TodayCard', () => {
     expect(inner.dataset.emphasized).toBe('true')
   })
 
+  it('renders a "Log run" action linking to /log in the workout variant', () => {
+    const plan = buildPlanFixture()
+    renderCard({
+      currentWeek: plan.mesoWeeks[0],
+      workouts: fixtureWeekOneWorkouts(),
+      today: monday,
+    })
+    const logAction = screen.getByTestId('today-card-log-action')
+    expect(logAction).toHaveAttribute('href', '/log')
+    expect(logAction).toHaveTextContent(/log run/i)
+  })
+
   it('renders the rest-day variant on a rest slot, calling out the next workout', () => {
     const plan = buildPlanFixture()
-    render(
-      <TodayCard
-        currentWeek={plan.mesoWeeks[0]}
-        workouts={fixtureWeekOneWorkouts()}
-        today={sunday}
-      />,
-    )
+    renderCard({
+      currentWeek: plan.mesoWeeks[0],
+      workouts: fixtureWeekOneWorkouts(),
+      today: sunday,
+    })
     const card = screen.getByTestId('today-card')
     expect(card.dataset.variant).toBe('rest')
     const next = screen.getByTestId('today-card-next-workout')
@@ -44,15 +62,23 @@ describe('TodayCard', () => {
     expect(next.textContent).toMatch(/easy aerobic shakeout/iu)
   })
 
+  it('does not render a Log action in the rest-day variant', () => {
+    const plan = buildPlanFixture()
+    renderCard({
+      currentWeek: plan.mesoWeeks[0],
+      workouts: fixtureWeekOneWorkouts(),
+      today: sunday,
+    })
+    expect(screen.queryByTestId('today-card-log-action')).toBeNull()
+  })
+
   it('renders the rest-day variant when slot is Rest even on a midweek day', () => {
     const plan = buildPlanFixture()
-    render(
-      <TodayCard
-        currentWeek={plan.mesoWeeks[0]}
-        workouts={fixtureWeekOneWorkouts()}
-        today={thursday}
-      />,
-    )
+    renderCard({
+      currentWeek: plan.mesoWeeks[0],
+      workouts: fixtureWeekOneWorkouts(),
+      today: thursday,
+    })
     const card = screen.getByTestId('today-card')
     expect(card.dataset.variant).toBe('rest')
     const next = screen.getByTestId('today-card-next-workout')
@@ -61,13 +87,11 @@ describe('TodayCard', () => {
 
   it('shows interval session details when today is the threshold day', () => {
     const plan = buildPlanFixture()
-    render(
-      <TodayCard
-        currentWeek={plan.mesoWeeks[0]}
-        workouts={fixtureWeekOneWorkouts()}
-        today={wednesday}
-      />,
-    )
+    renderCard({
+      currentWeek: plan.mesoWeeks[0],
+      workouts: fixtureWeekOneWorkouts(),
+      today: wednesday,
+    })
     expect(screen.getByRole('heading', { name: 'Threshold intervals' })).toBeInTheDocument()
   })
 
@@ -76,13 +100,11 @@ describe('TodayCard', () => {
     // contains no dayOfWeek=5 entry, exercising the graceful-degradation branch.
     const friday = new Date(2026, 3, 24) // 2026-04-24 is a Friday
     const plan = buildPlanFixture()
-    render(
-      <TodayCard
-        currentWeek={plan.mesoWeeks[0]}
-        workouts={fixtureWeekOneWorkouts()}
-        today={friday}
-      />,
-    )
+    renderCard({
+      currentWeek: plan.mesoWeeks[0],
+      workouts: fixtureWeekOneWorkouts(),
+      today: friday,
+    })
     const card = screen.getByTestId('today-card')
     expect(card.dataset.variant).toBe('rest')
     expect(screen.getByText('Rest day — recover well.')).toBeInTheDocument()
@@ -94,13 +116,11 @@ describe('TodayCard', () => {
 
   it('contains zero VDOT references in the rendered DOM (trademark rule)', () => {
     const plan = buildPlanFixture()
-    const { container } = render(
-      <TodayCard
-        currentWeek={plan.mesoWeeks[0]}
-        workouts={fixtureWeekOneWorkouts()}
-        today={wednesday}
-      />,
-    )
+    const { container } = renderCard({
+      currentWeek: plan.mesoWeeks[0],
+      workouts: fixtureWeekOneWorkouts(),
+      today: wednesday,
+    })
     expect(container.textContent ?? '').not.toMatch(/vdot/iu)
   })
 })

--- a/frontend/src/app/modules/plan/components/today-card.component.tsx
+++ b/frontend/src/app/modules/plan/components/today-card.component.tsx
@@ -1,4 +1,6 @@
 import type { ReactElement } from 'react'
+import { Link } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
 import type { MesoWeekTemplateDto, MicroWorkoutCardDto } from '~/modules/plan/models/plan.model'
 import {
   DAY_OF_WEEK_LABELS,
@@ -62,6 +64,9 @@ export const TodayCard = ({
           </span>
         </header>
         <MicroWorkoutCard workout={todaysWorkout} emphasized={true} />
+        <Button asChild size="sm" className="self-start" data-testid="today-card-log-action">
+          <Link to="/log">Log run</Link>
+        </Button>
       </section>
     )
   }

--- a/frontend/src/components/ui/form.tsx
+++ b/frontend/src/components/ui/form.tsx
@@ -27,9 +27,14 @@ const FormFieldContext = React.createContext<FormFieldContextValue | null>(null)
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  // Third generic forwarded to RHF's Controller so a form whose resolver
+  // transforms values (input ≠ output, e.g. the workout-log form's
+  // string → number coercion, DEC-075) can pass its `control` here. Defaults
+  // to `TFieldValues`, so single-generic forms are unaffected.
+  TTransformedValues = TFieldValues,
 >({
   ...props
-}: ControllerProps<TFieldValues, TName>) => {
+}: ControllerProps<TFieldValues, TName, TTransformedValues>) => {
   return (
     <FormFieldContext.Provider value={{ name: props.name }}>
       <Controller {...props} />


### PR DESCRIPTION
## Slice 2b — PR6b (`/log` route + logging form)

PR6b of the [8-PR slice-2b train](docs/specs/16-spec-slice-2b-workout-logging/pr-strategy.md). 6 of 8 already merged (PR1/PR6a/PR2/PR3/PR4/PR5); this is **Unit 6 — the frontend `/log` route + form**. PR7 (history list + E2E) follows.

### What this delivers
- **`/log` route** (auth + onboarding guarded, mirrors the home route's guard) — a mobile-first single-column logging form.
- **Flexible RHF + Zod form** (DEC-075): core fields (date, distance, duration, completion, notes) always visible; optional metrics (RPE, avg/max HR, elevation gain) behind an always-mounted **"More details" `Collapsible`** (default closed). `shouldUnregister: false` so a filled-then-collapsed metric still submits.
- **Schema derived from the generated request body** via `.pick().extend()` (DEC-075, first use in the repo): `occurredOn` + `completionStatus` stay drift-safe against the backend; the UI uses km / decimal-minutes mapped to meters/seconds on submit. Optional numerics resolve **empty → `undefined` (never `0`/`NaN`)**; distance + duration are required for `Complete`/`Partial`, optional for `Skipped` (→ `0` on the wire).
- **Pessimistic create** with a stable `idempotencyKey` (`useMemo`, DEC-077) → `createWorkoutLog` mutation invalidates a new `WorkoutLog` cache tag → **`Workout logged` toast** → navigate home.
- **Today-card "Log run" action** — a link to `/log` (`OccurredOn` defaults to today; the server resolves the prescription snapshot from the date).
- **Shared `metric-meta` map** mirroring backend `WorkoutMetricKeys` so form/history labels can't drift; `CompletionStatus` const/type + drift guard added to the codegen barrel.
- **`FormField` gains a backward-compatible 3rd `TTransformedValues` generic** so the input≠output (3-generic) form can use the shadcn `Form` stack; existing single-generic forms are unaffected.

### Gherkin scenarios covered
All of `frontend-log-route-and-form.feature` for the form (route renders core fields + collapsed metrics; missing-required inline `role="alert"`; minimum payload submits; empty optional numeric → `undefined`; filled-then-collapsed still submits; today-card Log action → `/log` with `OccurredOn` = today). The today-card **completed-state** scenario is **deferred to PR7** (per decision — it needs the `WorkoutLog` query consumer that PR7 builds).

### Verification
- `npm run build` (tsc + vite) ✅ · `npm run test` **409 passed** ✅ · `npm run lint` 0 errors ✅ · codegen drift gate ✅
- Multi-agent adversarial review: 20 findings → 19 refuted, 1 confirmed (positive/test-quality), 0 real defects.

### Open-question resolutions (Unit 6)
- **Skipped + zero distance/duration:** allowed (blank → `0`), required-`>0` only for Complete/Partial.
- **Off-plan UI entry:** deferred — `/log` already persists off-plan runs (server resolves a null snapshot from the date).

### Follow-ups found
- None new. (Today-card completed-state → PR7 by design.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated workout logging page with full form (date, distance, duration, completion status, notes) and save flow.
  * Added "Log run" quick-action on the daily plan card and a collapsible "More details" section for extra metrics (RPE, HR, elevation).
  * Exposed a create-workout API hook for submitting logs.

* **Bug Fixes / UX**
  * Client-side validation, deterministic idempotent submits, success toast and navigation on save; graceful error reporting.

* **Tests**
  * Comprehensive unit and integration tests covering form behavior, submission, retries, and UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->