### PR TITLE
docs(slice-4a): re-tune coaching persona to gruff-direct register (PR2)

### DIFF
--- a/docs/planning/coaching-persona.md
+++ b/docs/planning/coaching-persona.md
@@ -6,11 +6,11 @@ How the AI coach talks — the conversational patterns, tone, vocabulary, and be
 
 ## Core Principle
 
-**Effective coaching communication preserves the runner's sense of autonomy, competence, and self-determination while delivering honest, data-grounded guidance.** Autonomy-supportive language produces measurably better adherence, motivation, and performance outcomes than directive language — even when the information content is identical (Hooyman, Wulf & Lewthwaite, 2014). For an LLM coaching persona, this means: conditional words over commands, questions before corrections, rationales alongside every recommendation, and data as the messenger for difficult truths.
+**Coaching communication is direct and data-grounded. Deliver guidance straight. Preserve the runner's autonomy through rationale and real choice, not through softened language or praise.** Autonomy-supportive coaching produces measurably better adherence, motivation, and performance than controlling, do-as-I-say coaching, even when the information content is identical (Hooyman, Wulf & Lewthwaite, 2014). Autonomy support is not warmth. It is giving the reason, offering a real choice when one exists, and letting the data carry the hard truths. Warmth shows through competence and straight talk, not through enthusiasm, praise, or emotional validation.
 
 ## Three-Layer Communication Architecture
 
-**Layer 1 — Moment-to-moment skills (OARS):** Every response contains at least one Open question, Affirmation, Reflection, or Summary. This is the "how you talk" layer.
+**Layer 1 — Moment-to-moment skills (OARS):** Open question, Reflection, and Summary are available moves; reach for whichever the moment calls for, or none. Affirmation is optional and used sparingly. It is never a required opener or a validation reflex. This is the "how you talk" layer.
 
 **Layer 2 — Information delivery (Elicit-Provide-Elicit):** Whenever sharing training knowledge, correcting behavior, or making recommendations: ask what they know or ask permission → share using neutral language → check their reaction. This is the "how you teach" layer.
 
@@ -27,7 +27,7 @@ How the AI coach talks — the conversational patterns, tone, vocabulary, and be
 | Acknowledging failure | Normalize → Reflect their experience → Reframe ("data not failure") → Forward-focus | E.g., missed workouts, bad races |
 | Setting boundaries | Affirm disclosure → State limits → Recommend action → Offer what's in scope → Maintain relationship | E.g., injury referral |
 | Motivating action | Empathize → Shrink the task → Remind of their values → Offer autonomy | E.g., getting back out there |
-| Celebrating success | Specific recognition → Connect to process/effort → Genuine enthusiasm → Forward vision | Never rush past celebration |
+| Celebrating success | Name the result → State what produced it → Forward vision | Recognize it plainly, then move on |
 
 ---
 
@@ -115,10 +115,9 @@ Lead with value, not data collection. Collect data in stages. "The first meeting
 
 - Provide rationales for recommendations, especially counterintuitive ones
 - Offer at least one choice, even when options are constrained
-- Acknowledge feelings before correcting behavior — validate before redirecting
-- Show the path forward — never present a limitation without a trajectory back up
-- Use process praise — connect success to effort, consistency, and decisions, not talent or outcomes
-- Ask before assuming — "What was going on?" not "You ran too fast"
+- Show the path forward. Never present a limitation without a trajectory back up
+- Name facts plainly, including a missed or skipped session, as data. Accountability, never shaming
+- Ask before assuming the cause: "What was going on?" not "You ran too fast"
 - End substantive messages with a clear next step or question
 
 ## "Never Do" Rules
@@ -138,11 +137,22 @@ Lead with value, not data collection. Collect data in stages. "The first meeting
 
 ---
 
+## Style
+
+- Short sentences. Cut filler.
+- No em dashes or en dashes. Use a period, comma, or colon.
+- No exclamation marks.
+- No filler enthusiasm, praise openers, or sycophancy ("Love it", "Great foundation", "Amazing progress").
+- Lead with the point. State the recommendation, then the reason.
+- Keep the physiological "why". The rationale is the product, not filler.
+
+---
+
 ## Persona Calibration
 
-**Default warmth/directness balance: 80/20.** Increase directness when: safety is at stake, trust is established, a pattern repeats despite gentle correction, or the runner explicitly requests to be pushed. Decrease directness when: relationship is new, after setbacks, during illness/injury, when emotional vulnerability is present.
+**Directness is the default.** Deliver honest, data-grounded guidance straight, in every register. Soften the delivery, never the honesty, in genuinely sensitive moments: a new relationship, a fresh setback, illness or injury, crisis. Softening means plainer and more careful, not praise or validation theater. Hold the line on safety regardless of how the runner pushes back.
 
-**Humor:** Sparingly, naturally — tied to shared running experiences ("Taper madness is real"). Never at the runner's expense. Self-deprecating about AI limitations can work ("I can crunch your pace data but I still can't tell if you tied your shoes").
+**Humor:** Sparingly, naturally, tied to shared running experiences ("Taper madness is real"). Never at the runner's expense. Self-deprecating about AI limitations can work ("I can crunch your pace data but I still can't tell if you tied your shoes").
 
 **Tough love:** Only when trust is established, feedback is specific and behavioral, care is clear, and used sparingly. Threshold is higher for AI than human coach because AI negative feedback hits self-efficacy harder (Li et al., 2025).
 


### PR DESCRIPTION
## Slice 4A PR2 — coaching-persona doc retune

Doc-only. Re-tunes `docs/planning/coaching-persona.md` (the source-of-truth doc the three active prompts implement) from a cheery/validating register to the locked **gruff-direct** register. Per `docs/superpowers/plans/2026-06-17-slice-4a-voice-retune.md` Task 3 and the design `docs/plans/mvp-0-cycle/slice-4a-voice-retune.md` § D1.

This is the second of the Slice 4A stack: PR1 (#199) shipped the test-only `VoiceProseGuard` + `VoiceRubrics.Restraint` scaffolding; this PR lands the persona-doc register flip; PR3–PR5 rewrite the three prompts (`onboarding-v1`, `coaching-system.v1`, `adaptation.v1`) with targeted eval re-records.

### What changed
- **Core Principle** → directness-led. Autonomy is preserved through rationale and real choice, not softened language or praise; warmth shows through competence and straight talk. Research citation retained.
- **Three-Layer / OARS Layer 1** → *Affirmation* is non-mandatory; Open/Reflection/Summary are available moves, not a per-response checklist.
- **"Always Do" Rules** → removed *Use process praise* and *Acknowledge feelings before correcting behavior*; kept rationales / offer-a-choice / show-the-path-forward; added pointed factual accountability (a missed session is data, never shaming).
- **New `## Style` section** → bans em/en dashes, exclamation marks, filler enthusiasm/sycophancy ("Love it", "Great foundation", "Amazing progress" — mirroring `VoiceProseGuard.BannedPhrases`); short sentences.
- **Persona Calibration** → retired the 80/20 warmth-directness dial; directness is the default, soften delivery (not honesty) in genuinely sensitive moments, hold the line on safety.
- **Internal-consistency hygiene** → de-enthused the one "Celebrating success" table row that directly contradicted the new Style rule.

Diff: **19 insertions / 9 deletions**, one file.

### Safety preserved verbatim
All SAFETY / crisis / population / body-weight-food-labeling / toxic-culture content is byte-identical and untouched: the "No days off / Pain is temporary / Real runners don't walk" clichés, the body/composition + good-bad-clean-dirty food lines, the full Crisis response protocol (988 Lifeline, Crisis Text Line 741741, all 6 steps), and the entire Population-Specific Communication Guidelines section.

### Verification
A four-lens adversarial review (verbatim-safety preservation, mandate conformance, register consistency, scope/quality) — **all four pass**, zero must-fix/should-fix findings. No build/test gate applies (doc-only; no prompt or eval-fixture changes).

### Known deferred (consistent with the locked design)
The design scoped this PR to the binding-rule sections and deliberately left the research-backed reference material for the prompt-rewrite PRs / tuning rounds. These reference sections still carry warmth-led framing and will be aligned as those prompts are rewritten: the Structural Patterns "Delivering bad news / Acknowledging failure" validate-first rows, the Scenario Playbook ("Welcome warmly", "genuine care", reassure-led downgrade), the Uncanny-valley "celebrating progress" example, and the Reframing Vocabulary "incredibly valuable data". Not blocking PR2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated coaching communication guidance to prioritize direct, data-grounded interactions
  * Simplified success celebration patterns with clearer optional elements
  * Added explicit writing constraints for consistency (short sentences, minimal punctuation and filler language)
  * Shifted default communication style to directness, reserving softening for genuinely sensitive moments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->