### PR TITLE
feat(slice-3): deterministic deviation engine + escalation classifier (PR2)

### DIFF
--- a/backend/src/RunCoach.Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using RunCoach.Api.Infrastructure.Idempotency;
 using RunCoach.Api.Modules.Coaching;
 using RunCoach.Api.Modules.Coaching.Prompts;
 using RunCoach.Api.Modules.Coaching.Sanitization;
+using RunCoach.Api.Modules.Training.Adaptation;
 using RunCoach.Api.Modules.Training.Computations;
 using RunCoach.Api.Modules.Training.Plan;
 using RunCoach.Api.Modules.Training.Safety;
@@ -42,6 +43,12 @@ public static class ServiceCollectionExtensions
         // Stateless keyword classifier; the keyword catalog is compiled once at
         // type-load. Consumed by the Slice 3 adaptation orchestration handler.
         services.AddSingleton<ISafetyGate, SafetyGate>();
+
+        // Training module — deterministic deviation engine + escalation classifier
+        // (Slice 3 PR2 / Unit 1, DEC-012/DEC-078). Pure, stateless decision layer
+        // consumed by the Slice 3 adaptation orchestration handler (PR5).
+        services.AddSingleton<IDeviationEngine, DeviationEngine>();
+        services.AddSingleton<IEscalationClassifier, EscalationClassifier>();
 
         // Training module — workout-log persistence (scoped, shares the request DbContext).
         services.AddScoped<IWorkoutLogRepository, WorkoutLogRepository>();

--- a/backend/src/RunCoach.Api/Modules/Coaching/RecentLogFormatter.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/RecentLogFormatter.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using RunCoach.Api.Modules.Training.Computations;
 using RunCoach.Api.Modules.Training.Constants;
 using RunCoach.Api.Modules.Training.Models;
 
@@ -74,12 +75,12 @@ internal static class RecentLogFormatter
     /// </summary>
     private static string? FormatPace(Distance distance, Duration duration)
     {
-        if (distance.Kilometers <= 0 || duration.TotalSeconds <= 0)
+        if (PaceDerivation.TryDerive(distance, duration) is not { } pace)
         {
             return null;
         }
 
-        var ts = Pace.FromSecondsPerKm(duration.TotalSeconds / distance.Kilometers).ToTimeSpan();
+        var ts = pace.ToTimeSpan();
         var clock = ts.TotalHours >= 1
             ? ts.ToString(@"h\:mm\:ss", CultureInfo.InvariantCulture)
             : ts.ToString(@"m\:ss", CultureInfo.InvariantCulture);

--- a/backend/src/RunCoach.Api/Modules/Training/Adaptation/AdaptationSignalState.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Adaptation/AdaptationSignalState.cs
@@ -1,0 +1,31 @@
+namespace RunCoach.Api.Modules.Training.Adaptation;
+
+/// <summary>
+/// The minimal per-user signal + plan-state the deterministic escalation classifier
+/// threads between evaluations (Slice 3 PR2 / Unit 1, DEC-078). Pure data: the
+/// classifier consumes a prior state and returns the next one. <strong>How this state
+/// is persisted (a small Marten read-model vs. recomputed per evaluation from the
+/// recent-log window) is deliberately left to the PR5 orchestration</strong> — the
+/// spec's open question — so the deterministic layer stays a pure, total transition.
+/// No EWMA/ACWR/CTL/ATL/TSB load model is computed at MVP-0.
+/// </summary>
+/// <param name="PlanState">The current plan-state in the hysteresis machine.</param>
+/// <param name="RollingDeviationScore">
+/// A simple accumulator of recent under-performance: it steps up on an under-performing
+/// log and decays toward zero on an on-target log. Not a calibrated load metric.
+/// </param>
+/// <param name="ConsecutiveMissedDays">Run of consecutive skipped days; resets on any non-skipped log.</param>
+/// <param name="LastAdaptationOn">
+/// The day the most recent restructure fired, used for the cooldown half of the
+/// hysteresis; <c>null</c> until the first restructure.
+/// </param>
+public sealed record AdaptationSignalState(
+    PlanState PlanState,
+    double RollingDeviationScore,
+    int ConsecutiveMissedDays,
+    DateOnly? LastAdaptationOn)
+{
+    /// <summary>Gets the starting state for a user with no adaptation history.</summary>
+    public static AdaptationSignalState Initial { get; } =
+        new(PlanState.OnTrack, 0.0, 0, null);
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Adaptation/AdaptationThresholds.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Adaptation/AdaptationThresholds.cs
@@ -1,0 +1,81 @@
+namespace RunCoach.Api.Modules.Training.Adaptation;
+
+/// <summary>
+/// Named, first-pass threshold constants for the deterministic deviation/escalation
+/// layer (Slice 3 PR2 / Unit 1, DEC-078). Centralised here so the escalation policy
+/// lives in one place rather than scattered as call-site magic numbers — mirrors the
+/// <c>SafetyKeywordCatalog</c> resource convention.
+/// </summary>
+/// <remarks>
+/// These are deliberately simple first-pass values pending calibration against the
+/// five <c>TestProfiles</c> during eval authoring (Unit 6); the full
+/// EWMA/ACWR/CTL/ATL/TSB load model is deferred (DEC-078). Population-volume clamps
+/// (DEC-010/DEC-028) are enforced at the LLM/validator boundary (PR4), not re-derived
+/// here. Bump <see cref="PolicyVersion"/> on any change so audit replay can pin the
+/// active set.
+/// </remarks>
+internal static class AdaptationThresholds
+{
+    /// <summary>Version stamp for this threshold set; bump on any change for audit-replay pinning.</summary>
+    public const string PolicyVersion = "v1.0.0";
+
+    /// <summary>
+    /// Distance band tolerance (percent). Actuals within ±this of the prescribed
+    /// distance are treated as on target, absorbing value-object precision. Duration is
+    /// not checked directly against this: a slower-than-prescribed effort already
+    /// surfaces through the pace band (sec/km), so a separate duration percentage would
+    /// double-count it.
+    /// </summary>
+    public const double DistanceTolerancePercent = 5.0;
+
+    /// <summary>The rolling deviation score added for each under-performing log.</summary>
+    public const double MinorDeviationStep = 1.0;
+
+    /// <summary>
+    /// Multiplicative decay applied to the rolling deviation score on an on-target
+    /// (or over-performing) log, so a recovered week walks the signal back down.
+    /// </summary>
+    public const double OnTargetDecayFactor = 0.5;
+
+    /// <summary>
+    /// Upper bound on the rolling deviation score, keeping the hysteresis dead-zone
+    /// math bounded (a runaway streak cannot push the score arbitrarily high).
+    /// </summary>
+    public const double MaxRollingDeviationScore = RestructureEnterScore;
+
+    /// <summary>
+    /// Rolling deviation score at or above which accumulated minor deviations warrant
+    /// an L1 micro-adjust (the "2–3 minor deviations" trigger).
+    /// </summary>
+    public const double MicroAdjustEnterScore = 2.0;
+
+    /// <summary>
+    /// Rolling deviation score at or above which sustained under-performance crosses
+    /// the L1→L2 threshold into a restructure (enter threshold).
+    /// </summary>
+    public const double RestructureEnterScore = 3.0;
+
+    /// <summary>
+    /// Rolling deviation score at or below which the signal clears a restructure state
+    /// back to on-track (the dead-zone guard holds while the score is strictly above
+    /// this). Strictly less than <see cref="RestructureEnterScore"/> so enter/exit are
+    /// asymmetric (the hysteresis dead-zone that prevents flip-flop).
+    /// </summary>
+    public const double RestructureExitScore = 1.0;
+
+    /// <summary>Consecutive missed (skipped) days that force an L2 restructure regardless of score.</summary>
+    public const int ConsecutiveMissedDaysForRestructure = 3;
+
+    /// <summary>
+    /// Cooldown window (days) after a restructure during which another restructure
+    /// cannot fire — the time half of the asymmetric hysteresis.
+    /// </summary>
+    public const int RestructureCooldownDays = 7;
+
+    /// <summary>
+    /// First-pass cap (percent) on key-workout over-performance: over-performance
+    /// never upgrades the escalation level here, and any future target increase the
+    /// LLM proposes is bound by this (enforced at the PR4 validator, DEC-012 key rule).
+    /// </summary>
+    public const double OverPerformanceCapPercent = 3.0;
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Adaptation/DeviationEngine.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Adaptation/DeviationEngine.cs
@@ -1,0 +1,75 @@
+using RunCoach.Api.Modules.Training.Computations;
+using RunCoach.Api.Modules.Training.Workouts;
+
+namespace RunCoach.Api.Modules.Training.Adaptation;
+
+/// <summary>
+/// Deterministic deviation engine (Slice 3 PR2 / Unit 1): compares a logged
+/// workout's actuals against its frozen <see cref="WorkoutPrescriptionSnapshot"/>
+/// and reports band-membership pace deviation plus signed distance/duration
+/// percentages. Pure and stateless — owns no thresholds or escalation policy.
+/// </summary>
+public sealed class DeviationEngine : IDeviationEngine
+{
+    /// <inheritdoc />
+    public DeviationResult? Evaluate(WorkoutLog log)
+    {
+        ArgumentNullException.ThrowIfNull(log);
+
+        // Off-plan: a null prescription snapshot is a no-op for adaptation.
+        if (log.Prescription is not { } snapshot)
+        {
+            return null;
+        }
+
+        var (paceBand, paceDeviation) = ClassifyPace(log, snapshot);
+
+        return new DeviationResult(
+            log.OccurredOn,
+            log.CompletionStatus,
+            WorkoutKind.IsKey(snapshot.WorkoutType),
+            SignedPercent(log.Distance.Kilometers, snapshot.PrescribedDistance.Kilometers),
+            SignedPercent(log.Duration.TotalSeconds, snapshot.PrescribedDuration.TotalSeconds),
+            paceBand,
+            paceDeviation);
+    }
+
+    /// <summary>
+    /// Signed percentage of actual-vs-prescribed: <c>(actual - prescribed) / prescribed * 100</c>.
+    /// Guards a non-positive prescribed value (degenerate snapshot) by reporting no deviation.
+    /// </summary>
+    private static double SignedPercent(double actual, double prescribed) =>
+        prescribed <= 0 ? 0.0 : (actual - prescribed) / prescribed * 100.0;
+
+    /// <summary>
+    /// Classifies the derived pace as band membership relative to the snapshot's
+    /// Fast/Slow band. A skipped run, or a log whose distance/duration cannot yield a
+    /// pace, reports <see cref="PaceBandMembership.Unknown"/> with a zero magnitude so
+    /// no spurious pace deviation is produced.
+    /// </summary>
+    private static (PaceBandMembership Band, double DeviationSecondsPerKm) ClassifyPace(
+        WorkoutLog log,
+        WorkoutPrescriptionSnapshot snapshot)
+    {
+        if (log.CompletionStatus == CompletionStatus.Skipped ||
+            PaceDerivation.TryDerive(log.Distance, log.Duration) is not { } actualPace)
+        {
+            return (PaceBandMembership.Unknown, 0.0);
+        }
+
+        var band = snapshot.PrescribedPace;
+        if (actualPace.IsFasterThan(band.Fast))
+        {
+            // Negative magnitude: faster than the Fast bound (lower sec/km).
+            return (PaceBandMembership.FasterThanFast, actualPace.SecondsPerKm - band.Fast.SecondsPerKm);
+        }
+
+        if (actualPace.IsSlowerThan(band.Slow))
+        {
+            // Positive magnitude: slower than the Slow bound (higher sec/km).
+            return (PaceBandMembership.SlowerThanSlow, actualPace.SecondsPerKm - band.Slow.SecondsPerKm);
+        }
+
+        return (PaceBandMembership.InsideBand, 0.0);
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Adaptation/DeviationResult.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Adaptation/DeviationResult.cs
@@ -1,0 +1,39 @@
+using RunCoach.Api.Modules.Training.Workouts;
+
+namespace RunCoach.Api.Modules.Training.Adaptation;
+
+/// <summary>
+/// The deterministic comparison of a logged workout's actuals against its frozen
+/// <see cref="WorkoutPrescriptionSnapshot"/> (Slice 3 PR2 / Unit 1). Pure data —
+/// the escalation classifier interprets these signals against
+/// <see cref="AdaptationThresholds"/>; this record carries no policy.
+/// </summary>
+/// <param name="OccurredOn">The calendar day the logged workout occurred on.</param>
+/// <param name="CompletionStatus">How fully the runner completed the workout.</param>
+/// <param name="IsKeyWorkout">
+/// Whether the prescribed workout is a quality/long session (Tempo, Interval,
+/// Repetition, or LongRun) rather than an easy/recovery/cross-train day.
+/// </param>
+/// <param name="DistanceDeviationPercent">
+/// Signed percentage of actual-vs-prescribed distance: <c>(actual - prescribed) / prescribed * 100</c>.
+/// Negative is short of plan; positive is over.
+/// </param>
+/// <param name="DurationDeviationPercent">
+/// Signed percentage of actual-vs-prescribed duration, same sign convention as
+/// <paramref name="DistanceDeviationPercent"/>.
+/// </param>
+/// <param name="PaceBand">Where the derived pace falls relative to the prescribed Fast/Slow band.</param>
+/// <param name="PaceDeviationSecondsPerKm">
+/// Signed magnitude (sec/km) by which the derived pace misses the nearest band
+/// bound: positive when slower than the Slow bound, negative when faster than the
+/// Fast bound, and zero when inside the band or when the pace is
+/// <see cref="PaceBandMembership.Unknown"/>.
+/// </param>
+public sealed record DeviationResult(
+    DateOnly OccurredOn,
+    CompletionStatus CompletionStatus,
+    bool IsKeyWorkout,
+    double DistanceDeviationPercent,
+    double DurationDeviationPercent,
+    PaceBandMembership PaceBand,
+    double PaceDeviationSecondsPerKm);

--- a/backend/src/RunCoach.Api/Modules/Training/Adaptation/EscalationClassifier.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Adaptation/EscalationClassifier.cs
@@ -1,0 +1,103 @@
+using RunCoach.Api.Modules.Training.Safety;
+using RunCoach.Api.Modules.Training.Workouts;
+
+namespace RunCoach.Api.Modules.Training.Adaptation;
+
+/// <summary>
+/// Deterministic escalation classifier (Slice 3 PR2 / Unit 1, DEC-012/DEC-078):
+/// resolves L0 absorb / L1 micro-adjust / L2 restructure from a
+/// <see cref="DeviationResult"/>, the safety tier, and a prior signal state, applying
+/// asymmetric enter/exit hysteresis so a restructure cannot flip-flop. Pure and
+/// stateless — no LLM, no I/O; the L2 restructure is where PR5 hands off to the LLM.
+/// </summary>
+public sealed class EscalationClassifier : IEscalationClassifier
+{
+    /// <inheritdoc />
+    public EscalationDecision Classify(
+        DeviationResult deviation,
+        SafetyTier safetyTier,
+        AdaptationSignalState priorState)
+    {
+        ArgumentNullException.ThrowIfNull(deviation);
+        ArgumentNullException.ThrowIfNull(priorState);
+
+        // Red short-circuits to safety-only in the PR5 orchestration; defensively the
+        // classifier yields no plan adaptation and leaves the signal state untouched.
+        if (safetyTier == SafetyTier.Red)
+        {
+            return Absorb(priorState);
+        }
+
+        var missed = deviation.CompletionStatus == CompletionStatus.Skipped;
+        var newStreak = missed ? priorState.ConsecutiveMissedDays + 1 : 0;
+        var newScore = IsUnderPerformance(deviation)
+            ? Math.Min(
+                priorState.RollingDeviationScore + AdaptationThresholds.MinorDeviationStep,
+                AdaptationThresholds.MaxRollingDeviationScore)
+            : priorState.RollingDeviationScore * AdaptationThresholds.OnTargetDecayFactor;
+
+        // Asymmetric hysteresis: once a restructure has fired, suppress re-firing until
+        // the cooldown has elapsed AND the signal has cleared the (lower) exit threshold.
+        if (priorState.PlanState == PlanState.NeedsAdjustment)
+        {
+            var cooldownActive = priorState.LastAdaptationOn is { } last
+                && deviation.OccurredOn.DayNumber - last.DayNumber < AdaptationThresholds.RestructureCooldownDays;
+            if (cooldownActive || newScore > AdaptationThresholds.RestructureExitScore)
+            {
+                // Still inside the dead-zone — absorb without re-firing, hold the state.
+                return Absorb(priorState with
+                {
+                    RollingDeviationScore = newScore,
+                    ConsecutiveMissedDays = newStreak,
+                });
+            }
+
+            // Cleared: cooldown elapsed and the signal settled at or below the exit threshold.
+            return Absorb(new AdaptationSignalState(
+                PlanState.OnTrack, newScore, newStreak, priorState.LastAdaptationOn));
+        }
+
+        // L2 restructure: sustained under-performance crossing the enter threshold, or a
+        // run of consecutive missed days. This is where PR5 hands off to the LLM.
+        if (newScore >= AdaptationThresholds.RestructureEnterScore
+            || newStreak >= AdaptationThresholds.ConsecutiveMissedDaysForRestructure)
+        {
+            return new EscalationDecision(
+                EscalationLevel.Restructure,
+                AdaptationKind.Restructure,
+                new AdaptationSignalState(PlanState.NeedsAdjustment, newScore, newStreak, deviation.OccurredOn));
+        }
+
+        // L1 micro-adjust: a single reschedulable missed/moved key workout, or accumulated
+        // minor deviations reaching the micro-adjust threshold.
+        if ((missed && deviation.IsKeyWorkout) || newScore >= AdaptationThresholds.MicroAdjustEnterScore)
+        {
+            return new EscalationDecision(
+                EscalationLevel.MicroAdjust,
+                AdaptationKind.Nudge,
+                new AdaptationSignalState(PlanState.MinorDeviation, newScore, newStreak, priorState.LastAdaptationOn));
+        }
+
+        // L0 absorb.
+        var nextPlanState = newScore >= AdaptationThresholds.MinorDeviationStep
+            ? PlanState.MinorDeviation
+            : PlanState.OnTrack;
+        return new EscalationDecision(
+            EscalationLevel.Absorb,
+            AdaptationKind.Absorb,
+            new AdaptationSignalState(nextPlanState, newScore, newStreak, priorState.LastAdaptationOn));
+    }
+
+    private static EscalationDecision Absorb(AdaptationSignalState state) =>
+        new(EscalationLevel.Absorb, AdaptationKind.Absorb, state);
+
+    /// <summary>
+    /// A log under-performs when it was not completed (skipped or cut short), its pace
+    /// was slower than the prescribed band, or it ran meaningfully short of the
+    /// prescribed distance. Over-performance and on-target both fall through to decay.
+    /// </summary>
+    private static bool IsUnderPerformance(DeviationResult deviation) =>
+        deviation.CompletionStatus != CompletionStatus.Complete
+        || deviation.PaceBand == PaceBandMembership.SlowerThanSlow
+        || deviation.DistanceDeviationPercent < -AdaptationThresholds.DistanceTolerancePercent;
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Adaptation/EscalationDecision.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Adaptation/EscalationDecision.cs
@@ -1,0 +1,15 @@
+namespace RunCoach.Api.Modules.Training.Adaptation;
+
+/// <summary>
+/// The deterministic escalation classifier's output (Slice 3 PR2 / Unit 1): the
+/// resolved DEC-012 <see cref="EscalationLevel"/>, the panel-facing
+/// <see cref="AdaptationKind"/>, and the advanced <see cref="AdaptationSignalState"/>
+/// the caller persists for the next evaluation.
+/// </summary>
+/// <param name="EscalationLevel">The resolved DEC-012 ladder position (Absorb / MicroAdjust / Restructure).</param>
+/// <param name="AdaptationKind">The render discriminator (Absorb / Nudge / Restructure).</param>
+/// <param name="NextState">The signal state to carry into the next evaluation.</param>
+public sealed record EscalationDecision(
+    EscalationLevel EscalationLevel,
+    AdaptationKind AdaptationKind,
+    AdaptationSignalState NextState);

--- a/backend/src/RunCoach.Api/Modules/Training/Adaptation/IDeviationEngine.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Adaptation/IDeviationEngine.cs
@@ -1,0 +1,21 @@
+using RunCoach.Api.Modules.Training.Workouts;
+
+namespace RunCoach.Api.Modules.Training.Adaptation;
+
+/// <summary>
+/// Computes the deterministic <see cref="DeviationResult"/> for a logged workout
+/// versus its frozen prescription snapshot (Slice 3 PR2 / Unit 1). Pure and
+/// stateless — no LLM, no I/O.
+/// </summary>
+public interface IDeviationEngine
+{
+    /// <summary>
+    /// Compares the logged workout's actuals against its
+    /// <see cref="WorkoutLog.Prescription"/> snapshot. Returns <c>null</c> when the
+    /// log is off-plan (a null prescription snapshot) — a no-op for downstream
+    /// adaptation.
+    /// </summary>
+    /// <param name="log">The committed workout log to evaluate.</param>
+    /// <returns>The deviation signals, or <c>null</c> for an off-plan log.</returns>
+    DeviationResult? Evaluate(WorkoutLog log);
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Adaptation/IEscalationClassifier.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Adaptation/IEscalationClassifier.cs
@@ -1,0 +1,22 @@
+using RunCoach.Api.Modules.Training.Safety;
+
+namespace RunCoach.Api.Modules.Training.Adaptation;
+
+/// <summary>
+/// Resolves a DEC-012 escalation decision from a <see cref="DeviationResult"/>, the
+/// pre-LLM <see cref="SafetyTier"/>, and the prior signal state (Slice 3 PR2 / Unit 1).
+/// Pure and stateless — a total transition function, no LLM, no I/O.
+/// </summary>
+public interface IEscalationClassifier
+{
+    /// <summary>
+    /// Resolves the escalation level/kind for one on-plan logged workout and returns
+    /// the advanced signal state. L0 absorb and L1 micro-adjust are handled here with
+    /// no LLM; L2 restructure is the level the PR5 orchestration escalates to the LLM.
+    /// </summary>
+    /// <param name="deviation">The deterministic deviation of an on-plan log (never null/off-plan).</param>
+    /// <param name="safetyTier">The pre-LLM safety tier from the SafetyGate.</param>
+    /// <param name="priorState">The signal state carried from the previous evaluation.</param>
+    /// <returns>The resolved decision plus the next signal state.</returns>
+    EscalationDecision Classify(DeviationResult deviation, SafetyTier safetyTier, AdaptationSignalState priorState);
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Adaptation/MicroAdjustPlanner.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Adaptation/MicroAdjustPlanner.cs
@@ -1,0 +1,89 @@
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+
+namespace RunCoach.Api.Modules.Training.Adaptation;
+
+/// <summary>
+/// The deterministic L1 micro-adjust planner (Slice 3 PR2 / Unit 1): reschedules a
+/// missed key workout <em>forward</em> within the current micro week (DEC-012 — never
+/// redistribute backward), swapping it with the nearest later easy/recovery day such
+/// that no two key workouts land on consecutive days. Pure — it computes the
+/// before/after diff only; the PR5 orchestration reads the live micro week, calls this,
+/// and appends the resulting <see cref="PlanAdaptationDiff"/>. When no valid
+/// non-stacking forward swap exists, it returns <c>false</c> and the orchestration
+/// escalates the micro-adjust to an L2 restructure.
+/// </summary>
+internal static class MicroAdjustPlanner
+{
+    /// <summary>
+    /// Attempts to plan a forward swap for the missed key workout on
+    /// <paramref name="missedDayOfWeek"/>.
+    /// </summary>
+    /// <param name="currentWeek">The current micro week's workouts (one per scheduled day).</param>
+    /// <param name="missedDayOfWeek">The day-of-week (0=Sunday..6=Saturday) of the missed workout.</param>
+    /// <param name="weekNumber">The 1-based week number the changes target.</param>
+    /// <param name="diff">The resulting before/after diff when a swap is found; otherwise empty.</param>
+    /// <returns><c>true</c> when a non-stacking forward swap was planned; otherwise <c>false</c>.</returns>
+    public static bool TryPlanSwap(
+        IReadOnlyList<WorkoutOutput> currentWeek,
+        int missedDayOfWeek,
+        int weekNumber,
+        out PlanAdaptationDiff diff)
+    {
+        ArgumentNullException.ThrowIfNull(currentWeek);
+        diff = PlanAdaptationDiff.Empty;
+
+        var missed = currentWeek.FirstOrDefault(workout => workout.DayOfWeek == missedDayOfWeek);
+        if (missed is null || !WorkoutKind.IsKey(missed.WorkoutType))
+        {
+            // Only a scheduled key workout is rescheduled by a deterministic micro-adjust.
+            return false;
+        }
+
+        // Forward-only (DEC-012 — never redistribute backward): the nearest later
+        // easy/recovery day whose swap does not place two key workouts on consecutive days.
+        foreach (var target in currentWeek
+            .Where(workout => workout.DayOfWeek > missedDayOfWeek && !WorkoutKind.IsKey(workout.WorkoutType))
+            .OrderBy(workout => workout.DayOfWeek))
+        {
+            if (WouldStackKeyWorkouts(currentWeek, missed, target))
+            {
+                continue;
+            }
+
+            var movedKey = missed with { DayOfWeek = target.DayOfWeek };
+            var movedEasy = target with { DayOfWeek = missed.DayOfWeek };
+            diff = new PlanAdaptationDiff(
+                [
+                    new WorkoutChange(weekNumber, missed.DayOfWeek, missed, movedEasy),
+                    new WorkoutChange(weekNumber, target.DayOfWeek, target, movedKey),
+                ],
+                []);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// After the swap the key workout sits on the target day and an easy workout on the
+    /// missed day, so only the target day's neighbours can newly stack against the key.
+    /// </summary>
+    private static bool WouldStackKeyWorkouts(
+        IReadOnlyList<WorkoutOutput> week,
+        WorkoutOutput missed,
+        WorkoutOutput target) =>
+        NeighbourIsKey(week, missed, target.DayOfWeek - 1)
+        || NeighbourIsKey(week, missed, target.DayOfWeek + 1);
+
+    private static bool NeighbourIsKey(IReadOnlyList<WorkoutOutput> week, WorkoutOutput missed, int dayOfWeek)
+    {
+        // The missed day becomes an easy workout after the swap, so it never stacks.
+        if (dayOfWeek == missed.DayOfWeek)
+        {
+            return false;
+        }
+
+        var neighbour = week.FirstOrDefault(workout => workout.DayOfWeek == dayOfWeek);
+        return neighbour is not null && WorkoutKind.IsKey(neighbour.WorkoutType);
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Adaptation/PaceBandMembership.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Adaptation/PaceBandMembership.cs
@@ -1,0 +1,26 @@
+namespace RunCoach.Api.Modules.Training.Adaptation;
+
+/// <summary>
+/// Where a logged workout's derived pace falls relative to its prescribed
+/// Fast/Slow band (Slice 3 PR2 / Unit 1). Pace deviation is reported as band
+/// <em>membership</em> rather than a scalar diff: a run inside the band is on
+/// target regardless of the exact second-per-km. Members are explicitly numbered
+/// so reordering never shifts a serialized encoding.
+/// </summary>
+public enum PaceBandMembership
+{
+    /// <summary>The derived pace sits within the prescribed Fast/Slow band — on target.</summary>
+    InsideBand = 0,
+
+    /// <summary>The derived pace is faster than the band's Fast bound (lower sec/km).</summary>
+    FasterThanFast = 1,
+
+    /// <summary>The derived pace is slower than the band's Slow bound (higher sec/km).</summary>
+    SlowerThanSlow = 2,
+
+    /// <summary>
+    /// No pace could be derived (a skipped run, or a zero/near-zero distance or
+    /// duration) — there is no pace signal, and no spurious pace deviation is produced.
+    /// </summary>
+    Unknown = 3,
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Adaptation/PlanState.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Adaptation/PlanState.cs
@@ -1,0 +1,20 @@
+namespace RunCoach.Api.Modules.Training.Adaptation;
+
+/// <summary>
+/// The per-user adaptation plan-state in the simplified MVP-0 signal machine
+/// (Slice 3 PR2 / Unit 1, DEC-078). Drives the asymmetric enter/exit hysteresis:
+/// a restructure moves the state to <see cref="NeedsAdjustment"/> and cannot re-fire
+/// until the signal clears the exit threshold and the cooldown elapses. Members are
+/// explicitly numbered so reordering never shifts a serialized encoding.
+/// </summary>
+public enum PlanState
+{
+    /// <summary>On track — recent logs are within band; absorb with no plan change.</summary>
+    OnTrack = 0,
+
+    /// <summary>Minor deviation — a missed key workout or accumulating small misses; micro-adjust territory.</summary>
+    MinorDeviation = 1,
+
+    /// <summary>Needs adjustment — a restructure has fired; the hysteresis dead-zone is active.</summary>
+    NeedsAdjustment = 2,
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Adaptation/WorkoutKind.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Adaptation/WorkoutKind.cs
@@ -1,0 +1,19 @@
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+
+namespace RunCoach.Api.Modules.Training.Adaptation;
+
+/// <summary>
+/// Classifies a <see cref="WorkoutType"/> as a "key" (quality or long) session —
+/// Tempo, Interval, Repetition, or LongRun — versus an easy/recovery/cross-train day.
+/// Shared by the deviation engine and the micro-adjust planner so the key-workout
+/// definition lives in one place (Slice 3 PR2 / Unit 1).
+/// </summary>
+internal static class WorkoutKind
+{
+    /// <summary>Whether the workout type is a key (quality/long) session.</summary>
+    public static bool IsKey(WorkoutType type) =>
+        type is WorkoutType.Tempo
+            or WorkoutType.Interval
+            or WorkoutType.Repetition
+            or WorkoutType.LongRun;
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Computations/PaceDerivation.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Computations/PaceDerivation.cs
@@ -1,0 +1,28 @@
+using RunCoach.Api.Modules.Training.Models;
+
+namespace RunCoach.Api.Modules.Training.Computations;
+
+/// <summary>
+/// Shared, divide-by-zero-guarded pace derivation (<see cref="Distance"/> /
+/// <see cref="Duration"/> &#8594; seconds-per-km). Lifted out of the presentation-layer
+/// <c>RecentLogFormatter</c> so the deviation engine and the prompt formatter share
+/// one guarded derivation (Slice 3 PR2 / Unit 1).
+/// </summary>
+internal static class PaceDerivation
+{
+    /// <summary>
+    /// Derives the average pace from distance and duration, or <c>null</c> when the
+    /// inputs cannot yield a meaningful pace (zero/non-positive distance or duration —
+    /// e.g. a skipped run). Never throws: the guard also protects
+    /// <see cref="Pace.FromSecondsPerKm"/>, which rejects non-positive values.
+    /// </summary>
+    public static Pace? TryDerive(Distance distance, Duration duration)
+    {
+        if (distance.Kilometers <= 0 || duration.TotalSeconds <= 0)
+        {
+            return null;
+        }
+
+        return Pace.FromSecondsPerKm(duration.TotalSeconds / distance.Kilometers);
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Adaptation/DeviationEngineTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Adaptation/DeviationEngineTests.cs
@@ -1,0 +1,202 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+using RunCoach.Api.Modules.Training.Adaptation;
+using RunCoach.Api.Modules.Training.Models;
+using RunCoach.Api.Modules.Training.Workouts;
+
+namespace RunCoach.Api.Tests.Modules.Training.Adaptation;
+
+/// <summary>
+/// Unit tests for <see cref="DeviationEngine"/> (Slice 3 PR2 / Unit 1): the
+/// deterministic comparison of a logged workout's actuals against its frozen
+/// prescription snapshot.
+/// </summary>
+public sealed class DeviationEngineTests
+{
+    private readonly DeviationEngine _sut = new();
+
+    [Fact]
+    public void Evaluate_WithNullPrescriptionSnapshot_ReturnsNullNoOp()
+    {
+        // Arrange — an off-plan log carries no prescription snapshot.
+        var log = Log(km: 8, minutes: 40, prescription: null);
+
+        // Act
+        var actual = _sut.Evaluate(log);
+
+        // Assert
+        actual.Should().BeNull(because: "an off-plan log has no prescription to deviate from");
+    }
+
+    [Fact]
+    public void Evaluate_PaceSlowerThanSlowBound_ReportsBandMembershipWithSignedMagnitude()
+    {
+        // Arrange — band 280–320 sec/km; 10 km in 60 min = 360 sec/km (slower than the 320 Slow bound).
+        var snapshot = Snapshot(km: 10, minutes: 50, paceFast: 280, paceSlow: 320, type: WorkoutType.Tempo);
+        var log = Log(km: 10, minutes: 60, prescription: snapshot);
+
+        // Act
+        var actual = _sut.Evaluate(log);
+
+        // Assert — pace is band membership (slower-than-slow) with a signed magnitude, not a scalar diff.
+        actual.Should().NotBeNull();
+        actual!.PaceBand.Should().Be(PaceBandMembership.SlowerThanSlow);
+        actual.PaceDeviationSecondsPerKm.Should().BeApproximately(
+            40.0, 1e-6, because: "360 sec/km is 40 sec/km slower than the 320 Slow bound");
+        actual.DistanceDeviationPercent.Should().BeApproximately(0.0, 1e-6);
+        actual.DurationDeviationPercent.Should().BeApproximately(
+            20.0, 1e-6, because: "60 min vs the prescribed 50 min is +20%");
+    }
+
+    [Fact]
+    public void Evaluate_PaceInsideBand_ReportsInsideBandWithZeroMagnitude()
+    {
+        // Arrange — band 280–320; 10 km in 50 min = 300 sec/km (inside the band).
+        var snapshot = Snapshot(km: 10, minutes: 50, paceFast: 280, paceSlow: 320);
+        var log = Log(km: 10, minutes: 50, prescription: snapshot);
+
+        // Act
+        var actual = _sut.Evaluate(log);
+
+        // Assert
+        actual!.PaceBand.Should().Be(PaceBandMembership.InsideBand);
+        actual.PaceDeviationSecondsPerKm.Should().Be(0.0);
+    }
+
+    [Fact]
+    public void Evaluate_PaceFasterThanFastBound_ReportsNegativeMagnitude()
+    {
+        // Arrange — band 280–320; 10 km in 45 min = 270 sec/km (faster than the 280 Fast bound).
+        var snapshot = Snapshot(km: 10, minutes: 50, paceFast: 280, paceSlow: 320);
+        var log = Log(km: 10, minutes: 45, prescription: snapshot);
+
+        // Act
+        var actual = _sut.Evaluate(log);
+
+        // Assert
+        actual!.PaceBand.Should().Be(PaceBandMembership.FasterThanFast);
+        actual.PaceDeviationSecondsPerKm.Should().BeApproximately(
+            -10.0, 1e-6, because: "270 sec/km is 10 sec/km faster than the 280 Fast bound");
+    }
+
+    [Fact]
+    public void Evaluate_ZeroDistanceCompleteLog_ReportsUnknownPaceWithoutThrowing()
+    {
+        // Arrange — a degenerate zero-distance log must not divide by zero or invent a slow pace.
+        var log = Log(km: 0, minutes: 30, prescription: Snapshot(), status: CompletionStatus.Complete);
+
+        // Act
+        var act = () => _sut.Evaluate(log);
+
+        // Assert
+        act.Should().NotThrow();
+        act()!.PaceBand.Should().Be(
+            PaceBandMembership.Unknown,
+            because: "a zero-distance log yields no derivable pace and must not produce a spurious deviation");
+        act()!.PaceDeviationSecondsPerKm.Should().Be(0.0);
+    }
+
+    [Fact]
+    public void Evaluate_ZeroDurationCompleteLog_ReportsUnknownPaceWithoutThrowing()
+    {
+        // Arrange
+        var log = Log(km: 5, minutes: 0, prescription: Snapshot(), status: CompletionStatus.Complete);
+
+        // Act
+        var act = () => _sut.Evaluate(log);
+
+        // Assert
+        act.Should().NotThrow();
+        act()!.PaceBand.Should().Be(PaceBandMembership.Unknown);
+    }
+
+    [Fact]
+    public void Evaluate_SkippedKeyWorkout_ReportsUnknownPaceAndCarriesCompletionAndKeyFlags()
+    {
+        // Arrange — a skipped interval session: no actuals, but still a key workout.
+        var log = Log(
+            km: 0,
+            minutes: 0,
+            prescription: Snapshot(type: WorkoutType.Interval),
+            status: CompletionStatus.Skipped);
+
+        // Act
+        var actual = _sut.Evaluate(log);
+
+        // Assert
+        actual!.PaceBand.Should().Be(PaceBandMembership.Unknown);
+        actual.CompletionStatus.Should().Be(CompletionStatus.Skipped);
+        actual.IsKeyWorkout.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(WorkoutType.Tempo, true)]
+    [InlineData(WorkoutType.Interval, true)]
+    [InlineData(WorkoutType.Repetition, true)]
+    [InlineData(WorkoutType.LongRun, true)]
+    [InlineData(WorkoutType.Easy, false)]
+    [InlineData(WorkoutType.Recovery, false)]
+    [InlineData(WorkoutType.CrossTrain, false)]
+    public void Evaluate_ClassifiesKeyWorkoutsByPrescribedType(WorkoutType type, bool expectedIsKey)
+    {
+        // Arrange
+        var log = Log(km: 10, minutes: 50, prescription: Snapshot(type: type));
+
+        // Act
+        var actual = _sut.Evaluate(log);
+
+        // Assert
+        actual!.IsKeyWorkout.Should().Be(expectedIsKey);
+    }
+
+    [Fact]
+    public void Evaluate_CarriesTheLogOccurredOnDate()
+    {
+        // Arrange
+        var occurredOn = new DateOnly(2026, 6, 3);
+        var log = Log(km: 10, minutes: 50, prescription: Snapshot(), occurredOn: occurredOn);
+
+        // Act
+        var actual = _sut.Evaluate(log);
+
+        // Assert
+        actual!.OccurredOn.Should().Be(occurredOn);
+    }
+
+    private static WorkoutLog Log(
+        double km,
+        double minutes,
+        WorkoutPrescriptionSnapshot? prescription,
+        CompletionStatus status = CompletionStatus.Complete,
+        DateOnly? occurredOn = null) =>
+        new()
+        {
+            WorkoutLogId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            TenantId = Guid.NewGuid().ToString(),
+            IdempotencyKey = Guid.NewGuid(),
+            OccurredOn = occurredOn ?? new DateOnly(2026, 6, 1),
+            Distance = Distance.FromKilometers(km),
+            Duration = Duration.FromMinutes(minutes),
+            CompletionStatus = status,
+            Prescription = prescription,
+            CreatedOn = default,
+            ModifiedOn = default,
+        };
+
+    private static WorkoutPrescriptionSnapshot Snapshot(
+        double km = 10.0,
+        double minutes = 50.0,
+        double paceFast = 280.0,
+        double paceSlow = 320.0,
+        WorkoutType type = WorkoutType.Tempo) =>
+        WorkoutPrescriptionSnapshot.Create(
+            sourcePlanId: Guid.NewGuid(),
+            weekNumber: 1,
+            dayOfWeek: 3,
+            workoutType: type,
+            prescribedDistance: Distance.FromKilometers(km),
+            prescribedDuration: Duration.FromMinutes(minutes),
+            prescribedPaceFast: Pace.FromSecondsPerKm(paceFast),
+            prescribedPaceSlow: Pace.FromSecondsPerKm(paceSlow));
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Adaptation/DeviationEngineTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Adaptation/DeviationEngineTests.cs
@@ -163,6 +163,28 @@ public sealed class DeviationEngineTests
         actual!.OccurredOn.Should().Be(occurredOn);
     }
 
+    [Fact]
+    public void Evaluate_PartialLog_DerivesRealPaceFromTruncatedActualsAndCarriesPartialStatus()
+    {
+        // Arrange — a Partial (cut-short) run still has real actuals: band 280-320,
+        // 8 km in 48 min = 360 sec/km (slower than the Slow bound), short of the prescribed 10 km.
+        var snapshot = Snapshot(km: 10, minutes: 50, paceFast: 280, paceSlow: 320, type: WorkoutType.Tempo);
+        var log = Log(km: 8, minutes: 48, prescription: snapshot, status: CompletionStatus.Partial);
+
+        // Act
+        var actual = _sut.Evaluate(log);
+
+        // Assert — unlike Skipped, a Partial is not short-circuited to Unknown; it derives a real pace.
+        actual!.CompletionStatus.Should().Be(CompletionStatus.Partial);
+        actual.PaceBand.Should().Be(
+            PaceBandMembership.SlowerThanSlow,
+            because: "only Skipped forces Unknown; a Partial derives pace from its truncated distance/duration");
+        actual.PaceDeviationSecondsPerKm.Should().BeApproximately(
+            40.0, 1e-6, because: "360 sec/km is 40 sec/km slower than the 320 Slow bound");
+        actual.DistanceDeviationPercent.Should().BeApproximately(
+            -20.0, 1e-6, because: "8 km vs the prescribed 10 km is -20%");
+    }
+
     private static WorkoutLog Log(
         double km,
         double minutes,

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Adaptation/EscalationClassifierTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Adaptation/EscalationClassifierTests.cs
@@ -199,6 +199,64 @@ public sealed class EscalationClassifierTests
     }
 
     [Fact]
+    public void Classify_PartialLogInBand_UnderPerformsButDoesNotCountAsMissedDay()
+    {
+        // Arrange — a Partial (cut-short) log with in-band pace and on-target distance:
+        // the not-Complete clause of IsUnderPerformance alone drives under-performance,
+        // but a Partial is not a Skipped (missed) day.
+        var partial = Dev(status: CompletionStatus.Partial);
+
+        // Act
+        var actual = _sut.Classify(partial, SafetyTier.Green, AdaptationSignalState.Initial);
+
+        // Assert — scores like a Skipped log, but never advances the consecutive-missed streak.
+        actual.NextState.RollingDeviationScore.Should().BeApproximately(
+            AdaptationThresholds.MinorDeviationStep,
+            1e-6,
+            because: "a Partial log under-performs via the not-Complete clause, like a Skipped one");
+        actual.NextState.ConsecutiveMissedDays.Should().Be(
+            0, because: "only a Skipped log counts toward the consecutive-missed-day streak");
+        actual.EscalationLevel.Should().Be(EscalationLevel.Absorb);
+    }
+
+    [Fact]
+    public void Classify_TwoPartialLogs_AccumulateToMicroAdjust()
+    {
+        // Arrange / Act — two Partial logs accumulate the score exactly like minor deviations,
+        // reaching the micro-adjust threshold without ever touching the missed-day streak.
+        var afterFirst = _sut.Classify(
+            Dev(Day(1), status: CompletionStatus.Partial), SafetyTier.Green, AdaptationSignalState.Initial);
+        var afterSecond = _sut.Classify(
+            Dev(Day(2), status: CompletionStatus.Partial), SafetyTier.Green, afterFirst.NextState);
+
+        // Assert
+        afterFirst.EscalationLevel.Should().Be(
+            EscalationLevel.Absorb, because: "a single Partial log is absorbed below the micro-adjust threshold");
+        afterSecond.EscalationLevel.Should().Be(EscalationLevel.MicroAdjust);
+        afterSecond.NextState.ConsecutiveMissedDays.Should().Be(
+            0, because: "Partial logs never accrue a consecutive-missed-day streak");
+    }
+
+    [Theory]
+    [InlineData(-6.0, 1.0, PlanState.MinorDeviation)] // just beyond the -5% tolerance: under-performs
+    [InlineData(-4.0, 0.0, PlanState.OnTrack)] // just inside the -5% tolerance: absorbed as on target
+    public void Classify_DistanceShortfallAloneAtToleranceBoundary_DrivesUnderPerformance(
+        double distancePct, double expectedScore, PlanState expectedPlanState)
+    {
+        // Arrange — a Complete, in-band log whose only deviation is running short of the prescribed
+        // distance, isolating the distance clause of IsUnderPerformance at the ±tolerance boundary.
+        var log = Dev(distancePct: distancePct);
+
+        // Act
+        var actual = _sut.Classify(log, SafetyTier.Green, AdaptationSignalState.Initial);
+
+        // Assert — a single deviation never reaches micro-adjust; the score and plan-state pin the boundary.
+        actual.EscalationLevel.Should().Be(EscalationLevel.Absorb);
+        actual.NextState.RollingDeviationScore.Should().BeApproximately(expectedScore, 1e-6);
+        actual.NextState.PlanState.Should().Be(expectedPlanState);
+    }
+
+    [Fact]
     public void Classify_NullDeviation_Throws()
     {
         // Act

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Adaptation/EscalationClassifierTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Adaptation/EscalationClassifierTests.cs
@@ -1,0 +1,258 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Training.Adaptation;
+using RunCoach.Api.Modules.Training.Safety;
+using RunCoach.Api.Modules.Training.Workouts;
+
+namespace RunCoach.Api.Tests.Modules.Training.Adaptation;
+
+/// <summary>
+/// Unit tests for <see cref="EscalationClassifier"/> (Slice 3 PR2 / Unit 1): the
+/// deterministic L0/L1/L2 resolution and the asymmetric enter/exit hysteresis.
+/// </summary>
+public sealed class EscalationClassifierTests
+{
+    private readonly EscalationClassifier _sut = new();
+
+    [Fact]
+    public void Classify_WithinBandOnGreen_ResolvesToAbsorbWithNoPlanChange()
+    {
+        // Act
+        var actual = _sut.Classify(OnTarget(), SafetyTier.Green, AdaptationSignalState.Initial);
+
+        // Assert — Level 0: absorb, no downstream adaptation work.
+        actual.EscalationLevel.Should().Be(EscalationLevel.Absorb);
+        actual.AdaptationKind.Should().Be(AdaptationKind.Absorb);
+        actual.NextState.PlanState.Should().Be(PlanState.OnTrack);
+    }
+
+    [Fact]
+    public void Classify_SingleMissedKeyWorkoutOnGreen_ResolvesToMicroAdjust()
+    {
+        // Act
+        var actual = _sut.Classify(MissedKey(), SafetyTier.Green, AdaptationSignalState.Initial);
+
+        // Assert — Level 1: a single reschedulable missed key workout.
+        actual.EscalationLevel.Should().Be(EscalationLevel.MicroAdjust);
+        actual.AdaptationKind.Should().Be(AdaptationKind.Nudge);
+    }
+
+    [Fact]
+    public void Classify_TwoMinorDeviationsOnGreen_ResolvesToMicroAdjust()
+    {
+        // Arrange / Act — one minor deviation absorbs; the second reaches the micro-adjust threshold.
+        var afterFirst = _sut.Classify(MinorUnder(Day(1)), SafetyTier.Green, AdaptationSignalState.Initial);
+        var afterSecond = _sut.Classify(MinorUnder(Day(2)), SafetyTier.Green, afterFirst.NextState);
+
+        // Assert
+        afterFirst.EscalationLevel.Should().Be(
+            EscalationLevel.Absorb, because: "a single minor band deviation is absorbed");
+        afterSecond.EscalationLevel.Should().Be(EscalationLevel.MicroAdjust);
+        afterSecond.AdaptationKind.Should().Be(AdaptationKind.Nudge);
+    }
+
+    [Fact]
+    public void Classify_SustainedUnderPerformanceCrossingEnterThreshold_ResolvesToRestructure()
+    {
+        // Arrange / Act — three sustained minor deviations cross the L1→L2 enter threshold.
+        var d1 = _sut.Classify(MinorUnder(Day(1)), SafetyTier.Green, AdaptationSignalState.Initial);
+        var d2 = _sut.Classify(MinorUnder(Day(2)), SafetyTier.Green, d1.NextState);
+        var d3 = _sut.Classify(MinorUnder(Day(3)), SafetyTier.Green, d2.NextState);
+
+        // Assert
+        d3.EscalationLevel.Should().Be(EscalationLevel.Restructure);
+        d3.AdaptationKind.Should().Be(AdaptationKind.Restructure);
+        d3.NextState.PlanState.Should().Be(PlanState.NeedsAdjustment);
+    }
+
+    [Fact]
+    public void Classify_ThreeConsecutiveMissedDays_ResolvesToRestructure()
+    {
+        // Arrange / Act — three consecutive skipped days.
+        var d1 = _sut.Classify(MissedEasy(Day(1)), SafetyTier.Green, AdaptationSignalState.Initial);
+        var d2 = _sut.Classify(MissedEasy(Day(2)), SafetyTier.Green, d1.NextState);
+        var d3 = _sut.Classify(MissedEasy(Day(3)), SafetyTier.Green, d2.NextState);
+
+        // Assert
+        d3.NextState.ConsecutiveMissedDays.Should().Be(3);
+        d3.EscalationLevel.Should().Be(EscalationLevel.Restructure);
+    }
+
+    [Fact]
+    public void Classify_OverPerformanceOnGreen_DoesNotUpgradeEscalation()
+    {
+        // Act
+        var actual = _sut.Classify(OverPerformance(), SafetyTier.Green, AdaptationSignalState.Initial);
+
+        // Assert — over-performance never upgrades the plan (DEC-012).
+        actual.EscalationLevel.Should().Be(EscalationLevel.Absorb);
+    }
+
+    [Fact]
+    public void Classify_LargeOverPerformance_StillAbsorbsBoundedByCap()
+    {
+        // Arrange — an over-performance well beyond the over-performance cap.
+        var huge = Dev(
+            isKey: true,
+            distancePct: 25.0,
+            durationPct: -15.0,
+            paceBand: PaceBandMembership.FasterThanFast,
+            paceDev: -45.0);
+
+        // Act
+        var actual = _sut.Classify(huge, SafetyTier.Green, AdaptationSignalState.Initial);
+
+        // Assert — still bounded: no escalation from over-performance.
+        actual.EscalationLevel.Should().Be(EscalationLevel.Absorb);
+    }
+
+    [Fact]
+    public void Classify_SecondLogInsideHysteresisDeadZone_DoesNotRefireRestructure()
+    {
+        // Arrange — a restructure has just fired: NeedsAdjustment, score at the cap, fired Day 1.
+        var afterRestructure = new AdaptationSignalState(
+            PlanState.NeedsAdjustment, AdaptationThresholds.MaxRollingDeviationScore, 0, Day(1));
+
+        // Act — a second on-target log two days later, still inside the cooldown.
+        var actual = _sut.Classify(OnTarget(Day(3)), SafetyTier.Green, afterRestructure);
+
+        // Assert — no re-fire; the dead-zone holds NeedsAdjustment.
+        actual.EscalationLevel.Should().Be(EscalationLevel.Absorb);
+        actual.NextState.PlanState.Should().Be(PlanState.NeedsAdjustment);
+    }
+
+    [Fact]
+    public void Classify_SignalFallsButStaysAboveExitThreshold_HoldsNeedsAdjustmentNoRefire()
+    {
+        // Arrange — past the cooldown, but the rolling signal still sits above the exit threshold.
+        var afterRestructure = new AdaptationSignalState(PlanState.NeedsAdjustment, 1.5, 0, Day(1));
+
+        // Act — a fresh under-performance long after the cooldown elapsed.
+        var actual = _sut.Classify(MinorUnder(Day(20)), SafetyTier.Green, afterRestructure);
+
+        // Assert — asymmetric hysteresis: the state does not return to on-track and no restructure re-fires.
+        actual.NextState.PlanState.Should().Be(
+            PlanState.NeedsAdjustment, because: "the signal has not cleared the exit threshold");
+        actual.EscalationLevel.Should().NotBe(
+            EscalationLevel.Restructure, because: "a restructure cannot re-fire inside the dead-zone");
+    }
+
+    [Fact]
+    public void Classify_CooldownElapsedAndSignalBelowExit_ClearsToOnTrack()
+    {
+        // Arrange — past the cooldown and the signal will decay below the exit threshold.
+        var afterRestructure = new AdaptationSignalState(PlanState.NeedsAdjustment, 1.5, 0, Day(1));
+
+        // Act — an on-target log long after the cooldown drops the score below exit (1.5 * 0.5 = 0.75).
+        var actual = _sut.Classify(OnTarget(Day(20)), SafetyTier.Green, afterRestructure);
+
+        // Assert
+        actual.NextState.PlanState.Should().Be(PlanState.OnTrack);
+        actual.EscalationLevel.Should().Be(EscalationLevel.Absorb);
+    }
+
+    [Fact]
+    public void Classify_DeviationWithinTolerance_TreatedAsOnTargetAbsorb()
+    {
+        // Arrange — sub-tolerance distance/duration drift with the pace inside the band.
+        var withinTolerance = Dev(distancePct: 2.0, durationPct: -3.0);
+
+        // Act
+        var actual = _sut.Classify(withinTolerance, SafetyTier.Green, AdaptationSignalState.Initial);
+
+        // Assert — percentage-based tolerance treats this as on target.
+        actual.EscalationLevel.Should().Be(EscalationLevel.Absorb);
+        actual.NextState.PlanState.Should().Be(PlanState.OnTrack);
+    }
+
+    [Fact]
+    public void Classify_RedSafetyTier_ResolvesToAbsorbWithNoPlanChange()
+    {
+        // Act — Red short-circuits to safety-only in PR5; the classifier yields no plan adaptation.
+        var actual = _sut.Classify(MissedKey(), SafetyTier.Red, AdaptationSignalState.Initial);
+
+        // Assert
+        actual.EscalationLevel.Should().Be(EscalationLevel.Absorb);
+        actual.AdaptationKind.Should().Be(AdaptationKind.Absorb);
+    }
+
+    [Fact]
+    public void Classify_AmberSafetyTier_ResolvesLevelLikeGreen()
+    {
+        // Act
+        var actual = _sut.Classify(MissedKey(), SafetyTier.Amber, AdaptationSignalState.Initial);
+
+        // Assert — Amber does not change the level; the non-increase clamp is PR4's post-LLM validator.
+        actual.EscalationLevel.Should().Be(EscalationLevel.MicroAdjust);
+    }
+
+    [Fact]
+    public void Classify_NonSkippedLog_ResetsConsecutiveMissedStreak()
+    {
+        // Arrange / Act
+        var afterMiss = _sut.Classify(MissedEasy(Day(1)), SafetyTier.Green, AdaptationSignalState.Initial);
+        var afterComplete = _sut.Classify(OnTarget(Day(2)), SafetyTier.Green, afterMiss.NextState);
+
+        // Assert
+        afterMiss.NextState.ConsecutiveMissedDays.Should().Be(1);
+        afterComplete.NextState.ConsecutiveMissedDays.Should().Be(
+            0, because: "a non-skipped log resets the missed-day streak");
+    }
+
+    [Fact]
+    public void Classify_NullDeviation_Throws()
+    {
+        // Act
+        var act = () => _sut.Classify(null!, SafetyTier.Green, AdaptationSignalState.Initial);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    private static DateOnly Day(int day) => new(2026, 6, day);
+
+    /// <summary>Builds a <see cref="DeviationResult"/>; an on-target Complete log by default.</summary>
+    private static DeviationResult Dev(
+        DateOnly? on = null,
+        CompletionStatus status = CompletionStatus.Complete,
+        bool isKey = false,
+        double distancePct = 0.0,
+        double durationPct = 0.0,
+        PaceBandMembership paceBand = PaceBandMembership.InsideBand,
+        double paceDev = 0.0) =>
+        new(on ?? Day(1), status, isKey, distancePct, durationPct, paceBand, paceDev);
+
+    private static DeviationResult OnTarget(DateOnly? on = null) => Dev(on);
+
+    private static DeviationResult MinorUnder(DateOnly? on = null) =>
+        Dev(
+            on,
+            durationPct: 12.0,
+            paceBand: PaceBandMembership.SlowerThanSlow,
+            paceDev: 15.0);
+
+    private static DeviationResult MissedKey(DateOnly? on = null) =>
+        Dev(
+            on,
+            status: CompletionStatus.Skipped,
+            isKey: true,
+            distancePct: -100.0,
+            durationPct: -100.0,
+            paceBand: PaceBandMembership.Unknown);
+
+    private static DeviationResult MissedEasy(DateOnly? on = null) =>
+        Dev(
+            on,
+            status: CompletionStatus.Skipped,
+            distancePct: -100.0,
+            durationPct: -100.0,
+            paceBand: PaceBandMembership.Unknown);
+
+    private static DeviationResult OverPerformance(DateOnly? on = null) =>
+        Dev(
+            on,
+            isKey: true,
+            distancePct: 8.0,
+            durationPct: -5.0,
+            paceBand: PaceBandMembership.FasterThanFast,
+            paceDev: -20.0);
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Adaptation/MicroAdjustPlannerTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Adaptation/MicroAdjustPlannerTests.cs
@@ -1,0 +1,194 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+using RunCoach.Api.Modules.Training.Adaptation;
+
+namespace RunCoach.Api.Tests.Modules.Training.Adaptation;
+
+/// <summary>
+/// Unit tests for <see cref="MicroAdjustPlanner"/> (Slice 3 PR2 / Unit 1): the
+/// deterministic forward swap of a missed key workout that never stacks two key
+/// workouts on consecutive days.
+/// </summary>
+public sealed class MicroAdjustPlannerTests
+{
+    [Fact]
+    public void TryPlanSwap_MovesMissedKeyWorkoutForwardToNearestValidDay()
+    {
+        // Arrange — Monday's Tempo (key) is missed; Tue/Wed/Fri are easy days.
+        var week = new[]
+        {
+            W(0, WorkoutType.Easy),
+            W(1, WorkoutType.Tempo),
+            W(2, WorkoutType.Easy),
+            W(3, WorkoutType.Easy),
+            W(4, WorkoutType.Interval),
+            W(5, WorkoutType.Easy),
+            W(6, WorkoutType.LongRun),
+        };
+
+        // Act
+        var planned = MicroAdjustPlanner.TryPlanSwap(week, missedDayOfWeek: 1, weekNumber: 1, out var diff);
+
+        // Assert — swapped forward to the nearest valid (non-stacking) day, Tuesday.
+        planned.Should().BeTrue();
+        diff.WorkoutChanges.Should().HaveCount(2);
+        diff.WeeklyTargetChanges.Should().BeEmpty();
+        MovedKeyWorkoutDay(diff).Should().Be(2, because: "Tuesday is the nearest forward day that does not stack key workouts");
+        AssertNoConsecutiveKeyWorkouts(Apply(week, diff));
+    }
+
+    [Fact]
+    public void TryPlanSwap_SkipsForwardDaysThatWouldStackKeyWorkouts()
+    {
+        // Arrange — Tuesday and Thursday are easy but flank Wednesday's Interval session,
+        // so only Friday yields a non-stacking swap.
+        var week = new[]
+        {
+            W(1, WorkoutType.Tempo),
+            W(2, WorkoutType.Easy),
+            W(3, WorkoutType.Interval),
+            W(4, WorkoutType.Easy),
+            W(5, WorkoutType.Easy),
+        };
+
+        // Act
+        var planned = MicroAdjustPlanner.TryPlanSwap(week, missedDayOfWeek: 1, weekNumber: 1, out var diff);
+
+        // Assert
+        planned.Should().BeTrue();
+        MovedKeyWorkoutDay(diff).Should().Be(5, because: "Tue and Thu would both stack against Wednesday's key workout");
+        AssertNoConsecutiveKeyWorkouts(Apply(week, diff));
+    }
+
+    [Fact]
+    public void TryPlanSwap_MovesKeyWorkoutForwardOnly()
+    {
+        // Arrange — the missed key workout is on Saturday; there is no later day to move it to.
+        var week = new[]
+        {
+            W(2, WorkoutType.Easy),
+            W(4, WorkoutType.Easy),
+            W(6, WorkoutType.Tempo),
+        };
+
+        // Act
+        var planned = MicroAdjustPlanner.TryPlanSwap(week, missedDayOfWeek: 6, weekNumber: 1, out var diff);
+
+        // Assert — never reschedules backward; no forward slot means no deterministic swap.
+        planned.Should().BeFalse();
+        diff.WorkoutChanges.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryPlanSwap_MissedDayHoldsNonKeyWorkout_ReturnsFalse()
+    {
+        // Arrange — the missed day is an easy run; the micro-adjust swap only reschedules key workouts.
+        var week = new[]
+        {
+            W(1, WorkoutType.Easy),
+            W(3, WorkoutType.Tempo),
+            W(5, WorkoutType.Easy),
+        };
+
+        // Act
+        var planned = MicroAdjustPlanner.TryPlanSwap(week, missedDayOfWeek: 1, weekNumber: 1, out var diff);
+
+        // Assert
+        planned.Should().BeFalse();
+        diff.WorkoutChanges.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryPlanSwap_MissedDayHasNoScheduledWorkout_ReturnsFalse()
+    {
+        // Arrange — there is no workout on the claimed missed day (a rest day).
+        var week = new[]
+        {
+            W(1, WorkoutType.Tempo),
+            W(3, WorkoutType.Easy),
+        };
+
+        // Act
+        var planned = MicroAdjustPlanner.TryPlanSwap(week, missedDayOfWeek: 2, weekNumber: 1, out _);
+
+        // Assert
+        planned.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryPlanSwap_EveryForwardDayWouldStack_ReturnsFalse()
+    {
+        // Arrange — both easy forward days are flanked by key workouts; no valid swap exists.
+        var week = new[]
+        {
+            W(1, WorkoutType.Tempo),
+            W(2, WorkoutType.Easy),
+            W(3, WorkoutType.Interval),
+            W(4, WorkoutType.Easy),
+            W(5, WorkoutType.Interval),
+            W(6, WorkoutType.Repetition),
+        };
+
+        // Act
+        var planned = MicroAdjustPlanner.TryPlanSwap(week, missedDayOfWeek: 1, weekNumber: 1, out var diff);
+
+        // Assert — orchestration escalates this micro-adjust to an L2 restructure.
+        planned.Should().BeFalse();
+        diff.WorkoutChanges.Should().BeEmpty();
+    }
+
+    private static int MovedKeyWorkoutDay(PlanAdaptationDiff diff) =>
+        diff.WorkoutChanges
+            .Single(change => change.After is { } after && WorkoutKind.IsKey(after.WorkoutType))
+            .DayOfWeek;
+
+    private static List<WorkoutOutput> Apply(IReadOnlyList<WorkoutOutput> week, PlanAdaptationDiff diff)
+    {
+        var byDay = week.ToDictionary(workout => workout.DayOfWeek);
+        foreach (var change in diff.WorkoutChanges)
+        {
+            if (change.After is { } after)
+            {
+                byDay[change.DayOfWeek] = after;
+            }
+            else
+            {
+                byDay.Remove(change.DayOfWeek);
+            }
+        }
+
+        return byDay.Values.OrderBy(workout => workout.DayOfWeek).ToList();
+    }
+
+    private static void AssertNoConsecutiveKeyWorkouts(IReadOnlyList<WorkoutOutput> week)
+    {
+        var keyDays = week
+            .Where(workout => WorkoutKind.IsKey(workout.WorkoutType))
+            .Select(workout => workout.DayOfWeek)
+            .OrderBy(day => day)
+            .ToList();
+
+        for (var i = 1; i < keyDays.Count; i++)
+        {
+            (keyDays[i] - keyDays[i - 1]).Should().BeGreaterThan(
+                1, because: "no two key workouts may land on consecutive days");
+        }
+    }
+
+    private static WorkoutOutput W(int dayOfWeek, WorkoutType type) =>
+        new()
+        {
+            DayOfWeek = dayOfWeek,
+            WorkoutType = type,
+            Title = type.ToString(),
+            TargetDistanceKm = 10,
+            TargetDurationMinutes = 50,
+            TargetPaceEasySecPerKm = 330,
+            TargetPaceFastSecPerKm = 280,
+            Segments = Array.Empty<WorkoutSegmentOutput>(),
+            WarmupNotes = string.Empty,
+            CooldownNotes = string.Empty,
+            CoachingNotes = string.Empty,
+            PerceivedEffort = 5,
+        };
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Training/Computations/PaceDerivationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Training/Computations/PaceDerivationTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Training.Computations;
+using RunCoach.Api.Modules.Training.Models;
+
+namespace RunCoach.Api.Tests.Modules.Training.Computations;
+
+/// <summary>
+/// Unit tests for <see cref="PaceDerivation"/>, the shared divide-by-zero-guarded
+/// pace-derivation utility lifted out of the presentation-layer
+/// <c>RecentLogFormatter</c> (Slice 3 PR2 / Unit 1).
+/// </summary>
+public sealed class PaceDerivationTests
+{
+    [Fact]
+    public void TryDerive_WithPositiveDistanceAndDuration_ReturnsSecondsPerKm()
+    {
+        // Arrange — 40 minutes over 8 km is exactly 5:00/km = 300 sec/km.
+        var distance = Distance.FromKilometers(8.0);
+        var duration = Duration.FromMinutes(40.0);
+
+        // Act
+        var actual = PaceDerivation.TryDerive(distance, duration);
+
+        // Assert
+        actual.Should().NotBeNull();
+        actual!.Value.SecondsPerKm.Should().BeApproximately(300.0, 1e-9);
+    }
+
+    [Fact]
+    public void TryDerive_WithZeroDistance_ReturnsNullWithoutThrowing()
+    {
+        // Arrange — a skipped/degenerate log carries no distance.
+        var distance = Distance.FromKilometers(0);
+        var duration = Duration.FromMinutes(30);
+
+        // Act
+        var act = () => PaceDerivation.TryDerive(distance, duration);
+
+        // Assert — defined "no pace" result, never a divide-by-zero or Pace-ctor throw.
+        act.Should().NotThrow();
+        act().Should().BeNull(because: "a zero-distance log cannot yield a meaningful pace");
+    }
+
+    [Fact]
+    public void TryDerive_WithZeroDuration_ReturnsNullWithoutThrowing()
+    {
+        // Arrange
+        var distance = Distance.FromKilometers(5);
+        var duration = Duration.FromTicks(0);
+
+        // Act
+        var act = () => PaceDerivation.TryDerive(distance, duration);
+
+        // Assert
+        act.Should().NotThrow();
+        act().Should().BeNull(because: "a zero-duration log cannot yield a meaningful pace");
+    }
+}


### PR DESCRIPTION
## Slice 3 — PR2: deterministic deviation engine + escalation classifier (Unit 1)

The pure-C# **decision layer** of the adaptation loop. Given a logged workout and its
frozen prescription snapshot, it decides *how big a deal* a deviation is — without any
LLM, Marten append, or DB access. PR5 (orchestration) wires this into the post-log-create
flow and owns the event append.

Spec: `docs/specs/17-spec-slice-3-adaptation/` Unit 1 + `deterministic-deviation-and-escalation.feature`.
Merge order: PR1 ✅ (#161) → PR3 ✅ (#163) → **PR2 (this)** → PR4 → PR5 → PR6 → PR7.

### What's in it

- **`PaceDerivation`** — shared divide-by-zero-guarded `Distance`/`Duration` → sec/km util,
  lifted out of the presentation-layer `RecentLogFormatter.FormatPace`, which is refactored
  to consume it with **byte-identical output** (guarded by the existing `RecentLogFormatterTests`
  + `ContextAssemblerTests`).
- **`DeviationEngine` + `DeviationResult` + `PaceBandMembership`** — compares actuals vs the
  frozen `WorkoutPrescriptionSnapshot`. Pace deviation is reported as **band membership**
  (inside / faster-than-fast / slower-than-slow + signed sec/km magnitude), distance/duration
  as signed percentages. A `null` snapshot (off-plan) ⇒ `null` (no-op). Skipped or
  zero/near-zero logs ⇒ `Unknown` pace, never a spurious deviation, never a throw.
- **`EscalationClassifier` + `AdaptationSignalState` + `PlanState` + `EscalationDecision`** —
  resolves the DEC-012 level (L0 absorb / L1 micro-adjust / L2 restructure) from the deviation,
  the `SafetyTier`, and the prior signal state, with **asymmetric enter/exit hysteresis** so a
  restructure can't flip-flop (a dead-zone holds until both the cooldown elapses and the rolling
  signal clears the lower exit threshold). A pure transition function.
- **`MicroAdjustPlanner`** — the deterministic L1 swap: moves a missed key workout **forward**
  (DEC-012 — never backward) to the nearest later easy day such that **no two key workouts land
  on consecutive days**; returns `false` (PR5 escalates L1→L2) when no valid swap exists.
- **`AdaptationThresholds`** — named first-pass constants with a `PolicyVersion`, documented as
  pending Unit 6 eval calibration (mirrors the `SafetyKeywordCatalog` resource convention).
- DI: `IDeviationEngine` / `IEscalationClassifier` registered as singletons (mirroring `ISafetyGate`).

Reuses the `EscalationLevel` / `AdaptationKind` / `PlanAdaptationDiff` / `WorkoutChange` types
already shipped by PR3 (#163) — this PR only consumes/produces them.

### Deliberate scope boundary (PR2 vs PR5)

- **State persistence is deferred to PR5.** `AdaptationSignalState` is a pure value threaded in
  and out of the classifier; whether it's persisted as a Marten read-model or recomputed from the
  recent-log window is the spec's explicit open question (DEC-078), resolved when PR5 wires the loop.
- **Red/Amber handling is deferred.** Under `Red` the classifier defensively returns Absorb (the
  real crisis short-circuit is PR5); `Amber` resolves the level like `Green` (the non-increase clamp
  is PR4's post-LLM validator).
- **The swap is computed, not applied.** `MicroAdjustPlanner` produces the `PlanAdaptationDiff`;
  PR5 reads the live micro week and appends the `PlanAdaptedFromLog`.

### Testing

39 new unit tests (`PaceDerivation`, `DeviationEngine`, `EscalationClassifier`, `MicroAdjustPlanner`)
covering every `deterministic-deviation-and-escalation.feature` scenario: within-band absorb,
reschedulable miss ⇒ L1, 2–3 minor ⇒ L1, sustained / 3+ consecutive missed ⇒ L2, off-plan no-op,
over-performance no-upgrade, the hysteresis dead-zone, divide-by-zero edges, band-membership
reporting, and the no-consecutive-key swap invariant. Built TDD (red → green). **Full suite
1443/1443 green.** Adversarially reviewed pre-commit (bug / conventions / cross-file lenses + blind
verification); the two confirmed findings (both doc/naming accuracy) are folded in.

### Follow-ups found

- _None blocking._ PR5 consumes the planner + classifier and decides the signal-state persistence
  mechanism (the deferred open question above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent workout deviation detection and escalation (micro-adjusts or restructures plans).
  * Smart forward-rescheduling for missed key workouts that prevents consecutive key sessions.
  * Improved pace derivation used when rendering recent workout pace (returns no pace when it can’t be derived).

* **Tests**
  * Expanded unit test coverage for deviation detection, escalation logic, micro-adjust planning, and pace derivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->