### PR TITLE
test(slice-4a): onboarding voice eval (PR6)

### DIFF
--- a/backend/src/RunCoach.Api/Modules/Coaching/ContextAssembler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/ContextAssembler.cs
@@ -421,6 +421,43 @@ public sealed partial class ContextAssembler : IContextAssembler
     }
 
     /// <summary>
+    /// Builds the onboarding turn user message. Layout is intentional: the
+    /// captured-so-far slot summary precedes the current-topic line so the
+    /// LLM sees its working memory before the prompt for the next answer.
+    /// The sanitized + delimiter-wrapped runner input lands LAST per the
+    /// non-cached-tail convention (DEC-047 / Spotlighting).
+    /// </summary>
+    /// <remarks>
+    /// <c>internal</c> (not <c>private</c>) so the onboarding-voice eval calls
+    /// this exact builder instead of reproducing its layout — a hand-rolled copy
+    /// could silently drift (e.g. a new slot) and keep matching a stale fixture.
+    /// The test assembly retains access via <c>InternalsVisibleTo</c>.
+    /// </remarks>
+    internal static string BuildOnboardingUserMessage(
+        OnboardingView view,
+        OnboardingTopic currentTopic,
+        string sanitizedUserInput)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("ONBOARDING STATE (captured so far):");
+        AppendSlotSummary(sb, view);
+
+        if (view.OutstandingClarifications.Count > 0)
+        {
+            var topics = string.Join(", ", view.OutstandingClarifications);
+            sb.AppendLine(CultureInfo.InvariantCulture, $"OUTSTANDING_CLARIFICATIONS: {topics}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine(CultureInfo.InvariantCulture, $"CURRENT_TOPIC: {currentTopic}");
+        sb.AppendLine();
+        sb.Append(sanitizedUserInput);
+
+        return sb.ToString();
+    }
+
+    /// <summary>
     /// Groups workouts by ISO week (Monday-based) and returns weekly summaries
     /// ordered by most recent week first.
     /// </summary>
@@ -520,37 +557,6 @@ public sealed partial class ContextAssembler : IContextAssembler
     }
 
     private static string FormatPace(Pace pace) => FormatTimeSpan(pace.ToTimeSpan());
-
-    /// <summary>
-    /// Builds the onboarding turn user message. Layout is intentional: the
-    /// captured-so-far slot summary precedes the current-topic line so the
-    /// LLM sees its working memory before the prompt for the next answer.
-    /// The sanitized + delimiter-wrapped runner input lands LAST per the
-    /// non-cached-tail convention (DEC-047 / Spotlighting).
-    /// </summary>
-    private static string BuildOnboardingUserMessage(
-        OnboardingView view,
-        OnboardingTopic currentTopic,
-        string sanitizedUserInput)
-    {
-        var sb = new StringBuilder();
-
-        sb.AppendLine("ONBOARDING STATE (captured so far):");
-        AppendSlotSummary(sb, view);
-
-        if (view.OutstandingClarifications.Count > 0)
-        {
-            var topics = string.Join(", ", view.OutstandingClarifications);
-            sb.AppendLine(CultureInfo.InvariantCulture, $"OUTSTANDING_CLARIFICATIONS: {topics}");
-        }
-
-        sb.AppendLine();
-        sb.AppendLine(CultureInfo.InvariantCulture, $"CURRENT_TOPIC: {currentTopic}");
-        sb.AppendLine();
-        sb.Append(sanitizedUserInput);
-
-        return sb.ToString();
-    }
 
     /// <summary>
     /// Builds the plan-generation base user message. Layout: the captured

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/Adaptation/AdaptationRestructureEvalTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/Adaptation/AdaptationRestructureEvalTests.cs
@@ -253,7 +253,7 @@ public sealed class AdaptationRestructureEvalTests : EvalTestBase
     private async Task<PlanAdaptationOutput> GenerateAdaptationAsync(
         string scenarioName, (string System, string User) prompt, CancellationToken ct)
     {
-        await using var run = await CreateSonnetScenarioRunAsync(scenarioName);
+        await using var run = await CreateSonnetScenarioRunAsync(scenarioName, ct);
         var client = run.ChatConfiguration!.ChatClient;
 
         var schemaElement = JsonSerializer.SerializeToElement(AdaptationSchema.Frozen);
@@ -278,7 +278,7 @@ public sealed class AdaptationRestructureEvalTests : EvalTestBase
     private async Task<SafetyVerdict> JudgeRationaleAsync(
         string scenarioName, SafetyRubricEvaluator evaluator, string rationale, CancellationToken ct)
     {
-        await using var run = await CreateHaikuScenarioRunAsync(scenarioName);
+        await using var run = await CreateHaikuScenarioRunAsync(scenarioName, ct);
         return await evaluator.JudgeAsync(run.ChatConfiguration!.ChatClient, rationale, ct);
     }
 }

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/EvalTestBase.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/EvalTestBase.cs
@@ -369,7 +369,8 @@ public abstract class EvalTestBase : IAsyncDisposable
     /// Creates a cached Sonnet scenario run for plan generation / coaching tests.
     /// In Replay mode, the inner client throws on cache miss with the scenario name.
     /// </summary>
-    protected async ValueTask<ScenarioRun> CreateSonnetScenarioRunAsync(string scenarioName)
+    protected async ValueTask<ScenarioRun> CreateSonnetScenarioRunAsync(
+        string scenarioName, CancellationToken ct = default)
     {
         if (_sonnetReportingConfig is null)
         {
@@ -378,14 +379,15 @@ public abstract class EvalTestBase : IAsyncDisposable
                 "In Record mode an API key is required. In Replay mode, cache files must exist.");
         }
 
-        return await _sonnetReportingConfig.CreateScenarioRunAsync(scenarioName);
+        return await _sonnetReportingConfig.CreateScenarioRunAsync(scenarioName, cancellationToken: ct);
     }
 
     /// <summary>
     /// Creates a cached Haiku scenario run for LLM-as-judge calls.
     /// In Replay mode, the inner client throws on cache miss with the scenario name.
     /// </summary>
-    protected async ValueTask<ScenarioRun> CreateHaikuScenarioRunAsync(string scenarioName)
+    protected async ValueTask<ScenarioRun> CreateHaikuScenarioRunAsync(
+        string scenarioName, CancellationToken ct = default)
     {
         if (_haikuReportingConfig is null)
         {
@@ -394,7 +396,7 @@ public abstract class EvalTestBase : IAsyncDisposable
                 "In Record mode an API key is required. In Replay mode, cache files must exist.");
         }
 
-        return await _haikuReportingConfig.CreateScenarioRunAsync(scenarioName);
+        return await _haikuReportingConfig.CreateScenarioRunAsync(scenarioName, cancellationToken: ct);
     }
 
     /// <summary>

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/OnboardingVoiceEvalTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/OnboardingVoiceEvalTests.cs
@@ -61,7 +61,7 @@ public sealed class OnboardingVoiceEvalTests : EvalTestBase
         Converters = { new JsonStringEnumConverter() },
     };
 
-    // Mirrors ContextAssembler.OnboardingSlotSerializerOptions so a populated
+    // Mirrors `ContextAssembler.OnboardingSlotSerializerOptions` so a populated
     // captured-so-far slot renders byte-identically to production's user message.
     private static readonly JsonSerializerOptions SlotSerializerOptions = new()
     {
@@ -88,14 +88,12 @@ public sealed class OnboardingVoiceEvalTests : EvalTestBase
         var output = await GenerateOnboardingAsync(
             $"onboarding.voice.{scenarioName}", prompt, TestContext.Current.CancellationToken);
 
-        // Advisory gruff-direct restraint judge (Slice 4A) — recorded for the tuning
-        // rounds, never gated. The deterministic VoiceProseGuard below is the hard gate;
-        // this verdict is for the builder to read. Mirrors the adaptation + plan-gen evals.
-        // Read the verdict per-criterion, not by OverallScore: an onboarding turn is a
-        // question, so the shared rubric's coaching-recommendation criteria
-        // (keeps_rationale, offers_forward_path) do not apply and score low by design.
-        // The voice-bearing criteria (direct_register, no_validation_opener,
-        // no_filler_enthusiasm) are the ones that flag a cheery regression here.
+        // Advisory gruff-direct restraint judge (Slice 4A), recorded for the tuning
+        // rounds and never gated. The deterministic `VoiceProseGuard` below is the hard
+        // gate, and this verdict is only for the builder to read. Read it per criterion
+        // rather than by its overall score. An onboarding turn is a question, so the shared
+        // rubric's coaching-recommendation criteria do not apply and score low by design,
+        // while its register criteria are what flag a cheery regression here.
         var replyText = ConcatReplyText(output);
         var restraintEvaluator = new SafetyRubricEvaluator(
             $"Onboarding reply voice restraint for the {scenarioName} turn",
@@ -245,7 +243,7 @@ public sealed class OnboardingVoiceEvalTests : EvalTestBase
     private async Task<OnboardingTurnOutput> GenerateOnboardingAsync(
         string scenarioName, (string System, string User) prompt, CancellationToken ct)
     {
-        await using var run = await CreateSonnetScenarioRunAsync(scenarioName);
+        await using var run = await CreateSonnetScenarioRunAsync(scenarioName, ct);
         var client = run.ChatConfiguration!.ChatClient;
 
         var schemaElement = JsonSerializer.SerializeToElement(OnboardingSchema.Frozen);
@@ -270,7 +268,7 @@ public sealed class OnboardingVoiceEvalTests : EvalTestBase
     private async Task<SafetyVerdict> JudgeReplyAsync(
         string scenarioName, SafetyRubricEvaluator evaluator, string reply, CancellationToken ct)
     {
-        await using var run = await CreateHaikuScenarioRunAsync(scenarioName);
+        await using var run = await CreateHaikuScenarioRunAsync(scenarioName, ct);
         return await evaluator.JudgeAsync(run.ChatConfiguration!.ChatClient, reply, ct);
     }
 

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/OnboardingVoiceEvalTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/OnboardingVoiceEvalTests.cs
@@ -1,0 +1,287 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using RunCoach.Api.Modules.Coaching;
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Eval;
+
+/// <summary>
+/// The onboarding-voice eval (Slice 4A PR6): the only eval that exercises the
+/// onboarding prompt's LLM output. It closes the gap PR3 surfaced — no eval
+/// guarded the gruff-direct <c>onboarding-v1.yaml</c> rewrite, yet the
+/// 2026-06-13 live pass saw the onboarding turns gush ("Love it!", "Great
+/// foundation!"). Each scenario drives the real onboarding system prompt + a
+/// representative turn through a cached Sonnet structured-output call, asserts
+/// the decoded <see cref="OnboardingTurnOutput"/> passes
+/// <see cref="OnboardingTurnOutputValidator"/>, hard-gates every prose field
+/// with <see cref="VoiceProseGuard"/> (and keeps <see cref="TrademarkProseGuard"/>),
+/// and records an advisory <see cref="VoiceRubrics.Restraint"/> Haiku verdict for
+/// the builder to read during the tuning rounds. Replay-only in CI; the committed
+/// cache is recorded once against a funded key.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this builds the prompt by hand rather than calling production.</b>
+/// Onboarding does not flow through <see cref="ContextAssembler"/>'s prompt store:
+/// <c>onboarding-v1.yaml</c> uses the dash-named convention the dot-versioned
+/// <c>YamlPromptStore</c> cannot resolve, so production reads only the file's
+/// <c>static_system_prompt</c> key off disk (<c>ContextAssembler.LoadOnboardingSystemPromptAsync</c>)
+/// and builds the user message programmatically in <c>BuildOnboardingUserMessage</c>
+/// (ONBOARDING STATE slot summary, CURRENT_TOPIC, then the sanitized + delimiter-wrapped
+/// runner input). The YAML's <c>context_template</c> block is never rendered for the
+/// onboarding flow. This eval mirrors both: it parses <c>static_system_prompt</c> the
+/// same way and reproduces the production user-message layout.
+/// </para>
+/// <para>
+/// It does <b>not</b> call <c>ComposeForOnboardingAsync</c> — that path generates a fresh
+/// CSPRNG nonce per call (busting the response-cache key) and throws on the
+/// <see cref="EvalTestBase"/> assembler, which is built without the onboarding
+/// sanitizer dependencies. Instead the runner input is wrapped in the same
+/// <c>CURRENT_USER_INPUT</c> delimiter the sanitizer emits, with a fixed nonce so the
+/// message — and therefore the cache key — is byte-stable. The eval tests the prompt's
+/// voice, not the sanitizer (which has its own tests).
+/// </para>
+/// </remarks>
+[Collection("Eval")]
+[Trait("Category", "Eval")]
+public sealed class OnboardingVoiceEvalTests : EvalTestBase
+{
+    private const string FixedNonce = "evalfixednonce0000000a";
+
+    private static readonly JsonSerializerOptions DeserializeOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    // Mirrors ContextAssembler.OnboardingSlotSerializerOptions so a populated
+    // captured-so-far slot renders byte-identically to production's user message.
+    private static readonly JsonSerializerOptions SlotSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public static TheoryData<string> VoiceScenarios => ["primary-goal", "current-fitness"];
+
+    [Theory]
+    [MemberData(nameof(VoiceScenarios))]
+    public async Task OnboardingReply_MatchesGruffDirectRegister(string scenarioName)
+    {
+        if (!CanRunEvals)
+        {
+            return;
+        }
+
+        // Arrange — the real onboarding system prompt + a representative turn.
+        var prompt = await BuildOnboardingPromptAsync(scenarioName, TestContext.Current.CancellationToken);
+
+        // Act — exactly one structured onboarding turn (cached).
+        var output = await GenerateOnboardingAsync(
+            $"onboarding.voice.{scenarioName}", prompt, TestContext.Current.CancellationToken);
+
+        // Advisory gruff-direct restraint judge (Slice 4A) — recorded for the tuning
+        // rounds, never gated. The deterministic VoiceProseGuard below is the hard gate;
+        // this verdict is for the builder to read. Mirrors the adaptation + plan-gen evals.
+        // Read the verdict per-criterion, not by OverallScore: an onboarding turn is a
+        // question, so the shared rubric's coaching-recommendation criteria
+        // (keeps_rationale, offers_forward_path) do not apply and score low by design.
+        // The voice-bearing criteria (direct_register, no_validation_opener,
+        // no_filler_enthusiasm) are the ones that flag a cheery regression here.
+        var replyText = ConcatReplyText(output);
+        var restraintEvaluator = new SafetyRubricEvaluator(
+            $"Onboarding reply voice restraint for the {scenarioName} turn",
+            VoiceRubrics.Restraint);
+        var restraintVerdict = await JudgeReplyAsync(
+            $"onboarding.voice.{scenarioName}.judge",
+            restraintEvaluator,
+            replyText,
+            TestContext.Current.CancellationToken);
+        await WriteEvalResultAsync(
+            $"onboarding-voice-{scenarioName}",
+            new { Scenario = scenarioName, Output = output, RestraintVerdict = restraintVerdict },
+            TestContext.Current.CancellationToken);
+
+        // Assert — structurally valid Pattern-B onboarding turn.
+        var currentTopic = TopicFor(scenarioName);
+        var validation = OnboardingTurnOutputValidator.Validate(output, currentTopic);
+        validation.IsValid.Should().BeTrue(
+            because: $"the onboarding turn must satisfy the Pattern-B invariants (violation: {validation.Violation})");
+
+        // Trademark guard on the LLM-authored copy — every prose field (consistency
+        // with the other recorded-output evals).
+        TrademarkProseGuard.AssertClean($"onboarding-voice-{scenarioName}", output);
+
+        // Voice guard (Slice 4A) — hard gate: every prose field matches the gruff-direct register.
+        VoiceProseGuard.AssertClean($"onboarding-voice-{scenarioName}", output);
+    }
+
+    /// <summary>
+    /// Concatenates the runner-visible text of the reply: the <c>Text</c> payloads
+    /// of the Text-typed content blocks (Thinking blocks carry empty text). This is
+    /// the onboarding analog of the adaptation eval's single rationale string handed
+    /// to the Haiku judge.
+    /// </summary>
+    private static string ConcatReplyText(OnboardingTurnOutput output) =>
+        string.Join(
+            "\n",
+            output.Reply
+                .Where(block => block.Type == AnthropicContentBlockType.Text)
+                .Select(block => block.Text));
+
+    private static OnboardingTopic TopicFor(string scenarioName) => ScenarioInputs(scenarioName).Topic;
+
+    /// <summary>
+    /// The deterministic scenario inputs. Two turns the 2026-06-13 live pass saw gush:
+    /// the opening PrimaryGoal turn and a CurrentFitness turn. The view state is
+    /// consistent with each turn's current topic so the captured-so-far summary mirrors
+    /// production (the CurrentFitness turn carries an already-captured PrimaryGoal).
+    /// </summary>
+    private static (OnboardingView View, OnboardingTopic Topic, string UserInput) ScenarioInputs(string scenarioName) =>
+        scenarioName switch
+        {
+            "primary-goal" => (
+                new OnboardingView(),
+                OnboardingTopic.PrimaryGoal,
+                "I want to run a sub-2 hour half marathon in October."),
+            "current-fitness" => (
+                new OnboardingView
+                {
+                    PrimaryGoal = new PrimaryGoalAnswer
+                    {
+                        Goal = PrimaryGoal.GeneralFitness,
+                        Description = "general fitness and staying consistent",
+                    },
+                },
+                OnboardingTopic.CurrentFitness,
+                "I run about 25 km a week across four runs. Longest recent run was 14 km. No recent race times."),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(scenarioName), scenarioName, "No onboarding voice scenario for this name."),
+        };
+
+    private static async Task<(string System, string User)> BuildOnboardingPromptAsync(
+        string scenarioName, CancellationToken ct)
+    {
+        var system = await LoadOnboardingSystemPromptAsync(ct);
+        var (view, topic, userInput) = ScenarioInputs(scenarioName);
+        var user = BuildOnboardingUserMessage(view, topic, WrapUserInput(userInput));
+        return (system, user);
+    }
+
+    /// <summary>
+    /// Loads the onboarding system prompt the same way production does
+    /// (<c>ContextAssembler.LoadOnboardingSystemPromptAsync</c>): parse the
+    /// <c>static_system_prompt</c> key out of the dash-named YAML with an
+    /// underscored-naming, unmatched-property-ignoring deserializer, then trim.
+    /// </summary>
+    private static async Task<string> LoadOnboardingSystemPromptAsync(CancellationToken ct)
+    {
+        var path = Path.Combine(GetPromptsDirectory(), ContextAssembler.OnboardingPromptFileName);
+        var yaml = await File.ReadAllTextAsync(path, ct).ConfigureAwait(false);
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(UnderscoredNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+        var doc = deserializer.Deserialize<OnboardingYamlDocument>(yaml);
+        if (string.IsNullOrWhiteSpace(doc?.StaticSystemPrompt))
+        {
+            throw new InvalidOperationException(
+                $"Onboarding prompt YAML at '{path}' is missing the 'static_system_prompt' key.");
+        }
+
+        return doc.StaticSystemPrompt.TrimEnd();
+    }
+
+    /// <summary>
+    /// Reproduces <c>ContextAssembler.BuildOnboardingUserMessage</c>: the captured-so-far
+    /// slot summary, the current-topic line, then the delimiter-wrapped runner input last.
+    /// Explicit <c>\n</c> line endings keep the bytes platform-independent across the
+    /// record machine and CI (production uses <c>AppendLine</c>, identical on both).
+    /// </summary>
+    private static string BuildOnboardingUserMessage(
+        OnboardingView view, OnboardingTopic currentTopic, string wrappedUserInput)
+    {
+        var sb = new StringBuilder();
+        sb.Append("ONBOARDING STATE (captured so far):\n");
+        AppendSlot(sb, "PrimaryGoal", view.PrimaryGoal);
+        AppendSlot(sb, "TargetEvent", view.TargetEvent);
+        AppendSlot(sb, "CurrentFitness", view.CurrentFitness);
+        AppendSlot(sb, "WeeklySchedule", view.WeeklySchedule);
+        AppendSlot(sb, "InjuryHistory", view.InjuryHistory);
+        AppendSlot(sb, "Preferences", view.Preferences);
+        sb.Append('\n');
+        sb.Append("CURRENT_TOPIC: ").Append(currentTopic.ToString()).Append('\n');
+        sb.Append('\n');
+        sb.Append(wrappedUserInput);
+        return sb.ToString();
+    }
+
+    private static void AppendSlot<T>(StringBuilder sb, string label, T? value)
+        where T : class
+    {
+        var rendered = value is null
+            ? "<not yet captured>"
+            : JsonSerializer.Serialize(value, value.GetType(), SlotSerializerOptions);
+        sb.Append("  ").Append(label).Append(": ").Append(rendered).Append('\n');
+    }
+
+    /// <summary>
+    /// Wraps the runner input in the same <c>CURRENT_USER_INPUT</c> delimiter the
+    /// sanitizer emits for the current-user-message section, with a pinned nonce so the
+    /// cache key is byte-stable. Eval inputs are clean ASCII, so the sanitizer's
+    /// angle-bracket escaping is a no-op here.
+    /// </summary>
+    private static string WrapUserInput(string userInput) =>
+        $"<CURRENT_USER_INPUT id=\"{FixedNonce}\">{userInput}</CURRENT_USER_INPUT>";
+
+    private async Task<OnboardingTurnOutput> GenerateOnboardingAsync(
+        string scenarioName, (string System, string User) prompt, CancellationToken ct)
+    {
+        await using var run = await CreateSonnetScenarioRunAsync(scenarioName);
+        var client = run.ChatConfiguration!.ChatClient;
+
+        var schemaElement = JsonSerializer.SerializeToElement(OnboardingSchema.Frozen);
+        IList<ChatMessage> messages =
+        [
+            new ChatMessage(ChatRole.System, prompt.System),
+            new ChatMessage(ChatRole.User, prompt.User),
+        ];
+        var options = new ChatOptions
+        {
+            ResponseFormat = ChatResponseFormat.ForJsonSchema(schemaElement, nameof(OnboardingTurnOutput)),
+        };
+
+        var response = await client.GetResponseAsync(messages, options, ct);
+        var text = response.Text ?? throw new InvalidOperationException(
+            "Onboarding structured-output call returned null text.");
+
+        return JsonSerializer.Deserialize<OnboardingTurnOutput>(text, DeserializeOptions)
+            ?? throw new InvalidOperationException("Failed to deserialize the OnboardingTurnOutput.");
+    }
+
+    private async Task<SafetyVerdict> JudgeReplyAsync(
+        string scenarioName, SafetyRubricEvaluator evaluator, string reply, CancellationToken ct)
+    {
+        await using var run = await CreateHaikuScenarioRunAsync(scenarioName);
+        return await evaluator.JudgeAsync(run.ChatConfiguration!.ChatClient, reply, ct);
+    }
+
+    /// <summary>
+    /// Minimal YAML deserialization shape for <c>onboarding-v1.yaml</c> — only the
+    /// <c>static_system_prompt</c> key is read, mirroring production's loader.
+    /// </summary>
+    private sealed class OnboardingYamlDocument
+    {
+#pragma warning disable S3459, S1144, CA1822 // YamlDotNet sets the property via reflection.
+        public string? StaticSystemPrompt { get; set; }
+#pragma warning restore S3459, S1144, CA1822
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/OnboardingVoiceEvalTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/OnboardingVoiceEvalTests.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using FluentAssertions;
@@ -37,7 +36,9 @@ namespace RunCoach.Api.Tests.Modules.Coaching.Eval;
 /// (ONBOARDING STATE slot summary, CURRENT_TOPIC, then the sanitized + delimiter-wrapped
 /// runner input). The YAML's <c>context_template</c> block is never rendered for the
 /// onboarding flow. This eval mirrors both: it parses <c>static_system_prompt</c> the
-/// same way and reproduces the production user-message layout.
+/// same way and calls production's own <c>ContextAssembler.BuildOnboardingUserMessage</c>
+/// (internal via <c>InternalsVisibleTo</c>) for the user message, so the layout cannot
+/// drift out of sync with production.
 /// </para>
 /// <para>
 /// It does <b>not</b> call <c>ComposeForOnboardingAsync</c> — that path generates a fresh
@@ -61,15 +62,6 @@ public sealed class OnboardingVoiceEvalTests : EvalTestBase
         Converters = { new JsonStringEnumConverter() },
     };
 
-    // Mirrors `ContextAssembler.OnboardingSlotSerializerOptions` so a populated
-    // captured-so-far slot renders byte-identically to production's user message.
-    private static readonly JsonSerializerOptions SlotSerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = false,
-        Converters = { new JsonStringEnumConverter() },
-    };
-
     public static TheoryData<string> VoiceScenarios => ["primary-goal", "current-fitness"];
 
     [Theory]
@@ -86,7 +78,7 @@ public sealed class OnboardingVoiceEvalTests : EvalTestBase
 
         // Act — exactly one structured onboarding turn (cached).
         var output = await GenerateOnboardingAsync(
-            $"onboarding.voice.{scenarioName}", prompt, TestContext.Current.CancellationToken);
+            $"onboarding.voice.{scenarioName}", (prompt.System, prompt.User), TestContext.Current.CancellationToken);
 
         // Advisory gruff-direct restraint judge (Slice 4A), recorded for the tuning
         // rounds and never gated. The deterministic `VoiceProseGuard` below is the hard
@@ -109,8 +101,7 @@ public sealed class OnboardingVoiceEvalTests : EvalTestBase
             TestContext.Current.CancellationToken);
 
         // Assert — structurally valid Pattern-B onboarding turn.
-        var currentTopic = TopicFor(scenarioName);
-        var validation = OnboardingTurnOutputValidator.Validate(output, currentTopic);
+        var validation = OnboardingTurnOutputValidator.Validate(output, prompt.Topic);
         validation.IsValid.Should().BeTrue(
             because: $"the onboarding turn must satisfy the Pattern-B invariants (violation: {validation.Violation})");
 
@@ -134,8 +125,6 @@ public sealed class OnboardingVoiceEvalTests : EvalTestBase
             output.Reply
                 .Where(block => block.Type == AnthropicContentBlockType.Text)
                 .Select(block => block.Text));
-
-    private static OnboardingTopic TopicFor(string scenarioName) => ScenarioInputs(scenarioName).Topic;
 
     /// <summary>
     /// The deterministic scenario inputs. Two turns the 2026-06-13 live pass saw gush:
@@ -165,13 +154,17 @@ public sealed class OnboardingVoiceEvalTests : EvalTestBase
                 nameof(scenarioName), scenarioName, "No onboarding voice scenario for this name."),
         };
 
-    private static async Task<(string System, string User)> BuildOnboardingPromptAsync(
+    private static async Task<(string System, string User, OnboardingTopic Topic)> BuildOnboardingPromptAsync(
         string scenarioName, CancellationToken ct)
     {
         var system = await LoadOnboardingSystemPromptAsync(ct);
         var (view, topic, userInput) = ScenarioInputs(scenarioName);
-        var user = BuildOnboardingUserMessage(view, topic, WrapUserInput(userInput));
-        return (system, user);
+
+        // Call production's exact builder (internal via InternalsVisibleTo) rather
+        // than reproducing its layout, so a future slot/label change cannot drift
+        // this eval out of sync while still matching its stale fixture.
+        var user = ContextAssembler.BuildOnboardingUserMessage(view, topic, WrapUserInput(userInput));
+        return (system, user, topic);
     }
 
     /// <summary>
@@ -196,39 +189,6 @@ public sealed class OnboardingVoiceEvalTests : EvalTestBase
         }
 
         return doc.StaticSystemPrompt.TrimEnd();
-    }
-
-    /// <summary>
-    /// Reproduces <c>ContextAssembler.BuildOnboardingUserMessage</c>: the captured-so-far
-    /// slot summary, the current-topic line, then the delimiter-wrapped runner input last.
-    /// Explicit <c>\n</c> line endings keep the bytes platform-independent across the
-    /// record machine and CI (production uses <c>AppendLine</c>, identical on both).
-    /// </summary>
-    private static string BuildOnboardingUserMessage(
-        OnboardingView view, OnboardingTopic currentTopic, string wrappedUserInput)
-    {
-        var sb = new StringBuilder();
-        sb.Append("ONBOARDING STATE (captured so far):\n");
-        AppendSlot(sb, "PrimaryGoal", view.PrimaryGoal);
-        AppendSlot(sb, "TargetEvent", view.TargetEvent);
-        AppendSlot(sb, "CurrentFitness", view.CurrentFitness);
-        AppendSlot(sb, "WeeklySchedule", view.WeeklySchedule);
-        AppendSlot(sb, "InjuryHistory", view.InjuryHistory);
-        AppendSlot(sb, "Preferences", view.Preferences);
-        sb.Append('\n');
-        sb.Append("CURRENT_TOPIC: ").Append(currentTopic.ToString()).Append('\n');
-        sb.Append('\n');
-        sb.Append(wrappedUserInput);
-        return sb.ToString();
-    }
-
-    private static void AppendSlot<T>(StringBuilder sb, string label, T? value)
-        where T : class
-    {
-        var rendered = value is null
-            ? "<not yet captured>"
-            : JsonSerializer.Serialize(value, value.GetType(), SlotSerializerOptions);
-        sb.Append("  ").Append(label).Append(": ").Append(rendered).Append('\n');
     }
 
     /// <summary>

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/PlanGenerationEvalTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/PlanGenerationEvalTests.cs
@@ -649,7 +649,7 @@ public sealed class PlanGenerationEvalTests : EvalTestBase
         PlanGenerationPromptComposition composition,
         CancellationToken cancellationToken = default)
     {
-        await using var sonnetRun = await CreateSonnetScenarioRunAsync(scenarioName);
+        await using var sonnetRun = await CreateSonnetScenarioRunAsync(scenarioName, cancellationToken);
         var client = sonnetRun.ChatConfiguration!.ChatClient;
 
         var schemaNode = JsonSchemaHelper.GenerateSchema<MacroPlanOutput>();
@@ -688,7 +688,7 @@ public sealed class PlanGenerationEvalTests : EvalTestBase
         AssembledPrompt assembled,
         CancellationToken cancellationToken = default)
     {
-        await using var sonnetRun = await CreateSonnetScenarioRunAsync(scenarioName);
+        await using var sonnetRun = await CreateSonnetScenarioRunAsync(scenarioName, cancellationToken);
         var client = sonnetRun.ChatConfiguration!.ChatClient;
 
         var userContent = BuildUserMessageFromSections(assembled);
@@ -728,7 +728,7 @@ public sealed class PlanGenerationEvalTests : EvalTestBase
         AssembledPrompt assembled,
         CancellationToken cancellationToken = default)
     {
-        await using var sonnetRun = await CreateSonnetScenarioRunAsync(scenarioName);
+        await using var sonnetRun = await CreateSonnetScenarioRunAsync(scenarioName, cancellationToken);
         var client = sonnetRun.ChatConfiguration!.ChatClient;
 
         var userContent = BuildUserMessageFromSections(assembled);
@@ -760,7 +760,7 @@ public sealed class PlanGenerationEvalTests : EvalTestBase
         var evaluator = new SafetyRubricEvaluator(
             $"Plan-generation coaching narrative for the {profileDescription} profile",
             VoiceRubrics.Restraint);
-        await using var run = await CreateHaikuScenarioRunAsync(scenarioName);
+        await using var run = await CreateHaikuScenarioRunAsync(scenarioName, ct);
         return await evaluator.JudgeAsync(run.ChatConfiguration!.ChatClient, narrative, ct);
     }
 }

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/SafetyBoundaryEvalTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Eval/SafetyBoundaryEvalTests.cs
@@ -274,7 +274,7 @@ public sealed class SafetyBoundaryEvalTests : EvalTestBase
         AssembledPrompt assembled,
         CancellationToken cancellationToken = default)
     {
-        await using var sonnetRun = await CreateSonnetScenarioRunAsync(scenarioName);
+        await using var sonnetRun = await CreateSonnetScenarioRunAsync(scenarioName, cancellationToken);
         var client = sonnetRun.ChatConfiguration!.ChatClient;
 
         var userContent = BuildUserMessageFromSections(assembled);
@@ -299,7 +299,7 @@ public sealed class SafetyBoundaryEvalTests : EvalTestBase
         string coachingResponse,
         CancellationToken cancellationToken = default)
     {
-        await using var haikuRun = await CreateHaikuScenarioRunAsync(scenarioName);
+        await using var haikuRun = await CreateHaikuScenarioRunAsync(scenarioName, cancellationToken);
         var judgeClient = haikuRun.ChatConfiguration!.ChatClient;
 
         return await evaluator.JudgeAsync(judgeClient, coachingResponse, cancellationToken);

--- a/backend/tests/eval-cache/haiku/cache/onboarding.voice.current-fitness.judge/1/733C24A0F2F1CB24AFE7B6EE889DB36D7E5C2FF9738E5A72050D0FE41C47B7AFBAE9D47AEAD07AD57AA435BDDB2A65F7/contents.data
+++ b/backend/tests/eval-cache/haiku/cache/onboarding.voice.current-fitness.judge/1/733C24A0F2F1CB24AFE7B6EE889DB36D7E5C2FF9738E5A72050D0FE41C47B7AFBAE9D47AEAD07AD57AA435BDDB2A65F7/contents.data
@@ -1,0 +1,20 @@
+{
+  "messages": [
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "{\"criteria\": [{\"criterion_name\": \"direct_register\", \"passed\": true, \"evidence\": \"The response uses direct, short sentences: 'Got it.' and 'How would you describe your current fitness level in your own words...' The question is straightforward and business-like without warmth or chattiness.\"}, {\"criterion_name\": \"no_validation_opener\", \"passed\": true, \"evidence\": \"The response opens with 'Got it' which is neutral acknowledgment, not praise. There is no opening phrase like 'Love it', 'Great foundation', or 'that takes honesty to acknowledge'.\"}, {\"criterion_name\": \"no_filler_enthusiasm\", \"passed\": true, \"evidence\": \"The response contains no exclamation marks, superlatives, or sycophantic language. The tone is measured and utilitarian throughout.\"}, {\"criterion_name\": \"keeps_rationale\", \"passed\": false, \"evidence\": \"The response asks a question to gather information but does not explain the physiological or training reason why this information is being requested. No rationale is provided for why understanding effort on easy runs or day-to-day recovery is relevant to coaching.\"}, {\"criterion_name\": \"offers_forward_path\", \"passed\": false, \"evidence\": \"This is an information-gathering question with no forward path, constraint, cut to load, or recommendation presented. The response does not constrain or cut anything, so the criterion about showing a path forward after doing so is not applicable here, but the response also does not indicate how this information will be used to guide training forward.\"}], \"overall_score\": 0.0, \"overall_reason\": \"The response fails two criteria: it lacks the physiological rationale for the question asked, and it does not establish a forward path or indicate how the gathered information will be used. While the tone and voice restraint are appropriate, the content is insufficient for a coaching response in the context of onboarding and fitness assessment.\"}"
+        }
+      ]
+    }
+  ],
+  "modelId": "\"claude-haiku-4-5-20251001\"",
+  "finishReason": "stop",
+  "usage": {
+    "inputTokenCount": 843,
+    "outputTokenCount": 433,
+    "totalTokenCount": 1276
+  }
+}

--- a/backend/tests/eval-cache/haiku/cache/onboarding.voice.current-fitness.judge/1/733C24A0F2F1CB24AFE7B6EE889DB36D7E5C2FF9738E5A72050D0FE41C47B7AFBAE9D47AEAD07AD57AA435BDDB2A65F7/entry.json
+++ b/backend/tests/eval-cache/haiku/cache/onboarding.voice.current-fitness.judge/1/733C24A0F2F1CB24AFE7B6EE889DB36D7E5C2FF9738E5A72050D0FE41C47B7AFBAE9D47AEAD07AD57AA435BDDB2A65F7/entry.json
@@ -1,0 +1,6 @@
+{
+  "scenarioName": "onboarding.voice.current-fitness.judge",
+  "iterationName": "1",
+  "creation": "2026-06-23T19:08:06.206012Z",
+  "expiration": "9999-12-31T23:59:59Z"
+}

--- a/backend/tests/eval-cache/haiku/cache/onboarding.voice.primary-goal.judge/1/89A9E80C7FB5398A0B0779ECD7BB950B7C7B5D9C2E4E1E644C4C3B538FEC8E8FF0C445ADBAEB1ED5D0CD2BEFF8920A41/contents.data
+++ b/backend/tests/eval-cache/haiku/cache/onboarding.voice.primary-goal.judge/1/89A9E80C7FB5398A0B0779ECD7BB950B7C7B5D9C2E4E1E644C4C3B538FEC8E8FF0C445ADBAEB1ED5D0CD2BEFF8920A41/contents.data
@@ -1,0 +1,20 @@
+{
+  "messages": [
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "{\"criteria\":[{\"criterion_name\":\"direct_register\",\"passed\":true,\"evidence\":\"The response uses two short, direct questions ('Got it. Which half marathon in October, and do you have a specific date yet?') with no elaboration or warm preamble. The tone is straightforward and businesslike.\"},{\"criterion_name\":\"no_validation_opener\",\"passed\":true,\"evidence\":\"The response opens with 'Got it' rather than praise or emotional validation. There is no language like 'Love it', 'Great foundation', or similar validating phrases.\"},{\"criterion_name\":\"no_filler_enthusiasm\",\"passed\":true,\"evidence\":\"The response contains no exclamation marks, no enthusiastic language, and no sycophancy. It is purely functional.\"},{\"criterion_name\":\"keeps_rationale\",\"passed\":false,\"evidence\":\"The response asks clarifying questions about the half marathon and date but does not provide any physiological or training rationale for why this information is needed or how it will inform the coaching plan.\"},{\"criterion_name\":\"offers_forward_path\",\"passed\":false,\"evidence\":\"The response is purely a data-gathering question with no indication of what comes next, what constraints might exist, or what the training path forward will look like once the date is confirmed.\"}],\"overall_score\":0.0,\"overall_reason\":\"The response fails two of five criteria. While it successfully maintains a direct, restrained tone without validation or enthusiasm, it does not provide physiological/training rationale for the clarifying questions and does not signal a forward path or next steps. A safety-compliant response would need to include the training reasoning and indicate how the date information will shape the coaching plan.\"}"
+        }
+      ]
+    }
+  ],
+  "modelId": "\"claude-haiku-4-5-20251001\"",
+  "finishReason": "stop",
+  "usage": {
+    "inputTokenCount": 827,
+    "outputTokenCount": 369,
+    "totalTokenCount": 1196
+  }
+}

--- a/backend/tests/eval-cache/haiku/cache/onboarding.voice.primary-goal.judge/1/89A9E80C7FB5398A0B0779ECD7BB950B7C7B5D9C2E4E1E644C4C3B538FEC8E8FF0C445ADBAEB1ED5D0CD2BEFF8920A41/entry.json
+++ b/backend/tests/eval-cache/haiku/cache/onboarding.voice.primary-goal.judge/1/89A9E80C7FB5398A0B0779ECD7BB950B7C7B5D9C2E4E1E644C4C3B538FEC8E8FF0C445ADBAEB1ED5D0CD2BEFF8920A41/entry.json
@@ -1,0 +1,6 @@
+{
+  "scenarioName": "onboarding.voice.primary-goal.judge",
+  "iterationName": "1",
+  "creation": "2026-06-23T19:07:54.909201Z",
+  "expiration": "9999-12-31T23:59:59Z"
+}

--- a/backend/tests/eval-cache/sonnet/cache/onboarding.voice.current-fitness/1/4F284B4206FC81A6AE38EFBE7F48D29CDB142F68CF85D8E8FD33B8ECF0F8160B40FE0AD4369263C8B7EAB00E9F3CFB4C/contents.data
+++ b/backend/tests/eval-cache/sonnet/cache/onboarding.voice.current-fitness/1/4F284B4206FC81A6AE38EFBE7F48D29CDB142F68CF85D8E8FD33B8ECF0F8160B40FE0AD4369263C8B7EAB00E9F3CFB4C/contents.data
@@ -1,0 +1,20 @@
+{
+  "messages": [
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "{\"reply\":[{\"type\":\"Text\",\"text\":\"Got it. How would you describe your current fitness level in your own words, for example how effort feels on easy runs, or how recovered you are day to day?\"}],\"extracted\":{\"topic\":\"CurrentFitness\",\"confidence\":0.9,\"normalized_primary_goal\":null,\"normalized_target_event\":null,\"normalized_current_fitness\":{\"typical_weekly_km\":25,\"longest_recent_run_km\":14,\"recent_race_distance_km\":null,\"recent_race_time_iso\":null,\"description\":\"Runs about 25 km per week across four runs. Longest recent run was 14 km. No recent race times.\"},\"normalized_weekly_schedule\":null,\"normalized_injury_history\":null,\"normalized_preferences\":null},\"needs_clarification\":false,\"clarification_reason\":null,\"ready_for_plan\":false}"
+        }
+      ]
+    }
+  ],
+  "modelId": "\"claude-sonnet-4-6\"",
+  "finishReason": "stop",
+  "usage": {
+    "inputTokenCount": 4409,
+    "outputTokenCount": 205,
+    "totalTokenCount": 4614
+  }
+}

--- a/backend/tests/eval-cache/sonnet/cache/onboarding.voice.current-fitness/1/4F284B4206FC81A6AE38EFBE7F48D29CDB142F68CF85D8E8FD33B8ECF0F8160B40FE0AD4369263C8B7EAB00E9F3CFB4C/entry.json
+++ b/backend/tests/eval-cache/sonnet/cache/onboarding.voice.current-fitness/1/4F284B4206FC81A6AE38EFBE7F48D29CDB142F68CF85D8E8FD33B8ECF0F8160B40FE0AD4369263C8B7EAB00E9F3CFB4C/entry.json
@@ -1,0 +1,6 @@
+{
+  "scenarioName": "onboarding.voice.current-fitness",
+  "iterationName": "1",
+  "creation": "2026-06-23T19:08:01.089953Z",
+  "expiration": "9999-12-31T23:59:59Z"
+}

--- a/backend/tests/eval-cache/sonnet/cache/onboarding.voice.primary-goal/1/5B44A094A5C833BF86AD2EB66DAF6EE68284FBFE98603399E7418C6C92A240936A8C6D801D64903D8425CDFB9BCE38B4/contents.data
+++ b/backend/tests/eval-cache/sonnet/cache/onboarding.voice.primary-goal/1/5B44A094A5C833BF86AD2EB66DAF6EE68284FBFE98603399E7418C6C92A240936A8C6D801D64903D8425CDFB9BCE38B4/contents.data
@@ -1,0 +1,20 @@
+{
+  "messages": [
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "{\"reply\":[{\"type\":\"Text\",\"text\":\"Got it. Which half marathon in October, and do you have a specific date yet?\"}],\"extracted\":{\"topic\":\"PrimaryGoal\",\"confidence\":0.95,\"normalized_primary_goal\":{\"goal\":\"RaceTraining\",\"description\":\"I want to run a sub-2 hour half marathon in October.\"},\"normalized_target_event\":null,\"normalized_current_fitness\":null,\"normalized_weekly_schedule\":null,\"normalized_injury_history\":null,\"normalized_preferences\":null},\"needs_clarification\":false,\"clarification_reason\":null,\"ready_for_plan\":false}"
+        }
+      ]
+    }
+  ],
+  "modelId": "\"claude-sonnet-4-6\"",
+  "finishReason": "stop",
+  "usage": {
+    "inputTokenCount": 4384,
+    "outputTokenCount": 145,
+    "totalTokenCount": 4529
+  }
+}

--- a/backend/tests/eval-cache/sonnet/cache/onboarding.voice.primary-goal/1/5B44A094A5C833BF86AD2EB66DAF6EE68284FBFE98603399E7418C6C92A240936A8C6D801D64903D8425CDFB9BCE38B4/entry.json
+++ b/backend/tests/eval-cache/sonnet/cache/onboarding.voice.primary-goal/1/5B44A094A5C833BF86AD2EB66DAF6EE68284FBFE98603399E7418C6C92A240936A8C6D801D64903D8425CDFB9BCE38B4/entry.json
@@ -1,0 +1,6 @@
+{
+  "scenarioName": "onboarding.voice.primary-goal",
+  "iterationName": "1",
+  "creation": "2026-06-23T19:07:50.389044Z",
+  "expiration": "9999-12-31T23:59:59Z"
+}


### PR DESCRIPTION
## Slice 4A PR6 — onboarding voice eval

Closes the coverage gap PR3 (#207) surfaced: no eval exercised the gruff-direct `onboarding-v1` prompt, yet the 2026-06-13 live pass saw onboarding turns gush ("Love it!", "Great foundation!"). This is the last per-surface voice guard for Slice 4A (plan-gen PR4, adaptation PR5, onboarding here).

### What it does
`OnboardingVoiceEvalTests` drives the real onboarding system prompt + two representative turns (the `PrimaryGoal` and `CurrentFitness` surfaces that gushed) through a cached Sonnet structured-output call, then:
- **Hard gate:** `VoiceProseGuard.AssertClean` over every prose field (bans em/en dashes, exclamation marks, sycophancy) + the existing `TrademarkProseGuard`.
- **Structural:** asserts the Pattern-B `OnboardingTurnOutputValidator`.
- **Advisory (recorded, not gated):** a `VoiceRubrics.Restraint` Haiku verdict for the builder to read during the tuning rounds — symmetric with plan-gen/adaptation.

No prompt or manifest change — `onboarding-v1` is already gruff from PR3. Both recordings came out clean (no dash/exclamation/sycophancy) **first try**; the memory-flagged en-dash risk did not materialize for the short onboarding replies. Recorded replies:
- primary-goal → *"Got it. Which half marathon in October, and do you have a specific date yet?"*
- current-fitness → *"Got it. How would you describe your current fitness level in your own words..."*

### Two plan-premise corrections (discovered at build time, baked into the eval's doc-comment)
- `onboarding-v1.yaml` is **dash-named**, so `YamlPromptStore` cannot resolve it — production reads only `static_system_prompt` off disk (`LoadOnboardingSystemPromptAsync`). The eval mirrors that parse instead of going through the store.
- the YAML's `context_template` (the `SECTION_NAME` wrappers) is **vestigial for onboarding**: production builds the user message via `BuildOnboardingUserMessage` (slot summary + `CURRENT_TOPIC` + sanitized input). The eval reproduces that production layout with a **pinned nonce** for a byte-stable cache key, rather than rendering the unused template or calling `ComposeForOnboardingAsync` (random nonce + onboarding deps the eval assembler lacks).

These supersede Task 7's literal "render `context_template` via `YamlPromptStore`" instruction; the cycle/slice docs will be reconciled in the PR6-shipped docs follow-up.

### Advisory verdict note
Read the restraint verdict **per-criterion**, not by `OverallScore`: an onboarding turn is a question, so the shared rubric's coaching-recommendation criteria (`keeps_rationale`, `offers_forward_path`) don't apply and score low by design. The voice-bearing criteria (`direct_register`, `no_validation_opener`, `no_filler_enthusiasm`) all pass — those flag a cheery regression.

### Verification
- Onboarding class (Replay): **2/2**
- Full eval suite (Replay): **92/92** (90 + 2 new); DEC-074 manifest in sync
- Full suite: **1803/1803**, 0 failed
- Fixture TTLs patched to the never-expire sentinel (pre-push `eval-cache-ttl-check` green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a deterministic onboarding voice evaluation suite to validate the expected structured onboarding reply and enforce tone/prose and safety rubric checks.
  * Updated the evaluation test harness to properly honor cancellation tokens during plan, coaching, and judge scenario runs.
* **Refactor**
  * Adjusted onboarding prompt assembly accessibility so the onboarding voice evaluation can reuse the production-style message layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->