### PR TITLE
feat(slice-2b): workout-history surface with week grouping and e2e (PR7)

### DIFF
--- a/frontend/e2e/workout-logging.spec.ts
+++ b/frontend/e2e/workout-logging.spec.ts
@@ -1,0 +1,229 @@
+import { randomUUID } from 'node:crypto'
+import { expect, test, type Page, type Route } from '@playwright/test'
+
+// Workout-logging end-to-end per spec § Unit 7 + the canonical
+// `frontend-history-list-and-e2e.feature` scenario "End-to-end
+// log-and-view-history journey".
+//
+// Strategy (mirrors plan-render.spec.ts):
+//   1. `register` hits the REAL backend so the session cookie + antiforgery
+//      pair are seeded exactly as the runtime app expects.
+//   2. `GET /api/v1/onboarding/state` is stubbed `Completed` so the route
+//      guards on `/`, `/log`, and `/history` let the user through without
+//      walking the onboarding chat.
+//   3. `GET /api/v1/plan/current` is stubbed with a populated projection so the
+//      home page renders the plan view (and therefore the "Workout history"
+//      link the user clicks to reach the surface under test).
+//   4. The slice-2b units under test are NOT stubbed: `POST .../workouts/logs`
+//      (create) and `POST .../workouts/logs/query` (history) hit the real
+//      backend. The freshly-registered user has no real plan (onboarding/plan
+//      are stubbed at the wire only), so both logs persist off-plan with a null
+//      prescription snapshot — which is a first-class supported case (DEC-076).
+//
+// The "minimum-payload" workout carries only the required core fields (no note,
+// no metrics) by definition; the "rich" workout adds an Avg HR metric and a
+// freeform note. The journey asserts both appear in the week-grouped history
+// surface and that the rich workout's note + metric render.
+
+const VALID_PASSWORD = 'Correct-Horse-9!'
+
+// Fresh email per run so the suite is re-runnable against a shared dev Postgres
+// without collisions. `npm run e2e:clean` flushes the orphans.
+const uniqueEmail = (): string => `e2e-${randomUUID()}@runcoach.test`
+
+// Wire-format integer enum duplicated from the onboarding model so the stub
+// round-trips the exact JSON the page-level Zod schema accepts.
+const OnboardingStatus = { NotStarted: 0, InProgress: 1, Completed: 2 } as const
+
+const completedPlanId = '8a4b9b2a-1d3f-4f1c-9aab-5e2c1f0b9999'
+const userId = '00000000-0000-0000-0000-000000000042'
+
+// A populated projection — just enough for the home page to render the plan
+// layout (and therefore the "Workout history" link). String literals obey the
+// trademark rule: "pace-zone index" / "Daniels-Gilbert", never "VDOT".
+const buildPlanProjection = () => {
+  const dayKeys = [
+    'sunday',
+    'monday',
+    'tuesday',
+    'wednesday',
+    'thursday',
+    'friday',
+    'saturday',
+  ] as const
+  const runSlot = { slotType: 'Run', workoutType: 'Easy', notes: '' }
+
+  const buildWorkout = (dayOfWeek: number, title: string) => ({
+    dayOfWeek,
+    workoutType: 'Easy',
+    title,
+    targetDistanceKm: 8,
+    targetDurationMinutes: 48,
+    targetPaceEasySecPerKm: 360,
+    targetPaceFastSecPerKm: 330,
+    segments: [],
+    warmupNotes: '',
+    cooldownNotes: '',
+    coachingNotes: 'Hold pace-zone index easy throughout.',
+    perceivedEffort: 4,
+  })
+
+  return {
+    planId: completedPlanId,
+    userId,
+    planStartDate: '2026-06-07',
+    generatedAt: '2026-06-07T12:00:00.000Z',
+    previousPlanId: null,
+    promptVersion: 'plan-generation-v1',
+    modelId: 'claude-sonnet-4-6',
+    macro: {
+      totalWeeks: 12,
+      goalDescription: 'Build aerobic base for a half marathon.',
+      rationale: 'Daniels-Gilbert zones drive the pace targets across phases.',
+      warnings: '',
+      phases: [
+        {
+          phaseType: 'Base',
+          weeks: 12,
+          weeklyDistanceStartKm: 30,
+          weeklyDistanceEndKm: 40,
+          intensityDistribution: '80/20',
+          allowedWorkoutTypes: ['Easy', 'LongRun', 'Recovery'],
+          targetPaceEasySecPerKm: 360,
+          targetPaceFastSecPerKm: 330,
+          notes: 'Aerobic foundation — pace-zone index easy.',
+          includesDeload: false,
+        },
+      ],
+    },
+    mesoWeeks: [
+      {
+        weekNumber: 1,
+        phaseType: 'Base',
+        weeklyTargetKm: 30,
+        isDeloadWeek: false,
+        weekSummary: 'Week 1 — pace-zone index easy mileage.',
+        ...Object.fromEntries(dayKeys.map((key) => [key, runSlot])),
+      },
+    ],
+    microWorkoutsByWeek: {
+      1: {
+        workouts: [
+          buildWorkout(0, 'Sunday long run'),
+          buildWorkout(1, 'Monday easy run'),
+          buildWorkout(2, 'Tuesday recovery jog'),
+          buildWorkout(3, 'Wednesday easy run'),
+          buildWorkout(4, 'Thursday strides'),
+          buildWorkout(5, 'Friday easy run'),
+          buildWorkout(6, 'Saturday easy run'),
+        ],
+      },
+    },
+  }
+}
+
+const installNavigationStubs = async (page: Page): Promise<void> => {
+  await page.route('**/api/v1/onboarding/state', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        userId,
+        status: OnboardingStatus.Completed,
+        currentTopic: null,
+        completedTopics: 6,
+        totalTopics: 6,
+        isComplete: true,
+        outstandingClarifications: [],
+        primaryGoal: null,
+        targetEvent: null,
+        currentFitness: null,
+        weeklySchedule: null,
+        injuryHistory: null,
+        preferences: null,
+        currentPlanId: completedPlanId,
+      }),
+    })
+  })
+
+  await page.route('**/api/v1/plan/current', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildPlanProjection()),
+    })
+  })
+}
+
+const registerAndLandHome = async (page: Page): Promise<void> => {
+  await page.goto('/register')
+  await page.getByLabel('Email').fill(uniqueEmail())
+  await page.getByLabel('Password').fill(VALID_PASSWORD)
+  await page.getByRole('button', { name: /create account/i }).click()
+  await expect(page).toHaveURL('/')
+  await expect(page.getByTestId('home-page')).toBeVisible()
+}
+
+const logWorkout = async (
+  page: Page,
+  fields: { distanceKm: string; durationMinutes: string; note?: string; avgHr?: string },
+): Promise<void> => {
+  await page.goto('/log')
+  await expect(page.getByTestId('log-form')).toBeVisible()
+  await page.getByLabel('Distance (km)').fill(fields.distanceKm)
+  await page.getByLabel('Duration (minutes)').fill(fields.durationMinutes)
+
+  if (fields.note !== undefined) {
+    await page.getByLabel('How did it go?').fill(fields.note)
+  }
+  if (fields.avgHr !== undefined) {
+    await page.getByRole('button', { name: /more details/i }).click()
+    await page.getByLabel('Avg HR (bpm)').fill(fields.avgHr)
+  }
+
+  const submit = page.getByTestId('log-form-submit')
+  await expect(submit).toBeEnabled()
+  await submit.click()
+  // Pessimistic create: the page navigates home only after a 201.
+  await expect(page).toHaveURL('/')
+}
+
+test('register → log a minimum + a rich workout → both appear in week-grouped history', async ({
+  page,
+}) => {
+  const richNote = 'Felt strong — negative-split the back half on pace-zone index easy.'
+
+  await installNavigationStubs(page)
+  await registerAndLandHome(page)
+
+  // 1. Minimum-payload workout: required core fields only (no note, no metrics).
+  await logWorkout(page, { distanceKm: '5', durationMinutes: '30' })
+
+  // 2. Rich-payload workout: adds an Avg HR metric and a freeform note.
+  await logWorkout(page, {
+    distanceKm: '8',
+    durationMinutes: '50',
+    note: richNote,
+    avgHr: '150',
+  })
+
+  // 3. Navigate to the history surface via the home link (the real UI path).
+  await page.getByTestId('home-history-link').click()
+  await expect(page).toHaveURL('/history')
+  await expect(page.getByTestId('workout-history-page')).toBeVisible()
+
+  // 4. Both logged workouts appear, grouped under a single ISO-week header
+  //    (both logged today).
+  await expect(page.getByTestId('workout-history-entry')).toHaveCount(2)
+  await expect(page.getByTestId('workout-history-week-header')).toHaveCount(1)
+  await expect(page.getByText('5.0 km')).toBeVisible()
+  await expect(page.getByText('8.0 km')).toBeVisible()
+
+  // 5. The rich workout's note + metric render in its history entry.
+  await expect(page.getByText(richNote)).toBeVisible()
+  await expect(page.getByText('150 bpm')).toBeVisible()
+
+  // 6. Trademark guard — no "VDOT" anywhere in the rendered history DOM.
+  const bodyHtml = await page.locator('body').innerHTML()
+  expect(bodyHtml.match(/vdot/gi) ?? []).toHaveLength(0)
+})

--- a/frontend/src/app/api/generated/index.ts
+++ b/frontend/src/app/api/generated/index.ts
@@ -69,6 +69,17 @@ export type CreateWorkoutLogRequest = z.infer<typeof createWorkoutLogRequestSche
 // not pulled in) so the response wire shape stays generated, not hand-mirrored.
 export type { CreateWorkoutLogResponseDto } from './rtk/api'
 
+// History read DTOs (slice-2b PR7). These are response/request *types* the
+// history surface consumes; re-exported type-only (same reasoning as
+// `CreateWorkoutLogResponseDto`) so the wire shape stays generated, not
+// hand-mirrored. A backend rename ripples here via `codegen:check` + `tsc`.
+export type {
+  QueryWorkoutLogsRequestDto,
+  QueryWorkoutLogsResponseDto,
+  WorkoutLogDto,
+  WorkoutLogSplitDto,
+} from './rtk/api'
+
 export const completionStatusSchema = createWorkoutLogRequestSchema.shape.completionStatus
 export type CompletionStatus = z.infer<typeof completionStatusSchema>
 

--- a/frontend/src/app/api/workout-log.api.spec.ts
+++ b/frontend/src/app/api/workout-log.api.spec.ts
@@ -2,7 +2,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { apiSlice } from '~/api/api-slice'
 import type { CreateWorkoutLogRequest } from '~/api/generated'
-import { workoutLogApi } from './workout-log.api'
+import { workoutLogApi, WORKOUT_HISTORY_PAGE_SIZE } from './workout-log.api'
 
 // Dispatch the endpoint thunk directly with `fetch` stubbed at the global level
 // so the `query: (body) => ({...})` factory actually executes (the page spec
@@ -66,5 +66,61 @@ describe('workoutLogApi.createWorkoutLog query factory', () => {
     expect(request.url).toContain('/api/v1/workouts/logs')
     const sentBody = await request.clone().json()
     expect(sentBody).toEqual(SAMPLE_BODY)
+  })
+})
+
+describe('workoutLogApi.getWorkoutLogHistory pagination contract', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  const historyPage = (logs: Array<Record<string, unknown>>, nextCursor: string | null): Response =>
+    jsonResponse({ logs, nextCursor })
+
+  const sentBody = async (callIndex: number): Promise<Record<string, unknown>> => {
+    const request = fetchMock.mock.calls[callIndex][0] as Request
+    return request.clone().json()
+  }
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('Request', PatchedRequest)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('threads the keyset cursor: first page sends cursor null, the next page sends the prior nextCursor', async () => {
+    fetchMock
+      .mockResolvedValueOnce(historyPage([{ workoutLogId: 'w1' }], 'cursor-1'))
+      .mockResolvedValueOnce(historyPage([{ workoutLogId: 'w2' }], null))
+    const store = makeStore()
+
+    // First (newest) page — initialPageParam is null.
+    await store.dispatch(workoutLogApi.endpoints.getWorkoutLogHistory.initiate(undefined))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(await sentBody(0)).toEqual({ limit: WORKOUT_HISTORY_PAGE_SIZE, cursor: null })
+
+    // "Load older": getNextPageParam returns the prior page's nextCursor, threaded
+    // into the next request body.
+    await store.dispatch(
+      workoutLogApi.endpoints.getWorkoutLogHistory.initiate(undefined, { direction: 'forward' }),
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(await sentBody(1)).toEqual({ limit: WORKOUT_HISTORY_PAGE_SIZE, cursor: 'cursor-1' })
+  })
+
+  it('stops paginating once nextCursor is null (getNextPageParam returns undefined)', async () => {
+    fetchMock.mockResolvedValue(historyPage([{ workoutLogId: 'w1' }], null))
+    const store = makeStore()
+
+    await store.dispatch(workoutLogApi.endpoints.getWorkoutLogHistory.initiate(undefined))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // The first page exhausted the cursor, so a forward fetch must be a no-op.
+    await store.dispatch(
+      workoutLogApi.endpoints.getWorkoutLogHistory.initiate(undefined, { direction: 'forward' }),
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/app/api/workout-log.api.ts
+++ b/frontend/src/app/api/workout-log.api.ts
@@ -1,5 +1,17 @@
 import { apiSlice } from '~/api/api-slice'
-import type { CreateWorkoutLogRequest, CreateWorkoutLogResponseDto } from '~/api/generated'
+import type {
+  CreateWorkoutLogRequest,
+  CreateWorkoutLogResponseDto,
+  QueryWorkoutLogsRequestDto,
+  QueryWorkoutLogsResponseDto,
+} from '~/api/generated'
+
+/**
+ * Logs requested per history page. The backend clamps the page size
+ * server-side (DEC-076 § C); this is the client's preferred batch for the
+ * "Load older" infinite list.
+ */
+export const WORKOUT_HISTORY_PAGE_SIZE = 20
 
 // Workout-log endpoints are injected into the root `apiSlice` so every request
 // shares the same cookie + antiforgery base query (the X-XSRF-TOKEN header is
@@ -9,10 +21,10 @@ import type { CreateWorkoutLogRequest, CreateWorkoutLogResponseDto } from '~/api
 // unused at runtime (it would double the prefix); this hand-written wrapper is
 // the consumed surface (the auth/plan/onboarding convention).
 //
-// `createWorkoutLog` invalidates the `WorkoutLog` tag so any mounted
-// workout-history query refetches after a successful log (the history surface
-// lands in PR7). The client-generated `idempotencyKey` rides inside the body
-// (DEC-077), exactly like `regeneratePlan`.
+// `createWorkoutLog` invalidates the `WorkoutLog` tag and `getWorkoutLogHistory`
+// provides it, so logging a workout refetches the mounted history list. The
+// client-generated `idempotencyKey` rides inside the create body (DEC-077),
+// exactly like `regeneratePlan`.
 export const workoutLogApi = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
     createWorkoutLog: builder.mutation<CreateWorkoutLogResponseDto, CreateWorkoutLogRequest>({
@@ -23,8 +35,35 @@ export const workoutLogApi = apiSlice.injectEndpoints({
       }),
       invalidatesTags: ['WorkoutLog'],
     }),
+    // History over the DB-driven keyset query endpoint (POST is a read here, so
+    // no antiforgery token — `base-query.ts` only adds X-XSRF-TOKEN to
+    // mutations). Each page is a `{ logs, nextCursor }` envelope; the page param
+    // is the opaque keyset cursor (`null` for the first/newest page). RTK stores
+    // the `{ pages, pageParams }` structure and the component flattens
+    // `pages.flatMap(p => p.logs)` for week grouping. `getNextPageParam`
+    // returning `undefined` (nextCursor exhausted) drives `hasNextPage = false`,
+    // hiding the "Load older" control.
+    getWorkoutLogHistory: builder.infiniteQuery<
+      QueryWorkoutLogsResponseDto,
+      undefined,
+      string | null
+    >({
+      infiniteQueryOptions: {
+        initialPageParam: null,
+        getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      },
+      query: ({ pageParam }) => ({
+        url: '/v1/workouts/logs/query',
+        method: 'POST',
+        body: {
+          limit: WORKOUT_HISTORY_PAGE_SIZE,
+          cursor: pageParam,
+        } satisfies QueryWorkoutLogsRequestDto,
+      }),
+      providesTags: ['WorkoutLog'],
+    }),
   }),
 })
 
-/** Auto-generated RTK Query hook for the workout-log create endpoint. */
-export const { useCreateWorkoutLogMutation } = workoutLogApi
+/** Auto-generated RTK Query hooks for the workout-log endpoints. */
+export const { useCreateWorkoutLogMutation, useGetWorkoutLogHistoryInfiniteQuery } = workoutLogApi

--- a/frontend/src/app/modules/app/app.component.tsx
+++ b/frontend/src/app/modules/app/app.component.tsx
@@ -9,6 +9,7 @@ import { AppErrorBoundary } from '~/error-boundary/app-error-boundary'
 import { useGlobalErrorReporter } from '~/error-boundary/use-global-error-reporter'
 import { RequireAuth } from '~/modules/auth/components/require-auth.component'
 import { useAuthBootstrap, useAuthBroadcastListener } from '~/modules/auth/hooks/auth.hooks'
+import { HistoryPage } from '~/modules/logging/pages/history.page'
 import { LogPage } from '~/modules/logging/pages/log.page'
 import { OnboardingPage } from '~/modules/onboarding/pages/onboarding.page'
 import { HomePage } from '~/modules/plan/pages/home.page'
@@ -165,6 +166,16 @@ const AppShell = () => {
             <RequireAuth>
               <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
                 <LogPage />
+              </OnboardingRedirectGuard>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/history"
+          element={
+            <RequireAuth>
+              <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
+                <HistoryPage />
               </OnboardingRedirectGuard>
             </RequireAuth>
           }

--- a/frontend/src/app/modules/logging/history/history-format.helpers.spec.ts
+++ b/frontend/src/app/modules/logging/history/history-format.helpers.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { CompletionStatus } from '~/api/generated'
+import {
+  COMPLETION_STATUS_LABELS,
+  formatDistanceKm,
+  formatDuration,
+  formatLogDate,
+  formatLogPace,
+} from './history-format.helpers'
+
+describe('formatDistanceKm', () => {
+  it('renders metres as one-decimal kilometres', () => {
+    expect(formatDistanceKm(5000)).toBe('5.0 km')
+    expect(formatDistanceKm(1234)).toBe('1.2 km')
+  })
+
+  it('returns null for a non-positive distance (e.g. a skipped run)', () => {
+    expect(formatDistanceKm(0)).toBeNull()
+    expect(formatDistanceKm(-10)).toBeNull()
+    expect(formatDistanceKm(Number.NaN)).toBeNull()
+  })
+})
+
+describe('formatDuration', () => {
+  it('renders sub-hour durations as M:SS', () => {
+    expect(formatDuration(1800)).toBe('30:00')
+    expect(formatDuration(65)).toBe('1:05')
+  })
+
+  it('renders hour-plus durations as H:MM:SS', () => {
+    expect(formatDuration(5400)).toBe('1:30:00')
+    expect(formatDuration(3661)).toBe('1:01:01')
+  })
+
+  it('returns null for a non-positive duration', () => {
+    expect(formatDuration(0)).toBeNull()
+    expect(formatDuration(Number.NaN)).toBeNull()
+  })
+})
+
+describe('formatLogPace', () => {
+  it('derives average pace as MM:SS/km from distance + duration', () => {
+    // 5 km in 1800 s -> 360 s/km -> 06:00/km.
+    expect(formatLogPace(5000, 1800)).toBe('06:00/km')
+  })
+
+  it('returns null when distance or duration is non-positive', () => {
+    expect(formatLogPace(0, 1800)).toBeNull()
+    expect(formatLogPace(5000, 0)).toBeNull()
+  })
+})
+
+describe('formatLogDate', () => {
+  it('formats an ISO date-only string as a local weekday/month/day label', () => {
+    // 2026-06-07 is a Sunday (local-calendar parse, never UTC-shifted).
+    expect(formatLogDate('2026-06-07')).toBe('Sun, Jun 7')
+    expect(formatLogDate('2026-06-01')).toBe('Mon, Jun 1')
+  })
+})
+
+describe('COMPLETION_STATUS_LABELS', () => {
+  it('maps each completion status to a user-facing label', () => {
+    expect(COMPLETION_STATUS_LABELS[CompletionStatus.Complete]).toBe('Completed')
+    expect(COMPLETION_STATUS_LABELS[CompletionStatus.Partial]).toBe('Partial')
+    expect(COMPLETION_STATUS_LABELS[CompletionStatus.Skipped]).toBe('Skipped')
+  })
+})

--- a/frontend/src/app/modules/logging/history/history-format.helpers.ts
+++ b/frontend/src/app/modules/logging/history/history-format.helpers.ts
@@ -1,0 +1,103 @@
+// Display formatting for the workout-history surface (PR7).
+//
+// The wire shape (`WorkoutLogDto`) carries distance in **metres** and duration
+// in **seconds**; this module renders them for humans. Pace is derived
+// (distance + duration) and formatted via the plan module's single
+// `MM:SS/km` formatter so the history list and the plan view agree on pace
+// presentation. Per the root `CLAUDE.md` trademark rule, no zone-name coupling
+// lives here — only neutral distance/duration/pace strings.
+
+import { CompletionStatus } from '~/api/generated'
+import { formatPacePerKm } from '~/modules/plan/utils/pace-format.helpers'
+
+const METERS_PER_KM = 1000
+const SECONDS_PER_MINUTE = 60
+const SECONDS_PER_HOUR = 3600
+
+const MONTH_LABELS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const
+
+const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
+
+const pad2 = (value: number): string => value.toString().padStart(2, '0')
+
+/**
+ * Formats a distance in metres as one-decimal kilometres (e.g. `"5.0 km"`).
+ * Returns `null` for a non-positive or non-finite distance — a skipped run
+ * persists `0 m`, which the caller renders as a placeholder rather than
+ * a misleading `"0.0 km"`.
+ */
+export const formatDistanceKm = (distanceMeters: number): string | null => {
+  if (!Number.isFinite(distanceMeters) || distanceMeters <= 0) {
+    return null
+  }
+  return `${(distanceMeters / METERS_PER_KM).toFixed(1)} km`
+}
+
+/**
+ * Formats a duration in seconds as `M:SS` under an hour and `H:MM:SS` at or
+ * above an hour. Returns `null` for a non-positive or non-finite duration.
+ */
+export const formatDuration = (durationSeconds: number): string | null => {
+  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+    return null
+  }
+  const total = Math.round(durationSeconds)
+  const hours = Math.floor(total / SECONDS_PER_HOUR)
+  const minutes = Math.floor((total % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE)
+  const seconds = total % SECONDS_PER_MINUTE
+  if (hours > 0) {
+    return `${hours}:${pad2(minutes)}:${pad2(seconds)}`
+  }
+  return `${minutes}:${pad2(seconds)}`
+}
+
+/**
+ * Derives average pace from distance + duration and formats it as `MM:SS/km`.
+ * Returns `null` when either input is non-positive (no meaningful pace for a
+ * zero-distance or zero-duration log).
+ */
+export const formatLogPace = (distanceMeters: number, durationSeconds: number): string | null => {
+  if (!Number.isFinite(distanceMeters) || distanceMeters <= 0) {
+    return null
+  }
+  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+    return null
+  }
+  const kilometres = distanceMeters / METERS_PER_KM
+  return formatPacePerKm(durationSeconds / kilometres)
+}
+
+/**
+ * Formats an ISO `YYYY-MM-DD` date-only string as a short local label
+ * (e.g. `"Sun, Jun 7"`). Parsed as a local-calendar date so the displayed day
+ * never shifts under timezone conversion (DEC-076: dates are local training
+ * dates).
+ */
+export const formatLogDate = (occurredOn: string): string => {
+  const [year, month, day] = occurredOn.split('-').map(Number)
+  const date = new Date(year, month - 1, day)
+  return `${WEEKDAY_LABELS[date.getDay()]}, ${MONTH_LABELS[date.getMonth()]} ${date.getDate()}`
+}
+
+/** Shared month-label lookup for the `Week of …` header (week-grouping). */
+export const monthLabel = (monthIndex: number): string => MONTH_LABELS[monthIndex]
+
+/** User-facing labels for each `CompletionStatus`. */
+export const COMPLETION_STATUS_LABELS: Record<CompletionStatus, string> = {
+  [CompletionStatus.Complete]: 'Completed',
+  [CompletionStatus.Partial]: 'Partial',
+  [CompletionStatus.Skipped]: 'Skipped',
+}

--- a/frontend/src/app/modules/logging/history/week-grouping.helpers.spec.ts
+++ b/frontend/src/app/modules/logging/history/week-grouping.helpers.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import type { WorkoutLogDto } from '~/api/generated'
+import { CompletionStatus } from '~/api/generated'
+import { getIsoWeekStart, groupLogsByIsoWeek, parseIsoDateOnly } from './week-grouping.helpers'
+
+const log = (occurredOn: string, workoutLogId = occurredOn): WorkoutLogDto => ({
+  workoutLogId,
+  occurredOn,
+  distanceMeters: 5000,
+  durationSeconds: 1800,
+  completionStatus: CompletionStatus.Complete,
+})
+
+describe('parseIsoDateOnly', () => {
+  it('parses YYYY-MM-DD as a local-calendar date (no UTC shift)', () => {
+    const date = parseIsoDateOnly('2026-06-07')
+    expect(date.getFullYear()).toBe(2026)
+    expect(date.getMonth()).toBe(5) // June, 0-based
+    expect(date.getDate()).toBe(7)
+  })
+})
+
+describe('getIsoWeekStart', () => {
+  it('returns the Monday of the ISO week', () => {
+    // 2026-06-07 is a Sunday; its ISO week starts Monday 2026-06-01.
+    expect(getIsoWeekStart(parseIsoDateOnly('2026-06-07')).getDate()).toBe(1)
+    // 2026-06-01 is itself a Monday — its own week start.
+    expect(getIsoWeekStart(parseIsoDateOnly('2026-06-01')).getDate()).toBe(1)
+    // 2026-06-08 is the next Monday.
+    expect(getIsoWeekStart(parseIsoDateOnly('2026-06-08')).getDate()).toBe(8)
+  })
+})
+
+describe('groupLogsByIsoWeek', () => {
+  it('buckets logs of one ISO week (Mon–Sun) under a single group', () => {
+    const groups = groupLogsByIsoWeek([log('2026-06-07'), log('2026-06-03'), log('2026-06-01')])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].label).toBe('Week of Jun 1, 2026')
+    expect(groups[0].logs.map((l) => l.occurredOn)).toEqual([
+      '2026-06-07',
+      '2026-06-03',
+      '2026-06-01',
+    ])
+  })
+
+  it('returns week groups newest-first with newest-first logs within each', () => {
+    const groups = groupLogsByIsoWeek([log('2026-06-08'), log('2026-06-07'), log('2026-05-31')])
+    expect(groups.map((g) => g.label)).toEqual([
+      'Week of Jun 8, 2026',
+      'Week of Jun 1, 2026',
+      'Week of May 25, 2026',
+    ])
+  })
+
+  it('merges logs of the same ISO week split across two fetched pages into one group', () => {
+    // Page 1 (newest) then page 2 (older), flattened — the boundary splits one
+    // ISO week. Grouping over the merged flat list must NOT duplicate the header.
+    const page1 = [log('2026-06-07'), log('2026-06-03')]
+    const page2 = [log('2026-06-01'), log('2026-05-31')]
+    const groups = groupLogsByIsoWeek([...page1, ...page2])
+
+    expect(groups.map((g) => g.label)).toEqual(['Week of Jun 1, 2026', 'Week of May 25, 2026'])
+    expect(groups[0].logs).toHaveLength(3) // 06-07, 06-03, 06-01 — single header
+    expect(groups[1].logs).toHaveLength(1) // 05-31
+  })
+
+  it('sorts defensively so an out-of-order merged page still groups newest-first', () => {
+    const groups = groupLogsByIsoWeek([log('2026-06-01'), log('2026-06-07'), log('2026-06-03')])
+    expect(groups[0].logs.map((l) => l.occurredOn)).toEqual([
+      '2026-06-07',
+      '2026-06-03',
+      '2026-06-01',
+    ])
+  })
+
+  it('returns an empty array for no logs', () => {
+    expect(groupLogsByIsoWeek([])).toEqual([])
+  })
+})

--- a/frontend/src/app/modules/logging/history/week-grouping.helpers.spec.ts
+++ b/frontend/src/app/modules/logging/history/week-grouping.helpers.spec.ts
@@ -77,4 +77,25 @@ describe('groupLogsByIsoWeek', () => {
   it('returns an empty array for no logs', () => {
     expect(groupLogsByIsoWeek([])).toEqual([])
   })
+
+  it('orders same-day logs by workoutLogId descending (secondary tiebreak)', () => {
+    // Two logs sharing one occurredOn (same ISO week) but with distinct ids exercise
+    // the secondary workoutLogId-desc tiebreak that the date-distinct tests never hit,
+    // mirroring the backend keyset order (occurredOn desc, then workoutLogId desc).
+    const groups = groupLogsByIsoWeek([log('2026-06-03', 'a-id'), log('2026-06-03', 'c-id')])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].logs.map((l) => l.workoutLogId)).toEqual(['c-id', 'a-id'])
+  })
+
+  it('keeps equal-key entries in their original order (equal-key return-0 branch)', () => {
+    // Two entries sharing BOTH occurredOn and workoutLogId exercise the equal-key
+    // `return 0` branch (the comparator-contract fix in 3bcefa1). A non-zero return
+    // here would violate antisymmetry and reorder equal keys; the distinct
+    // distanceMeters make that reordering observable.
+    const first = { ...log('2026-06-03', 'dup-id'), distanceMeters: 1000 }
+    const second = { ...log('2026-06-03', 'dup-id'), distanceMeters: 2000 }
+    const groups = groupLogsByIsoWeek([first, second])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].logs.map((l) => l.distanceMeters)).toEqual([1000, 2000])
+  })
 })

--- a/frontend/src/app/modules/logging/history/week-grouping.helpers.ts
+++ b/frontend/src/app/modules/logging/history/week-grouping.helpers.ts
@@ -1,0 +1,84 @@
+// ISO-calendar-week bucketing for the workout-history surface (PR7).
+//
+// The history query endpoint returns a flat, newest-first page of logs;
+// week grouping is *presentation*, computed client-side over the merged
+// flat list (DEC-075 / spec § Unit 7). Operating on the whole merged list —
+// rather than per page — is what keeps the grouping page-boundary-safe: logs
+// of the same ISO week that straddle two fetched pages land under one header,
+// never a duplicated one.
+//
+// Dates are local-calendar (DEC-076). All arithmetic uses native `Date` with
+// local Y/M/D construction (no library; no UTC parse) — month rollover is
+// handled by `Date`'s own normalisation.
+
+import type { WorkoutLogDto } from '~/api/generated'
+import { monthLabel } from './history-format.helpers'
+
+/** A single ISO-week bucket of logs for the history surface. */
+export interface WorkoutHistoryWeekGroup {
+  /** ISO `YYYY-MM-DD` of the week's Monday — stable React key + bucket id. */
+  weekStartIso: string
+  /** Display header, e.g. `"Week of Jun 1, 2026"`. */
+  label: string
+  /** Logs in this week, newest-first. */
+  logs: WorkoutLogDto[]
+}
+
+/** Parses an ISO `YYYY-MM-DD` string as a local-calendar date (never UTC). */
+export const parseIsoDateOnly = (isoDate: string): Date => {
+  const [year, month, day] = isoDate.split('-').map(Number)
+  return new Date(year, month - 1, day)
+}
+
+/** Local `YYYY-MM-DD` for a date (never `toISOString`, which would UTC-shift). */
+const toIsoDateOnly = (date: Date): string => {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+/** Returns the Monday (ISO week start) of the given date's week. */
+export const getIsoWeekStart = (date: Date): Date => {
+  // `getDay()` is 0=Sunday..6=Saturday; `(day + 6) % 7` is 0=Monday..6=Sunday.
+  const mondayOffset = (date.getDay() + 6) % 7
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() - mondayOffset)
+}
+
+const formatWeekOfLabel = (weekStart: Date): string =>
+  `Week of ${monthLabel(weekStart.getMonth())} ${weekStart.getDate()}, ${weekStart.getFullYear()}`
+
+/**
+ * Groups a flat log list into ISO-week buckets, newest week first, with
+ * newest-first logs inside each. Sorts defensively by `occurredOn` desc
+ * (tiebreak `workoutLogId` desc, mirroring the backend keyset order) so a
+ * merged multi-page list groups correctly even if the pages interleave.
+ */
+export const groupLogsByIsoWeek = (logs: readonly WorkoutLogDto[]): WorkoutHistoryWeekGroup[] => {
+  const sorted = [...logs].sort((a, b) => {
+    if (a.occurredOn !== b.occurredOn) {
+      return a.occurredOn < b.occurredOn ? 1 : -1
+    }
+    return a.workoutLogId < b.workoutLogId ? 1 : -1
+  })
+
+  const groups = new Map<string, WorkoutHistoryWeekGroup>()
+  for (const entry of sorted) {
+    const weekStart = getIsoWeekStart(parseIsoDateOnly(entry.occurredOn))
+    const weekStartIso = toIsoDateOnly(weekStart)
+    const existing = groups.get(weekStartIso)
+    if (existing === undefined) {
+      groups.set(weekStartIso, {
+        weekStartIso,
+        label: formatWeekOfLabel(weekStart),
+        logs: [entry],
+      })
+    } else {
+      existing.logs.push(entry)
+    }
+  }
+
+  // `Map` preserves insertion order; sorted desc ⇒ groups + members are
+  // newest-first.
+  return [...groups.values()]
+}

--- a/frontend/src/app/modules/logging/history/week-grouping.helpers.ts
+++ b/frontend/src/app/modules/logging/history/week-grouping.helpers.ts
@@ -59,6 +59,9 @@ export const groupLogsByIsoWeek = (logs: readonly WorkoutLogDto[]): WorkoutHisto
     if (a.occurredOn !== b.occurredOn) {
       return a.occurredOn < b.occurredOn ? 1 : -1
     }
+    if (a.workoutLogId === b.workoutLogId) {
+      return 0
+    }
     return a.workoutLogId < b.workoutLogId ? 1 : -1
   })
 

--- a/frontend/src/app/modules/logging/history/workout-history-list.component.spec.tsx
+++ b/frontend/src/app/modules/logging/history/workout-history-list.component.spec.tsx
@@ -1,0 +1,43 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { WorkoutLogDto } from '~/api/generated'
+import { CompletionStatus } from '~/api/generated'
+import { WorkoutHistoryList } from './workout-history-list.component'
+
+const log = (occurredOn: string): WorkoutLogDto => ({
+  workoutLogId: occurredOn,
+  occurredOn,
+  distanceMeters: 5000,
+  durationSeconds: 1800,
+  completionStatus: CompletionStatus.Complete,
+})
+
+describe('WorkoutHistoryList', () => {
+  it('renders one week header per ISO week, newest week first', () => {
+    render(<WorkoutHistoryList logs={[log('2026-06-08'), log('2026-06-07'), log('2026-05-31')]} />)
+
+    const headers = screen.getAllByTestId('workout-history-week-header').map((h) => h.textContent)
+    expect(headers).toEqual(['Week of Jun 8, 2026', 'Week of Jun 1, 2026', 'Week of May 25, 2026'])
+    expect(screen.getAllByTestId('workout-history-entry')).toHaveLength(3)
+  })
+
+  it('groups logs of one ISO week split across two pages under a single header', () => {
+    // Simulates a merged infinite-query result where the page boundary splits
+    // one ISO week — the bucketing must not duplicate the header.
+    const page1 = [log('2026-06-07'), log('2026-06-03')]
+    const page2 = [log('2026-06-01'), log('2026-05-31')]
+    render(<WorkoutHistoryList logs={[...page1, ...page2]} />)
+
+    const headers = screen.getAllByTestId('workout-history-week-header').map((h) => h.textContent)
+    expect(headers).toEqual(['Week of Jun 1, 2026', 'Week of May 25, 2026'])
+
+    const firstWeek = screen.getByRole('region', { name: 'Week of Jun 1, 2026' })
+    expect(within(firstWeek).getAllByTestId('workout-history-entry')).toHaveLength(3)
+  })
+
+  it('renders nothing visible for an empty log list', () => {
+    render(<WorkoutHistoryList logs={[]} />)
+    expect(screen.queryByTestId('workout-history-week-header')).toBeNull()
+  })
+})

--- a/frontend/src/app/modules/logging/history/workout-history-list.component.tsx
+++ b/frontend/src/app/modules/logging/history/workout-history-list.component.tsx
@@ -1,0 +1,43 @@
+import type { ReactElement } from 'react'
+
+import type { WorkoutLogDto } from '~/api/generated'
+import { WorkoutLogEntry } from './workout-log-entry.component'
+import { groupLogsByIsoWeek } from './week-grouping.helpers'
+
+export interface WorkoutHistoryListProps {
+  /** The full merged, newest-first log list across all fetched pages. */
+  logs: readonly WorkoutLogDto[]
+}
+
+/**
+ * The presentational history list: groups the flat (possibly multi-page) log
+ * list into ISO-week buckets and renders a `Week of …` section per week, each
+ * with its newest-first entries. Grouping is done here over the whole merged
+ * list (not per page), so a week split across a page boundary renders under a
+ * single header (spec § Unit 7).
+ */
+export const WorkoutHistoryList = ({ logs }: WorkoutHistoryListProps): ReactElement => {
+  const weeks = groupLogsByIsoWeek(logs)
+
+  return (
+    <div data-testid="workout-history-list" className="flex flex-col gap-8">
+      {weeks.map((week) => (
+        <section key={week.weekStartIso} aria-label={week.label} className="flex flex-col gap-3">
+          <h2
+            data-testid="workout-history-week-header"
+            className="text-sm font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            {week.label}
+          </h2>
+          <ul className="flex flex-col gap-3">
+            {week.logs.map((log) => (
+              <li key={log.workoutLogId}>
+                <WorkoutLogEntry log={log} />
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/app/modules/logging/history/workout-log-entry.component.spec.tsx
+++ b/frontend/src/app/modules/logging/history/workout-log-entry.component.spec.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { WorkoutLogDto } from '~/api/generated'
+import { CompletionStatus } from '~/api/generated'
+import { WorkoutLogEntry } from './workout-log-entry.component'
+
+const baseLog = (overrides: Partial<WorkoutLogDto> = {}): WorkoutLogDto => ({
+  workoutLogId: 'log-1',
+  occurredOn: '2026-06-06',
+  distanceMeters: 5000,
+  durationSeconds: 1800,
+  completionStatus: CompletionStatus.Complete,
+  ...overrides,
+})
+
+describe('WorkoutLogEntry', () => {
+  it('renders the date, status, and derived core stats for a completed run', () => {
+    render(<WorkoutLogEntry log={baseLog()} />)
+
+    expect(screen.getByText('Sat, Jun 6')).toBeInTheDocument()
+    expect(screen.getByText('Completed')).toBeInTheDocument()
+    expect(screen.getByText('5.0 km')).toBeInTheDocument()
+    expect(screen.getByText('30:00')).toBeInTheDocument()
+    expect(screen.getByText('06:00/km')).toBeInTheDocument()
+  })
+
+  it('renders the freeform note when present', () => {
+    render(<WorkoutLogEntry log={baseLog({ notes: 'Legs felt heavy but pushed through.' })} />)
+    expect(screen.getByTestId('workout-history-entry-notes')).toHaveTextContent(
+      'Legs felt heavy but pushed through.',
+    )
+  })
+
+  it('omits the note element when there is no note', () => {
+    render(<WorkoutLogEntry log={baseLog()} />)
+    expect(screen.queryByTestId('workout-history-entry-notes')).toBeNull()
+  })
+
+  it('renders present optional metrics via the sparse metric list', () => {
+    render(<WorkoutLogEntry log={baseLog({ metrics: { hrAvg: 140 } })} />)
+    expect(screen.getByText('Avg HR')).toBeInTheDocument()
+    expect(screen.getByText('140 bpm')).toBeInTheDocument()
+  })
+
+  it('renders a splits summary when the log has splits', () => {
+    const log = baseLog({
+      splits: [
+        {
+          index: 0,
+          distanceMeters: 1000,
+          durationSeconds: 300,
+          paceSecPerKm: 300,
+          averageHeartRate: null,
+        },
+        {
+          index: 1,
+          distanceMeters: 1000,
+          durationSeconds: 300,
+          paceSecPerKm: 300,
+          averageHeartRate: null,
+        },
+      ],
+    })
+    render(<WorkoutLogEntry log={log} />)
+    expect(screen.getByRole('button', { name: /2 splits/i })).toBeInTheDocument()
+  })
+
+  it('shows the skipped status and no pace for a skipped (zero-actuals) run', () => {
+    render(
+      <WorkoutLogEntry
+        log={baseLog({
+          distanceMeters: 0,
+          durationSeconds: 0,
+          completionStatus: CompletionStatus.Skipped,
+        })}
+      />,
+    )
+    expect(screen.getByText('Skipped')).toBeInTheDocument()
+    expect(screen.queryByText('5.0 km')).toBeNull()
+    expect(screen.queryByText(/\/km$/)).toBeNull()
+  })
+})

--- a/frontend/src/app/modules/logging/history/workout-log-entry.component.tsx
+++ b/frontend/src/app/modules/logging/history/workout-log-entry.component.tsx
@@ -1,0 +1,99 @@
+import type { ReactElement } from 'react'
+
+import type { WorkoutLogDto } from '~/api/generated'
+import {
+  COMPLETION_STATUS_LABELS,
+  formatDistanceKm,
+  formatDuration,
+  formatLogDate,
+  formatLogPace,
+} from './history-format.helpers'
+import { WorkoutLogMetrics } from './workout-log-metrics.component'
+import { WorkoutLogSplits } from './workout-log-splits.component'
+
+export interface WorkoutLogEntryProps {
+  /** A single logged workout from the history query. */
+  log: WorkoutLogDto
+}
+
+interface CoreStat {
+  label: string
+  value: string
+}
+
+const buildCoreStats = (log: WorkoutLogDto): CoreStat[] => {
+  const stats: CoreStat[] = []
+  const distance = formatDistanceKm(log.distanceMeters)
+  if (distance !== null) {
+    stats.push({ label: 'Distance', value: distance })
+  }
+  const duration = formatDuration(log.durationSeconds)
+  if (duration !== null) {
+    stats.push({ label: 'Duration', value: duration })
+  }
+  const pace = formatLogPace(log.distanceMeters, log.durationSeconds)
+  if (pace !== null) {
+    stats.push({ label: 'Pace', value: pace })
+  }
+  return stats
+}
+
+const hasText = (value: string | null | undefined): value is string =>
+  value !== null && value !== undefined && value.trim().length > 0
+
+/**
+ * One logged workout as a card: date + completion status header, the derived
+ * core stats (distance/duration/pace, each shown only when meaningful — a
+ * skipped run has none), the sparse optional-metrics `<dl>`, the freeform note,
+ * and the display-only splits collapsible (spec § Unit 7). All colour is
+ * semantic-token-based and animations pair a `motion-reduce:` variant.
+ */
+export const WorkoutLogEntry = ({ log }: WorkoutLogEntryProps): ReactElement => {
+  const coreStats = buildCoreStats(log)
+
+  return (
+    <article
+      data-testid="workout-history-entry"
+      data-completion-status={log.completionStatus}
+      className="flex flex-col gap-3 rounded-lg border bg-card p-4 text-sm text-card-foreground shadow-sm"
+    >
+      <header className="flex items-baseline justify-between gap-2">
+        <h3 className="text-base font-semibold text-foreground">{formatLogDate(log.occurredOn)}</h3>
+        <span
+          data-testid="workout-history-entry-status"
+          className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
+        >
+          {COMPLETION_STATUS_LABELS[log.completionStatus]}
+        </span>
+      </header>
+
+      {coreStats.length > 0 ? (
+        <dl className="grid grid-cols-3 gap-3">
+          {coreStats.map((stat) => (
+            <div key={stat.label} className="flex flex-col">
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                {stat.label}
+              </dt>
+              <dd className="text-base font-semibold text-foreground">{stat.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+
+      <WorkoutLogMetrics metrics={log.metrics} />
+
+      {hasText(log.notes) ? (
+        <p
+          data-testid="workout-history-entry-notes"
+          className="rounded-md bg-muted px-3 py-2 text-xs leading-snug text-muted-foreground"
+        >
+          {log.notes}
+        </p>
+      ) : null}
+
+      {log.splits !== null && log.splits !== undefined && log.splits.length > 0 ? (
+        <WorkoutLogSplits splits={log.splits} />
+      ) : null}
+    </article>
+  )
+}

--- a/frontend/src/app/modules/logging/history/workout-log-metrics.component.spec.tsx
+++ b/frontend/src/app/modules/logging/history/workout-log-metrics.component.spec.tsx
@@ -31,6 +31,17 @@ describe('WorkoutLogMetrics', () => {
     expect(screen.queryByText('99')).toBeNull()
   })
 
+  it('renders a metric whose value is 0 (0 is present, not absent)', () => {
+    // `0` is a valid recorded value (a flat run logs elevationGain 0; rpe can be 0)
+    // and must render — `isPresent` treats 0 as present, per the explicit-0-check
+    // convention. A truthiness check would wrongly drop it.
+    render(<WorkoutLogMetrics metrics={{ elevationGain: 0, rpe: 0 }} />)
+    expect(screen.getByText('Elevation gain')).toBeInTheDocument()
+    expect(screen.getByText('0 m')).toBeInTheDocument()
+    expect(screen.getByText('RPE')).toBeInTheDocument()
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
   it('renders nothing when there are no present metrics', () => {
     const { container } = render(<WorkoutLogMetrics metrics={{ hrAvg: null, rpe: undefined }} />)
     expect(container).toBeEmptyDOMElement()

--- a/frontend/src/app/modules/logging/history/workout-log-metrics.component.spec.tsx
+++ b/frontend/src/app/modules/logging/history/workout-log-metrics.component.spec.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { WorkoutLogMetrics } from './workout-log-metrics.component'
+
+describe('WorkoutLogMetrics', () => {
+  it('renders a sparse definition list with only the metrics that are present', () => {
+    render(<WorkoutLogMetrics metrics={{ hrAvg: 142, rpe: 7 }} />)
+
+    expect(screen.getByText('Avg HR')).toBeInTheDocument()
+    expect(screen.getByText('142 bpm')).toBeInTheDocument()
+    expect(screen.getByText('RPE')).toBeInTheDocument()
+    expect(screen.getByText('7')).toBeInTheDocument()
+
+    // Absent metrics produce no row at all (sparse, DEC-075).
+    expect(screen.queryByText('Cadence')).toBeNull()
+    expect(screen.queryByText('Power')).toBeNull()
+  })
+
+  it('renders free-text metrics (weather/terrain) without a unit suffix', () => {
+    render(<WorkoutLogMetrics metrics={{ weather: 'Cold rain', terrain: 'Trail' }} />)
+    expect(screen.getByText('Weather')).toBeInTheDocument()
+    expect(screen.getByText('Cold rain')).toBeInTheDocument()
+    expect(screen.getByText('Terrain')).toBeInTheDocument()
+    expect(screen.getByText('Trail')).toBeInTheDocument()
+  })
+
+  it('ignores keys that are not canonical metric keys', () => {
+    render(<WorkoutLogMetrics metrics={{ hrAvg: 150, bogusKey: 99 }} />)
+    expect(screen.getByText('Avg HR')).toBeInTheDocument()
+    expect(screen.queryByText('99')).toBeNull()
+  })
+
+  it('renders nothing when there are no present metrics', () => {
+    const { container } = render(<WorkoutLogMetrics metrics={{ hrAvg: null, rpe: undefined }} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when metrics is null or undefined', () => {
+    const { container, rerender } = render(<WorkoutLogMetrics metrics={null} />)
+    expect(container).toBeEmptyDOMElement()
+    rerender(<WorkoutLogMetrics metrics={undefined} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/app/modules/logging/history/workout-log-metrics.component.tsx
+++ b/frontend/src/app/modules/logging/history/workout-log-metrics.component.tsx
@@ -1,0 +1,69 @@
+import type { ReactElement } from 'react'
+
+import { WORKOUT_METRIC_META } from '~/modules/logging/metric-meta'
+
+export interface WorkoutLogMetricsProps {
+  /** The open `metrics` bag from a `WorkoutLogDto` (may be null/undefined). */
+  metrics?: Record<string, unknown> | null
+}
+
+interface PresentMetric {
+  key: string
+  label: string
+  display: string
+}
+
+const isPresent = (value: unknown): boolean => value !== undefined && value !== null && value !== ''
+
+/**
+ * Collects the present metrics in canonical (`WORKOUT_METRIC_META`) order so
+ * the sparse list reads consistently and unknown keys are dropped. Iterating
+ * the metadata map — not the bag — is what guarantees identical labels/units to
+ * the log form (DEC-075) and skips any non-canonical key the wire might carry.
+ */
+const collectPresentMetrics = (
+  metrics: Record<string, unknown> | null | undefined,
+): PresentMetric[] => {
+  if (metrics === null || metrics === undefined) {
+    return []
+  }
+  const present: PresentMetric[] = []
+  for (const [key, { label, unit }] of Object.entries(WORKOUT_METRIC_META)) {
+    const value = metrics[key]
+    if (!isPresent(value)) {
+      continue
+    }
+    const display = unit.length > 0 ? `${String(value)} ${unit}` : String(value)
+    present.push({ key, label, display })
+  }
+  return present
+}
+
+/**
+ * Renders the present optional metrics of a logged workout as a raw, sparse
+ * `<dl>` — only metrics that were actually recorded appear, each labelled from
+ * the shared metric-meta map (DEC-075 / spec § Unit 7). Renders nothing when no
+ * canonical metric is present.
+ */
+export const WorkoutLogMetrics = ({ metrics }: WorkoutLogMetricsProps): ReactElement | null => {
+  const present = collectPresentMetrics(metrics)
+  if (present.length === 0) {
+    return null
+  }
+
+  return (
+    <dl
+      data-testid="workout-history-metrics"
+      className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-3"
+    >
+      {present.map(({ key, label, display }) => (
+        <div key={key} className="flex flex-col">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            {label}
+          </dt>
+          <dd className="font-semibold text-foreground">{display}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/frontend/src/app/modules/logging/history/workout-log-splits.component.spec.tsx
+++ b/frontend/src/app/modules/logging/history/workout-log-splits.component.spec.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import type { WorkoutLogSplitDto } from '~/api/generated'
+import { WorkoutLogSplits } from './workout-log-splits.component'
+
+const split = (index: number, overrides: Partial<WorkoutLogSplitDto> = {}): WorkoutLogSplitDto => ({
+  index,
+  distanceMeters: 1000,
+  durationSeconds: 300,
+  paceSecPerKm: 300,
+  averageHeartRate: null,
+  ...overrides,
+})
+
+const threeSplits = [split(0), split(1), split(2)]
+
+describe('WorkoutLogSplits', () => {
+  it('shows a one-line splits summary and hides the table until expanded', () => {
+    render(<WorkoutLogSplits splits={threeSplits} />)
+
+    expect(screen.getByRole('button', { name: /3 splits/i })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    // Lazy: the table is not in the DOM until the collapsible is opened.
+    expect(screen.queryByRole('table')).toBeNull()
+  })
+
+  it('reveals a table with one row per split when expanded', async () => {
+    const user = userEvent.setup()
+    render(<WorkoutLogSplits splits={threeSplits} />)
+
+    await user.click(screen.getByRole('button', { name: /3 splits/i }))
+
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    // 1 header row + 3 data rows.
+    expect(screen.getAllByRole('row')).toHaveLength(4)
+  })
+
+  it('singularises the summary for a single split', () => {
+    render(<WorkoutLogSplits splits={[split(0)]} />)
+    expect(screen.getByRole('button', { name: /^1 split$/i })).toBeInTheDocument()
+  })
+
+  it('renders an HR column only when at least one split has a heart rate', async () => {
+    const user = userEvent.setup()
+    render(<WorkoutLogSplits splits={[split(0, { averageHeartRate: 150 }), split(1)]} />)
+
+    await user.click(screen.getByRole('button', { name: /2 splits/i }))
+    expect(screen.getByRole('columnheader', { name: /hr/i })).toBeInTheDocument()
+    expect(screen.getByText('150')).toBeInTheDocument()
+  })
+
+  it('renders nothing when there are no splits', () => {
+    const { container } = render(<WorkoutLogSplits splits={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/app/modules/logging/history/workout-log-splits.component.tsx
+++ b/frontend/src/app/modules/logging/history/workout-log-splits.component.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import type { ReactElement } from 'react'
+import { ChevronDownIcon } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import type { WorkoutLogSplitDto } from '~/api/generated'
+import { formatPacePerKm } from '~/modules/plan/utils/pace-format.helpers'
+import { formatDistanceKm, formatDuration } from './history-format.helpers'
+
+export interface WorkoutLogSplitsProps {
+  /** The per-lap splits of a logged workout (display-only at MVP-0). */
+  splits: readonly WorkoutLogSplitDto[]
+}
+
+const headerCellClass =
+  'px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-wide text-muted-foreground'
+const dataCellClass = 'px-3 py-2 text-foreground'
+
+/**
+ * Display-only splits for a logged workout: a one-line `"N splits"` summary that
+ * expands a lazy nested `<table>` (DEC-075 / spec § Unit 7). Radix unmounts the
+ * collapsible content while closed, so the table is only rendered once opened.
+ * The HR column appears only when at least one split carries a heart rate, so a
+ * GPS-only import doesn't show an empty column.
+ */
+export const WorkoutLogSplits = ({ splits }: WorkoutLogSplitsProps): ReactElement | null => {
+  const [open, setOpen] = useState(false)
+
+  if (splits.length === 0) {
+    return null
+  }
+
+  const summary = `${splits.length} split${splits.length === 1 ? '' : 's'}`
+  const showHeartRate = splits.some(
+    (split) => split.averageHeartRate !== null && split.averageHeartRate !== undefined,
+  )
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="flex flex-col gap-2">
+      <CollapsibleTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="w-full justify-between px-3 text-muted-foreground"
+          data-testid="workout-history-splits-trigger"
+        >
+          {summary}
+          <ChevronDownIcon
+            aria-hidden="true"
+            className={`size-4 transition-transform duration-200 ease-out motion-reduce:transition-none ${
+              open ? 'rotate-180' : ''
+            }`}
+          />
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="overflow-x-auto data-[state=open]:animate-in data-[state=closed]:animate-out motion-reduce:animate-none">
+        <table
+          className="w-full border-collapse text-sm"
+          data-testid="workout-history-splits-table"
+        >
+          <thead>
+            <tr className="border-b border-border">
+              <th scope="col" className={headerCellClass}>
+                #
+              </th>
+              <th scope="col" className={headerCellClass}>
+                Distance
+              </th>
+              <th scope="col" className={headerCellClass}>
+                Time
+              </th>
+              <th scope="col" className={headerCellClass}>
+                Pace
+              </th>
+              {showHeartRate ? (
+                <th scope="col" className={headerCellClass}>
+                  HR
+                </th>
+              ) : null}
+            </tr>
+          </thead>
+          <tbody>
+            {splits.map((split) => (
+              <tr key={split.index} className="border-b border-border last:border-0">
+                <td className={dataCellClass}>{split.index + 1}</td>
+                <td className={dataCellClass}>{formatDistanceKm(split.distanceMeters) ?? '—'}</td>
+                <td className={dataCellClass}>{formatDuration(split.durationSeconds) ?? '—'}</td>
+                <td className={dataCellClass}>{formatPacePerKm(split.paceSecPerKm) ?? '—/km'}</td>
+                {showHeartRate ? (
+                  <td className={dataCellClass}>
+                    {split.averageHeartRate !== null && split.averageHeartRate !== undefined
+                      ? split.averageHeartRate
+                      : '—'}
+                  </td>
+                ) : null}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/frontend/src/app/modules/logging/history/workout-log-splits.component.tsx
+++ b/frontend/src/app/modules/logging/history/workout-log-splits.component.tsx
@@ -89,11 +89,7 @@ export const WorkoutLogSplits = ({ splits }: WorkoutLogSplitsProps): ReactElemen
                 <td className={dataCellClass}>{formatDuration(split.durationSeconds) ?? '—'}</td>
                 <td className={dataCellClass}>{formatPacePerKm(split.paceSecPerKm) ?? '—/km'}</td>
                 {showHeartRate ? (
-                  <td className={dataCellClass}>
-                    {split.averageHeartRate !== null && split.averageHeartRate !== undefined
-                      ? split.averageHeartRate
-                      : '—'}
-                  </td>
+                  <td className={dataCellClass}>{split.averageHeartRate ?? '—'}</td>
                 ) : null}
               </tr>
             ))}

--- a/frontend/src/app/modules/logging/pages/history.page.spec.tsx
+++ b/frontend/src/app/modules/logging/pages/history.page.spec.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { QueryWorkoutLogsResponseDto, WorkoutLogDto } from '~/api/generated'
+import { CompletionStatus } from '~/api/generated'
+
+const { historyQueryMock, fetchNextPageMock } = vi.hoisted(() => ({
+  historyQueryMock: vi.fn(),
+  fetchNextPageMock: vi.fn(),
+}))
+
+vi.mock('~/api/workout-log.api', () => ({
+  useGetWorkoutLogHistoryInfiniteQuery: () => historyQueryMock(),
+}))
+
+import HistoryPage from './history.page'
+
+const log = (occurredOn: string): WorkoutLogDto => ({
+  workoutLogId: occurredOn,
+  occurredOn,
+  distanceMeters: 5000,
+  durationSeconds: 1800,
+  completionStatus: CompletionStatus.Complete,
+})
+
+const page = (
+  logs: WorkoutLogDto[],
+  nextCursor: string | null = null,
+): QueryWorkoutLogsResponseDto => ({
+  logs,
+  nextCursor,
+})
+
+interface QueryStateOverrides {
+  data?: { pages: QueryWorkoutLogsResponseDto[]; pageParams: unknown[] }
+  isLoading?: boolean
+  isError?: boolean
+  hasNextPage?: boolean
+  isFetchingNextPage?: boolean
+}
+
+const setQueryState = (overrides: QueryStateOverrides): void => {
+  historyQueryMock.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: fetchNextPageMock,
+    refetch: vi.fn(),
+    ...overrides,
+  })
+}
+
+const dataOf = (...pages: QueryWorkoutLogsResponseDto[]) => ({
+  pages,
+  pageParams: pages.map(() => null),
+})
+
+const renderPage = () => {
+  const user = userEvent.setup()
+  return {
+    user,
+    ...render(
+      <MemoryRouter initialEntries={['/history']}>
+        <HistoryPage />
+      </MemoryRouter>,
+    ),
+  }
+}
+
+describe('HistoryPage', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows a loading state while the first page is in flight', () => {
+    setQueryState({ isLoading: true })
+    renderPage()
+    expect(screen.getByRole('status')).toHaveTextContent(/loading/i)
+  })
+
+  it('shows an error surface when the query fails', () => {
+    setQueryState({ isError: true })
+    renderPage()
+    expect(screen.getByTestId('workout-history-error')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when there are no logged workouts', () => {
+    setQueryState({ data: dataOf(page([])) })
+    renderPage()
+    expect(screen.getByTestId('workout-history-empty')).toBeInTheDocument()
+    expect(screen.queryByTestId('workout-history-list')).toBeNull()
+  })
+
+  it('renders week-grouped entries flattened across pages, merging a split week', () => {
+    setQueryState({
+      data: dataOf(page([log('2026-06-07'), log('2026-06-03')], 'c1'), page([log('2026-06-01')])),
+    })
+    renderPage()
+
+    expect(screen.getAllByTestId('workout-history-entry')).toHaveLength(3)
+    // The three logs span one ISO week split across two pages — single header.
+    const headers = screen.getAllByTestId('workout-history-week-header')
+    expect(headers).toHaveLength(1)
+    expect(headers[0]).toHaveTextContent('Week of Jun 1, 2026')
+  })
+
+  it('shows "Load older" when more pages exist and calls fetchNextPage on click', async () => {
+    setQueryState({ data: dataOf(page([log('2026-06-07')], 'c1')), hasNextPage: true })
+    const { user } = renderPage()
+
+    const loadOlder = screen.getByTestId('workout-history-load-older')
+    expect(loadOlder).toBeEnabled()
+    await user.click(loadOlder)
+    expect(fetchNextPageMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables "Load older" while the next page is loading', () => {
+    setQueryState({
+      data: dataOf(page([log('2026-06-07')], 'c1')),
+      hasNextPage: true,
+      isFetchingNextPage: true,
+    })
+    renderPage()
+    expect(screen.getByTestId('workout-history-load-older')).toBeDisabled()
+  })
+
+  it('hides "Load older" when there are no more pages', () => {
+    setQueryState({ data: dataOf(page([log('2026-06-07')])), hasNextPage: false })
+    renderPage()
+    expect(screen.queryByTestId('workout-history-load-older')).toBeNull()
+  })
+
+  it('renders a back link to the plan home', () => {
+    setQueryState({ data: dataOf(page([log('2026-06-07')])) })
+    renderPage()
+    expect(screen.getByRole('link', { name: /back to plan/i })).toHaveAttribute('href', '/')
+  })
+})

--- a/frontend/src/app/modules/logging/pages/history.page.tsx
+++ b/frontend/src/app/modules/logging/pages/history.page.tsx
@@ -1,0 +1,128 @@
+import type { ReactElement } from 'react'
+import { Link } from 'react-router-dom'
+
+import { Button } from '@/components/ui/button'
+import type { WorkoutLogDto } from '~/api/generated'
+import { useGetWorkoutLogHistoryInfiniteQuery } from '~/api/workout-log.api'
+import { WorkoutHistoryList } from '~/modules/logging/history/workout-history-list.component'
+
+interface HistoryBodyProps {
+  logs: WorkoutLogDto[]
+  isLoading: boolean
+  isError: boolean
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  loadOlder: () => void
+}
+
+/**
+ * The state-dependent body of the history surface: loading, error, empty, or
+ * the week-grouped list with its "Load older" control. Guard-clause returns
+ * keep the branches flat (no nested ternaries).
+ */
+const HistoryBody = ({
+  logs,
+  isLoading,
+  isError,
+  hasNextPage,
+  isFetchingNextPage,
+  loadOlder,
+}: HistoryBodyProps): ReactElement => {
+  if (isLoading) {
+    return (
+      <div role="status" aria-live="polite" className="py-12 text-center">
+        <span className="text-sm text-muted-foreground">Loading…</span>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div
+        role="alert"
+        data-testid="workout-history-error"
+        className="flex flex-col items-center gap-2 py-12 text-center"
+      >
+        <p className="text-sm text-muted-foreground">
+          We couldn’t load your workout history. Reload the page in a moment.
+        </p>
+      </div>
+    )
+  }
+
+  if (logs.length === 0) {
+    return (
+      <div
+        data-testid="workout-history-empty"
+        className="flex flex-col items-center gap-3 py-12 text-center"
+      >
+        <p className="text-base font-semibold text-foreground">No workouts logged yet</p>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          Once you log a run it’ll show up here, grouped by week.
+        </p>
+        <Button asChild size="sm">
+          <Link to="/log">Log a workout</Link>
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <WorkoutHistoryList logs={logs} />
+      {hasNextPage ? (
+        <Button
+          type="button"
+          variant="outline"
+          data-testid="workout-history-load-older"
+          disabled={isFetchingNextPage}
+          onClick={loadOlder}
+          className="self-center"
+        >
+          {isFetchingNextPage ? 'Loading…' : 'Load older'}
+        </Button>
+      ) : null}
+    </>
+  )
+}
+
+/**
+ * Protected `/history` route: the runner's logged-workout history. Consumes the
+ * DB-driven keyset query endpoint via an RTK `infiniteQuery` ("Load older"),
+ * flattens the fetched pages into one newest-first list, and hands it to
+ * `WorkoutHistoryList` which groups it by ISO week (spec § Unit 7). "Load older"
+ * appears only while the server still has a cursor to hand back.
+ */
+export const HistoryPage = (): ReactElement => {
+  const { data, isLoading, isError, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useGetWorkoutLogHistoryInfiniteQuery(undefined)
+
+  const logs = data?.pages.flatMap((logPage) => logPage.logs) ?? []
+
+  return (
+    <main
+      data-testid="workout-history-page"
+      className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-6 bg-background px-4 py-8"
+    >
+      <header className="flex flex-col gap-1">
+        <Link to="/" className="text-sm text-muted-foreground hover:text-foreground">
+          ← Back to plan
+        </Link>
+        <h1 className="text-2xl font-semibold text-foreground">Workout history</h1>
+      </header>
+
+      <HistoryBody
+        logs={logs}
+        isLoading={isLoading}
+        isError={isError}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        loadOlder={() => {
+          void fetchNextPage()
+        }}
+      />
+    </main>
+  )
+}
+
+export default HistoryPage

--- a/frontend/src/app/modules/plan/pages/home.page.spec.tsx
+++ b/frontend/src/app/modules/plan/pages/home.page.spec.tsx
@@ -121,6 +121,10 @@ describe('HomePage', () => {
     expect(screen.getByTestId('macro-phase-strip')).toBeInTheDocument()
     expect(screen.getByTestId('today-card')).toBeInTheDocument()
     expect(screen.getByTestId('upcoming-list')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /workout history/i })).toHaveAttribute(
+      'href',
+      '/history',
+    )
   })
 
   it('renders the no-plan-yet state on a 404 response', () => {

--- a/frontend/src/app/modules/plan/pages/home.page.tsx
+++ b/frontend/src/app/modules/plan/pages/home.page.tsx
@@ -87,6 +87,14 @@ const PlanLayout = ({ plan }: PlanLayoutProps): ReactElement => {
       className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-8 bg-background px-4 py-8"
       data-testid="home-page"
     >
+      <div className="flex justify-end">
+        <Button asChild variant="ghost" size="sm">
+          <Link to="/history" data-testid="home-history-link">
+            Workout history
+          </Link>
+        </Button>
+      </div>
+
       {plan.macro === null ? null : (
         <MacroPhaseStrip macro={plan.macro} currentWeek={currentWeek} />
       )}


### PR DESCRIPTION
## Slice 2b — PR7: frontend workout-history surface + E2E (final PR of the slice)

Implements **Unit 7** of the Slice 2b spec — the week-grouped workout-history surface over the DB-driven query endpoint (PR4), plus the slice's end-to-end proof. This is the last of the 8 stacked PRs for Slice 2b (PR1–PR6b already merged).

### What's included

- **`getWorkoutLogHistory` RTK `infiniteQuery`** (`workout-log.api.ts`) over `POST /api/v1/workouts/logs/query` — opaque keyset cursor as the page param, `getNextPageParam` driven by `nextCursor` (drives "Load older"/`hasNextPage`). Provides the `WorkoutLog` tag so logging a workout refetches the list. It's a read (`query`, not `mutation`), so no antiforgery header — matching the endpoint having no `[RequireAntiforgeryToken]`.
- **ISO-week bucketing helper** — groups the flat, newest-first merged page list into `Week of …` sections client-side. Page-boundary-safe: a week split across two fetched pages renders under a **single** header (sorts defensively by `occurredOn` desc, tiebreak id).
- **Sparse log entry card** — derived distance/duration/pace, a sparse `<dl>` of only the metrics actually present (labels from the shared `WORKOUT_METRIC_META` map, so form + history never drift), the freeform note, and display-only splits as a one-line summary + lazy `<table>` inside a `Collapsible`.
- **`/history` route** reusing the auth + onboarding route guards; a **"Workout history"** link on the home plan view as the entry point.
- Read DTO types (`WorkoutLogDto`, `QueryWorkoutLogs*`, `WorkoutLogSplitDto`) re-exported through the generated barrel (type-only, same pattern as `CreateWorkoutLogResponseDto`).
- Semantic tokens + `motion-reduce:` pairing throughout (DEC-063/DEC-070).

### Proof artifacts (spec § Unit 7)

- **Component tests** — sparse `<dl>` renders only present metrics; week grouping buckets correctly across a page boundary; "Load older" appends/hides; splits one-line summary + lazy table.
- **Playwright E2E** — register/onboard → log a minimum-payload workout → log a rich-payload workout with a note → both appear in the week-grouped history with the rich note + Avg HR. The create + history-query calls hit the **real backend** (onboarding/plan stubbed at the wire, per the slice-2a pattern).

### Verification

- `npm run test` — **453 passed** (47 files; +43 new).
- `npm run build` — tsc + vite clean.
- `npm run lint` — 0 errors.
- `npm run check-contrast` — 28/28 WCAG pairs pass.
- `npx playwright test` — **13/13 e2e pass** against the host-run stack (Postgres + backend on :5001 + Vite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Workout History page (linked from home) showing workouts grouped by ISO week, with formatted distance, duration, pace, date and completion status; shows notes, metrics (e.g., avg HR) and expandable splits; supports pagination with "Load older".

* **Tests**
  * End-to-end tests for workout logging and history display; comprehensive unit tests for history grouping, formatting helpers and history UI components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->