### PR TITLE
test(slice-4a): voice-guard test scaffolding (PR1)

### DIFF
--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/VoiceProseGuard.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/VoiceProseGuard.cs
@@ -1,0 +1,102 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Eval;
+
+/// <summary>
+/// Deterministic eval-side voice/style guard (Slice 4A). Serializes an LLM
+/// output and asserts no prose field carries a banned style "tell": an em or
+/// en dash, an exclamation mark, or a sycophancy/validation phrase. Mirrors
+/// <see cref="TrademarkProseGuard"/> — it scans decoded string leaves via
+/// <see cref="JsonNode"/> rather than the serialized JSON text. There is no
+/// runtime scrubber for these tells, so a fresh fixture that trips this guard
+/// means the prompt regressed against the gruff-direct register: tighten the
+/// prompt and re-record. ISO dates use U+002D hyphen-minus and are NOT matched.
+/// </summary>
+internal static class VoiceProseGuard
+{
+    // Sycophancy / filler-enthusiasm tells flagged on the 2026-06-13 live pass.
+    // Case-insensitive substring match. Extended during the tuning rounds.
+    internal static readonly string[] BannedPhrases =
+    [
+        "love it",
+        "love that",
+        "great foundation",
+        "great job",
+        "well done",
+        "amazing",
+        "awesome",
+        "fantastic",
+        "wonderful",
+        "so proud",
+    ];
+
+    // U+2014 EM DASH, U+2013 EN DASH. Plain hyphen-minus (U+002D) is allowed.
+    private static readonly char[] BannedDashes = ['—', '–'];
+
+    /// <summary>
+    /// Returns a description of the first style violation in <paramref name="value"/>,
+    /// or <see langword="null"/> when the string is clean.
+    /// </summary>
+    internal static string? FindViolation(string value)
+    {
+        if (value.IndexOfAny(BannedDashes) >= 0)
+        {
+            return "contains an em/en dash";
+        }
+
+        if (value.Contains('!'))
+        {
+            return "contains an exclamation mark";
+        }
+
+        foreach (var phrase in BannedPhrases)
+        {
+            if (value.Contains(phrase, StringComparison.OrdinalIgnoreCase))
+            {
+                return $"contains the banned phrase '{phrase}'";
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Asserts that every string field reachable from <paramref name="output"/> is
+    /// free of banned style tells (Slice 4A gruff-direct register).
+    /// </summary>
+    internal static void AssertClean(string label, object output)
+    {
+        var node = JsonSerializer.SerializeToNode(output, ClaudeCoachingLlm.StructuredOutputSerializerOptions)
+            ?? throw new InvalidOperationException($"Failed to serialize '{label}' to JsonNode.");
+        AssertNodeClean(label, node);
+    }
+
+    private static void AssertNodeClean(string label, JsonNode? node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                foreach (var (_, value) in obj)
+                {
+                    AssertNodeClean(label, value);
+                }
+
+                break;
+            case JsonArray arr:
+                foreach (var item in arr)
+                {
+                    AssertNodeClean(label, item);
+                }
+
+                break;
+            case JsonValue v when v.TryGetValue<string>(out var s):
+                FindViolation(s).Should().BeNull(
+                    because: $"every prose field of '{label}' must match the Slice 4A gruff-direct style "
+                        + $"(offending value: '{s}')");
+                break;
+        }
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/VoiceProseGuardTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/VoiceProseGuardTests.cs
@@ -24,6 +24,15 @@ public sealed class VoiceProseGuardTests
         VoiceProseGuard.FindViolation(value).Should().NotBeNull();
     }
 
+    [Theory]
+    [InlineData("Block starts 2026-06-13, ends 2026-07-04.")] // plain hyphen-minus dates
+    [InlineData("Easy run, 8-10 km.")] // plain hyphen-minus range, not a banned dash
+    public void FindViolation_PlainHyphenMinus_ReturnsNull(string value)
+    {
+        // Assert
+        VoiceProseGuard.FindViolation(value).Should().BeNull();
+    }
+
     [Fact]
     public void FindViolation_Exclamation_ReturnsViolation()
     {
@@ -51,7 +60,20 @@ public sealed class VoiceProseGuardTests
         var act = () => VoiceProseGuard.AssertClean("test", output);
 
         // Assert
-        act.Should().Throw<Exception>();
+        act.Should().Throw<Xunit.Sdk.XunitException>().WithMessage("*Love that*");
+    }
+
+    [Fact]
+    public void AssertClean_ArrayElementWithBannedPhrase_Throws()
+    {
+        // Arrange
+        var output = new { notes = new[] { "fine", "Love that target." } };
+
+        // Act
+        var act = () => VoiceProseGuard.AssertClean("test", output);
+
+        // Assert
+        act.Should().Throw<Xunit.Sdk.XunitException>().WithMessage("*Love that*");
     }
 
     [Fact]

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/VoiceProseGuardTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/VoiceProseGuardTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Eval;
+
+public sealed class VoiceProseGuardTests
+{
+    [Fact]
+    public void FindViolation_CleanGruffProse_ReturnsNull()
+    {
+        // Arrange
+        var actual = VoiceProseGuard.FindViolation(
+            "Cut Sunday to 9 km. Legs were flat from the first km. Build back to 14 next week.");
+
+        // Assert
+        actual.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("You ran hard — too hard.")] // em dash U+2014
+    [InlineData("Easy run, 8–10 km.")] // en dash U+2013
+    public void FindViolation_Dash_ReturnsViolation(string value)
+    {
+        // Assert
+        VoiceProseGuard.FindViolation(value).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void FindViolation_Exclamation_ReturnsViolation()
+    {
+        // Assert
+        VoiceProseGuard.FindViolation("Strong work today!").Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData("Love it. Let us lock the goal.")]
+    [InlineData("Great foundation to build on.")]
+    [InlineData("That is AMAZING progress.")]
+    public void FindViolation_SycophancyPhrase_ReturnsViolation(string value)
+    {
+        // Assert
+        VoiceProseGuard.FindViolation(value).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AssertClean_NestedObjectWithBannedPhrase_Throws()
+    {
+        // Arrange
+        var output = new { rationale = "Love that target.", nested = new { note = "fine" } };
+
+        // Act
+        var act = () => VoiceProseGuard.AssertClean("test", output);
+
+        // Assert
+        act.Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void AssertClean_CleanObject_DoesNotThrow()
+    {
+        // Arrange
+        var output = new { rationale = "Held the week flat. Volume rebuilds Monday." };
+
+        // Act
+        var act = () => VoiceProseGuard.AssertClean("test", output);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/VoiceRubrics.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/VoiceRubrics.cs
@@ -1,0 +1,21 @@
+namespace RunCoach.Api.Tests.Modules.Coaching.Eval;
+
+/// <summary>
+/// Advisory LLM-as-judge rubric (Slice 4A) for the gruff-direct register. Reuses
+/// the <see cref="SafetyRubricEvaluator"/> harness. Scored and recorded for the
+/// builder to read during the tuning rounds; NOT a hard CI gate (the deterministic
+/// <see cref="VoiceProseGuard"/> is the gate). Promote to a threshold gate once the
+/// scores are calibrated against builder-approved output.
+/// </summary>
+public static class VoiceRubrics
+{
+    /// <summary>Gets the gruff-direct restraint rubric.</summary>
+    public static SafetyRubricCriteria[] Restraint { get; } =
+    [
+        new("direct_register", "Is the response blunt and direct with short sentences, rather than warm, gushing, or chatty?"),
+        new("no_validation_opener", "Does the response avoid opening with praise or emotional validation (no 'Love it', 'Great foundation', 'that takes honesty to acknowledge')?"),
+        new("no_filler_enthusiasm", "Does the response avoid filler enthusiasm, exclamation marks, and sycophancy?"),
+        new("keeps_rationale", "Does the response still give the physiological or training reason for any recommendation?"),
+        new("offers_forward_path", "When it constrains or cuts load, does it still show the path forward?"),
+    ];
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/VoiceRubricsTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/VoiceRubricsTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Eval;
+
+public sealed class VoiceRubricsTests
+{
+    [Fact]
+    public void Restraint_HasTheExpectedCriteria()
+    {
+        // Assert
+        VoiceRubrics.Restraint.Select(c => c.Name).Should().BeEquivalentTo(
+            "direct_register",
+            "no_validation_opener",
+            "no_filler_enthusiasm",
+            "keeps_rationale",
+            "offers_forward_path");
+    }
+
+    [Fact]
+    public void BuildJudgePrompt_IncludesEveryRestraintCriterion()
+    {
+        // Arrange
+        var evaluator = new SafetyRubricEvaluator("voice restraint check", VoiceRubrics.Restraint);
+
+        // Act
+        var prompt = evaluator.BuildJudgePrompt("Cut Sunday to 9 km. Volume rebuilds Monday.");
+
+        // Assert
+        foreach (var criterion in VoiceRubrics.Restraint)
+        {
+            prompt.Should().Contain(criterion.Name);
+        }
+    }
+}


### PR DESCRIPTION
## Slice 4A — Coaching Voice Re-tune · PR1 (test-only scaffolding)

First PR of Slice 4A per `docs/superpowers/plans/2026-06-17-slice-4a-voice-retune.md`. **Test-only and additive** — establishes the deterministic enforcement that later PRs (PR3 onboarding / PR4 coaching-system / PR5 adaptation) wire into the eval tests once each prompt is re-tuned to the gruff-direct register. Independent of PR2 (persona doc); both branch off `main`.

### What's here
- **`VoiceProseGuard`** (Task 1) — a deterministic eval-side guard mirroring `TrademarkProseGuard`. Serializes an LLM output and asserts no prose string leaf carries a banned style "tell": an em/en dash (U+2014/U+2013), an exclamation mark, or a sycophancy phrase. Plain hyphen-minus (U+002D) — ISO dates, ranges — is deliberately **not** matched. No runtime scrubber: the guard is the enforcement.
- **`VoiceRubrics.Restraint`** (Task 2) — a five-criterion advisory LLM-as-judge rubric reusing the existing `SafetyRubricEvaluator` harness. Recorded for the builder during tuning rounds; **not** a hard gate (the deterministic guard is the gate).

### Adversarial self-review (folded in)
A multi-lens review of the diff surfaced three confirmed test-coverage gaps, now fixed in `3aea422`:
- Pinned the `AssertClean` throw assertions to `Xunit.Sdk.XunitException` + a banned-phrase `WithMessage` match (was the only bare `Throw<Exception>()` in the suite) so the test proves the detection path fired.
- Added a negative theory pinning plain hyphen-minus (U+002D) as allowed — the guard's headline ISO-date contract previously had no test.
- Added array-element coverage for the `JsonArray` recursion branch (real LLM outputs carry prose inside arrays).

### Notes
- Three plan-verbatim style issues were corrected during TDD to satisfy StyleCop under `TreatWarningsAsErrors`: **SA1025** (comment whitespace), **SA1117** (param wrapping), and field reordering for **SA1202** (`internal` before `private`).

### Verification
- `dotnet build RunCoach.slnx` — clean (0 warnings, 0 errors).
- `VoiceProseGuardTests` + `VoiceRubricsTests` — 14 cases green.
- Full suite — **1801 passed, 0 failed, 0 errors** (Replay mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added quality assurance test infrastructure for validating LLM-generated coaching responses against specific prose style standards, including checks for appropriate tone and language patterns.
  * Added test suite definitions and validation rules to ensure coaching guidance maintains the intended communication style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->