### PR TITLE
feat(slice-4b): streaming llm adapter + dec-073 stream-error translation (pr1)

### DIFF
--- a/backend/src/RunCoach.Api/Modules/Coaching/ClaudeCoachingLlm.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/ClaudeCoachingLlm.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 using Anthropic;
 using Anthropic.Core;
 using Anthropic.Exceptions;
+using Anthropic.Models;
 using Anthropic.Models.Messages;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
@@ -279,82 +280,18 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
     }
 
     /// <inheritdoc />
-    public async IAsyncEnumerable<string> StreamAsync(
+    public IAsyncEnumerable<string> StreamAsync(
         string systemPrompt,
         string userMessage,
-        [EnumeratorCancellation] CancellationToken ct)
+        CancellationToken ct)
     {
+        // Validate eagerly at the call site (not deferred to the first MoveNextAsync of the
+        // returned iterator), matching the async-Task ICoachingLlm methods — split from the
+        // iterator body per sonar S4456.
         ArgumentException.ThrowIfNullOrWhiteSpace(systemPrompt);
         ArgumentException.ThrowIfNullOrWhiteSpace(userMessage);
 
-        // Run inside a RetryAfterCapture scope so a pre-stream 429's raw Retry-After header
-        // (seen by RetryAfterCaptureHandler on the owned pipeline) is attached to the translated
-        // Transient exception, exactly as the non-streaming path does. Mid-stream errors have no
-        // header once SSE headers are flushed (R-084).
-        using (RetryAfterCapture.BeginScope())
-        {
-            using var chatClient = _streamingChatClientFactory();
-            var messages = new List<ChatMessage>
-            {
-                new(ChatRole.System, systemPrompt),
-                new(ChatRole.User, userMessage),
-            };
-
-            // R-084: the SDK throws mid-enumeration for streamed errors. Drive the enumerator
-            // manually so MoveNextAsync sits inside try/catch while `yield return` stays outside it
-            // (C# forbids yielding from a try that has a catch), translating the Anthropic failure
-            // surface into the DEC-073 totality contract.
-            await using var enumerator = chatClient
-                .GetStreamingResponseAsync(messages, options: null, ct)
-                .GetAsyncEnumerator(ct);
-
-            string? terminalStopReason = null;
-
-            while (true)
-            {
-                ChatResponseUpdate update;
-                try
-                {
-                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        break;
-                    }
-
-                    update = enumerator.Current;
-                }
-                catch (OperationCanceledException ex) when (!ct.IsCancellationRequested)
-                {
-                    // The SDK's per-attempt timeout fired (the caller did not cancel) — a transient
-                    // service failure. A genuine client abort (ct cancelled) fails this filter and
-                    // propagates unwrapped as not-an-error, mirroring CreateMessageAsync.
-                    throw new TransientCoachingLlmException(UnavailableMessage, retryAfterSeconds: null, ex);
-                }
-                catch (AnthropicException ex)
-                {
-                    throw TranslateAnthropicFailure(ex);
-                }
-
-                // The terminal stop reason rides the message_delta update (and may repeat on
-                // trailing updates — last-write-wins keeps that idempotent). Captured here, acted
-                // on after the stream ends cleanly.
-                var stopReason = TryGetTerminalStopReason(update);
-                if (stopReason is not null)
-                {
-                    terminalStopReason = stopReason;
-                }
-
-                var delta = update.Text;
-                if (!string.IsNullOrEmpty(delta))
-                {
-                    yield return delta;
-                }
-            }
-
-            // A clean enumeration end on an incomplete stop reason (truncation, context overflow,
-            // or a refusal) is the errored-turn signal: the partial just yielded is unusable as a
-            // complete turn. R-084 — these end the stream cleanly, never as an exception.
-            ThrowIfIncompleteFinish(terminalStopReason);
-        }
+        return StreamCore(systemPrompt, userMessage, ct);
     }
 
     /// <summary>
@@ -567,7 +504,12 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
             return null;
         }
 
-        return raw.Json.TryGetProperty("delta", out var delta)
+        // ValueKind guards keep JsonElement.TryGetProperty from throwing on a non-object element
+        // (it throws InvalidOperationException unless the element is an Object) — defensive against
+        // a malformed event, so no untyped exception can escape the totality contract.
+        return raw.Json.ValueKind == JsonValueKind.Object
+            && raw.Json.TryGetProperty("delta", out var delta)
+            && delta.ValueKind == JsonValueKind.Object
             && delta.TryGetProperty("stop_reason", out var stopReason)
             && stopReason.ValueKind == JsonValueKind.String
             ? stopReason.GetString()
@@ -638,28 +580,22 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
     }
 
     /// <summary>
-    /// Classifies a mid-stream <see cref="AnthropicSseException"/>. The SDK 12.29.1 exposes no
-    /// structured error-type accessor; the error <c>type</c> string is carried verbatim in the
-    /// message (e.g. <c>SSE error returned from server: '{"type":"error","error":{"type":"overloaded_error",…}}'</c>),
-    /// so classification matches on that token. <c>invalid_request_error</c> /
-    /// <c>authentication_error</c> / <c>permission_error</c> are terminal (Permanent); the
-    /// retryable service-side types (<c>overloaded_error</c> / <c>rate_limit_error</c> /
-    /// <c>api_error</c> / <c>timeout_error</c>) and any unrecognized type default to Transient
-    /// (recall-over-precision). There is no <c>Retry-After</c> header once SSE headers are flushed,
-    /// so a transient mid-stream error carries no delay hint (the SSE endpoint applies a configured
-    /// default).
+    /// Classifies a mid-stream <see cref="AnthropicSseException"/> on the SDK's strongly-typed
+    /// <see cref="AnthropicServiceException.ErrorType"/> (parsed from the SSE <c>error.type</c> field
+    /// by the SDK, independent of the server-controlled <c>error.message</c> text). Bad-request /
+    /// auth / permission / not-found / billing types are terminal (Permanent); the retryable
+    /// service-side types (rate-limit / overloaded / api / timeout) and any unrecognized type
+    /// (<see langword="null"/>) default to Transient (recall-over-precision). There is no
+    /// <c>Retry-After</c> header once SSE headers are flushed, so a transient mid-stream error
+    /// carries no delay hint (the SSE endpoint applies a configured default).
     /// </summary>
-    private static CoachingLlmException ClassifySseError(AnthropicSseException sse)
+    private static CoachingLlmException ClassifySseError(AnthropicSseException sse) => sse.ErrorType switch
     {
-        var message = sse.Message;
-        var permanent = message.Contains("invalid_request_error", StringComparison.Ordinal)
-            || message.Contains("authentication_error", StringComparison.Ordinal)
-            || message.Contains("permission_error", StringComparison.Ordinal);
-
-        return permanent
-            ? new PermanentCoachingLlmException(RejectedMessage, sse)
-            : new TransientCoachingLlmException(UnavailableMessage, retryAfterSeconds: null, sse);
-    }
+        ErrorType.InvalidRequestError or ErrorType.AuthenticationError or ErrorType.PermissionError
+            or ErrorType.NotFoundError or ErrorType.BillingError
+            => new PermanentCoachingLlmException(RejectedMessage, sse),
+        _ => new TransientCoachingLlmException(UnavailableMessage, retryAfterSeconds: null, sse),
+    };
 
     /// <summary>
     /// Validates that required settings are present.
@@ -691,6 +627,89 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Scrubbed {Occurrences} trademarked pace-index term occurrence(s) from LLM output ({OutputKind})")]
     private static partial void LogScrubbedTrademarkedTerm(ILogger logger, int occurrences, string outputKind);
+
+    /// <summary>
+    /// The streaming iterator behind <see cref="StreamAsync"/> (split out so argument validation
+    /// runs eagerly at the call site rather than on first enumeration — sonar S4456).
+    /// </summary>
+    private async IAsyncEnumerable<string> StreamCore(
+        string systemPrompt,
+        string userMessage,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        // Run inside a RetryAfterCapture scope so a pre-stream 429's raw Retry-After header
+        // (seen by RetryAfterCaptureHandler on the owned pipeline) is attached to the translated
+        // Transient exception, exactly as the non-streaming path does. NOTE: an AsyncLocal value
+        // set here is only visible up to the FIRST `yield return` — after the consumer resumes the
+        // iterator it runs under its own ExecutionContext, so RetryAfterCapture.CurrentSeconds is
+        // reliable only in the pre-first-byte window. That is sufficient: a 429 is a pre-first-byte
+        // failure, and mid-stream errors have no Retry-After header once SSE headers are flushed
+        // (R-084).
+        using (RetryAfterCapture.BeginScope())
+        {
+            using var chatClient = _streamingChatClientFactory();
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.System, systemPrompt),
+                new(ChatRole.User, userMessage),
+            };
+
+            // R-084: the SDK throws mid-enumeration for streamed errors. Drive the enumerator
+            // manually so MoveNextAsync sits inside try/catch while `yield return` stays outside it
+            // (C# forbids yielding from a try that has a catch), translating the Anthropic failure
+            // surface into the DEC-073 totality contract.
+            await using var enumerator = chatClient
+                .GetStreamingResponseAsync(messages, options: null, ct)
+                .GetAsyncEnumerator(ct);
+
+            string? terminalStopReason = null;
+
+            while (true)
+            {
+                ChatResponseUpdate update;
+                try
+                {
+                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                    {
+                        break;
+                    }
+
+                    update = enumerator.Current;
+                }
+                catch (OperationCanceledException ex) when (!ct.IsCancellationRequested)
+                {
+                    // The SDK's per-attempt timeout fired (the caller did not cancel) — a transient
+                    // service failure. A genuine client abort (ct cancelled) fails this filter and
+                    // propagates unwrapped as not-an-error, mirroring CreateMessageAsync.
+                    throw new TransientCoachingLlmException(UnavailableMessage, retryAfterSeconds: null, ex);
+                }
+                catch (AnthropicException ex)
+                {
+                    throw TranslateAnthropicFailure(ex);
+                }
+
+                // The terminal stop reason rides the message_delta update (and may repeat on
+                // trailing updates — last-write-wins keeps that idempotent). Captured here, acted
+                // on after the stream ends cleanly.
+                var stopReason = TryGetTerminalStopReason(update);
+                if (stopReason is not null)
+                {
+                    terminalStopReason = stopReason;
+                }
+
+                var delta = update.Text;
+                if (!string.IsNullOrEmpty(delta))
+                {
+                    yield return delta;
+                }
+            }
+
+            // A clean enumeration end on an incomplete stop reason (truncation, context overflow,
+            // or a refusal) is the errored-turn signal: the partial just yielded is unusable as a
+            // complete turn. R-084 — these end the stream cleanly, never as an exception.
+            ThrowIfIncompleteFinish(terminalStopReason);
+        }
+    }
 
     /// <summary>
     /// Issues the Anthropic <c>messages.create</c> call inside a <see cref="RetryAfterCapture"/>

--- a/backend/src/RunCoach.Api/Modules/Coaching/ClaudeCoachingLlm.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/ClaudeCoachingLlm.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -11,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RunCoach.Api.Modules.Coaching.Models;
 using RunCoach.Api.Modules.Coaching.Models.Structured;
+using RunCoach.Api.Modules.Coaching.Sanitization;
 using AnthropicMessages = Anthropic.Models.Messages;
 
 namespace RunCoach.Api.Modules.Coaching;
@@ -54,6 +56,16 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
     private readonly HttpClient? _httpClient;
 
     /// <summary>
+    /// Factory for the streaming <see cref="IChatClient"/> the
+    /// <see cref="StreamAsync"/> path drives. Production wraps the SDK's M.E.AI
+    /// bridge (<see cref="AsIChatClient"/>) in <see cref="SanitizationAuditChatClient"/>
+    /// so the stream inherits the GUARDRAIL audit span; tests inject a controllable
+    /// stub so the DEC-073 stream-error translation can be exercised without a live
+    /// SSE transport.
+    /// </summary>
+    private readonly Func<IChatClient> _streamingChatClientFactory;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ClaudeCoachingLlm"/> class
     /// using dependency-injected settings and logger.
     /// Creates the <see cref="AnthropicClient"/> from configuration.
@@ -72,6 +84,7 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
         ValidateSettings(_settings);
 
         (_client, _httpClient) = CreateClientPipeline(_settings, new SocketsHttpHandler());
+        _streamingChatClientFactory = () => new SanitizationAuditChatClient(AsIChatClient());
     }
 
     /// <summary>
@@ -81,7 +94,8 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
     internal ClaudeCoachingLlm(
         IAnthropicClient client,
         CoachingLlmSettings settings,
-        ILogger<ClaudeCoachingLlm> logger)
+        ILogger<ClaudeCoachingLlm> logger,
+        Func<IChatClient>? streamingChatClientFactory = null)
     {
         ArgumentNullException.ThrowIfNull(client);
         ArgumentNullException.ThrowIfNull(settings);
@@ -92,6 +106,8 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
         _logger = logger;
         _ownsClient = false;
         _httpClient = null;
+        _streamingChatClientFactory = streamingChatClientFactory
+            ?? (() => new SanitizationAuditChatClient(AsIChatClient()));
     }
 
     /// <inheritdoc />
@@ -257,6 +273,33 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
 
         var usage = ExtractUsage(response);
         return (result, usage);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<string> StreamAsync(
+        string systemPrompt,
+        string userMessage,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(systemPrompt);
+        ArgumentException.ThrowIfNullOrWhiteSpace(userMessage);
+
+        using var chatClient = _streamingChatClientFactory();
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, systemPrompt),
+            new(ChatRole.User, userMessage),
+        };
+
+        var stream = chatClient.GetStreamingResponseAsync(messages, options: null, ct);
+        await foreach (var update in stream.ConfigureAwait(false))
+        {
+            var delta = update.Text;
+            if (!string.IsNullOrEmpty(delta))
+            {
+                yield return delta;
+            }
+        }
     }
 
     /// <summary>

--- a/backend/src/RunCoach.Api/Modules/Coaching/ClaudeCoachingLlm.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/ClaudeCoachingLlm.cs
@@ -49,6 +49,9 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
     private const string RejectedMessage =
         "The coaching request could not be completed.";
 
+    private const string IncompleteMessage =
+        "The coaching reply could not be completed.";
+
     private readonly IAnthropicClient _client;
     private readonly CoachingLlmSettings _settings;
     private readonly ILogger<ClaudeCoachingLlm> _logger;
@@ -284,21 +287,73 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
         ArgumentException.ThrowIfNullOrWhiteSpace(systemPrompt);
         ArgumentException.ThrowIfNullOrWhiteSpace(userMessage);
 
-        using var chatClient = _streamingChatClientFactory();
-        var messages = new List<ChatMessage>
+        // Run inside a RetryAfterCapture scope so a pre-stream 429's raw Retry-After header
+        // (seen by RetryAfterCaptureHandler on the owned pipeline) is attached to the translated
+        // Transient exception, exactly as the non-streaming path does. Mid-stream errors have no
+        // header once SSE headers are flushed (R-084).
+        using (RetryAfterCapture.BeginScope())
         {
-            new(ChatRole.System, systemPrompt),
-            new(ChatRole.User, userMessage),
-        };
-
-        var stream = chatClient.GetStreamingResponseAsync(messages, options: null, ct);
-        await foreach (var update in stream.ConfigureAwait(false))
-        {
-            var delta = update.Text;
-            if (!string.IsNullOrEmpty(delta))
+            using var chatClient = _streamingChatClientFactory();
+            var messages = new List<ChatMessage>
             {
-                yield return delta;
+                new(ChatRole.System, systemPrompt),
+                new(ChatRole.User, userMessage),
+            };
+
+            // R-084: the SDK throws mid-enumeration for streamed errors. Drive the enumerator
+            // manually so MoveNextAsync sits inside try/catch while `yield return` stays outside it
+            // (C# forbids yielding from a try that has a catch), translating the Anthropic failure
+            // surface into the DEC-073 totality contract.
+            await using var enumerator = chatClient
+                .GetStreamingResponseAsync(messages, options: null, ct)
+                .GetAsyncEnumerator(ct);
+
+            string? terminalStopReason = null;
+
+            while (true)
+            {
+                ChatResponseUpdate update;
+                try
+                {
+                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                    {
+                        break;
+                    }
+
+                    update = enumerator.Current;
+                }
+                catch (OperationCanceledException ex) when (!ct.IsCancellationRequested)
+                {
+                    // The SDK's per-attempt timeout fired (the caller did not cancel) — a transient
+                    // service failure. A genuine client abort (ct cancelled) fails this filter and
+                    // propagates unwrapped as not-an-error, mirroring CreateMessageAsync.
+                    throw new TransientCoachingLlmException(UnavailableMessage, retryAfterSeconds: null, ex);
+                }
+                catch (AnthropicException ex)
+                {
+                    throw TranslateAnthropicFailure(ex);
+                }
+
+                // The terminal stop reason rides the message_delta update (and may repeat on
+                // trailing updates — last-write-wins keeps that idempotent). Captured here, acted
+                // on after the stream ends cleanly.
+                var stopReason = TryGetTerminalStopReason(update);
+                if (stopReason is not null)
+                {
+                    terminalStopReason = stopReason;
+                }
+
+                var delta = update.Text;
+                if (!string.IsNullOrEmpty(delta))
+                {
+                    yield return delta;
+                }
             }
+
+            // A clean enumeration end on an incomplete stop reason (truncation, context overflow,
+            // or a refusal) is the errored-turn signal: the partial just yielded is unusable as a
+            // complete turn. R-084 — these end the stream cleanly, never as an exception.
+            ThrowIfIncompleteFinish(terminalStopReason);
         }
     }
 
@@ -499,6 +554,114 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
     }
 
     /// <summary>
+    /// Reads the authoritative Anthropic <c>stop_reason</c> from a streamed update's
+    /// <c>message_delta</c> event, or <see langword="null"/> for any other update. Read from the
+    /// raw event JSON rather than M.E.AI's <see cref="ChatResponseUpdate.FinishReason"/> because the
+    /// SDK enum has no <c>model_context_window_exceeded</c> member and the bridge maps it to
+    /// <c>Stop</c> — indistinguishable from a clean <c>end_turn</c> at the finish-reason layer.
+    /// </summary>
+    private static string? TryGetTerminalStopReason(ChatResponseUpdate update)
+    {
+        if (update.RawRepresentation is not RawMessageStreamEvent raw || !raw.TryPickDelta(out _))
+        {
+            return null;
+        }
+
+        return raw.Json.TryGetProperty("delta", out var delta)
+            && delta.TryGetProperty("stop_reason", out var stopReason)
+            && stopReason.ValueKind == JsonValueKind.String
+            ? stopReason.GetString()
+            : null;
+    }
+
+    /// <summary>
+    /// Raises the errored-turn signal (<see cref="IncompleteCoachingLlmException"/>) when a stream
+    /// ended cleanly on an incomplete stop reason. <c>max_tokens</c> is retryable (a fresh turn may
+    /// fit); context overflow and a refusal are not (re-sending the same input fails the same way).
+    /// Clean stop reasons (<c>end_turn</c>/<c>stop_sequence</c>) and a missing reason are no-ops.
+    /// </summary>
+    private static void ThrowIfIncompleteFinish(string? stopReason)
+    {
+        IncompleteReason? reason = stopReason switch
+        {
+            "max_tokens" => IncompleteReason.MaxTokens,
+            "model_context_window_exceeded" => IncompleteReason.ContextWindowExceeded,
+            "refusal" => IncompleteReason.Refusal,
+            _ => null,
+        };
+
+        if (reason is not { } incompleteReason)
+        {
+            return;
+        }
+
+        throw new IncompleteCoachingLlmException(
+            IncompleteMessage,
+            incompleteReason,
+            retryable: incompleteReason == IncompleteReason.MaxTokens);
+    }
+
+    /// <summary>
+    /// Translates an Anthropic SDK failure into the DEC-073 totality contract — the single classifier
+    /// shared by the request/response (<see cref="CreateMessageAsync"/>) and streaming
+    /// (<see cref="StreamAsync"/>) paths so they cannot drift. A mid-stream error after the HTTP 200
+    /// arrives as <see cref="AnthropicSseException"/> (streaming-only) and is classified on its SSE
+    /// error <c>type</c>; everything else is a pre-first-byte failure classified by HTTP status
+    /// (408/409/429/5xx → Transient, other 4xx → Permanent) or a transport
+    /// <see cref="AnthropicIOException"/> → Transient. Switch order mirrors the leaf-to-base hierarchy
+    /// (rate-limit and 5xx derive from <see cref="AnthropicApiException"/>; 408/409 land on the
+    /// non-leaf branch and are classified by status). The caller wraps the call in a
+    /// <see cref="RetryAfterCapture"/> scope so a 429's raw <c>Retry-After</c> header is attached.
+    /// </summary>
+    private static CoachingLlmException TranslateAnthropicFailure(AnthropicException ex) => ex switch
+    {
+        AnthropicSseException sse => ClassifySseError(sse),
+        AnthropicRateLimitException => new TransientCoachingLlmException(BusyMessage, RetryAfterCapture.CurrentSeconds, ex),
+        Anthropic5xxException => new TransientCoachingLlmException(UnavailableMessage, RetryAfterCapture.CurrentSeconds, ex),
+        AnthropicIOException => new TransientCoachingLlmException(UnavailableMessage, retryAfterSeconds: null, ex),
+        AnthropicInvalidDataException => new PermanentCoachingLlmException(RejectedMessage, ex),
+        AnthropicApiException api => ClassifyApiStatus(api),
+        _ => new PermanentCoachingLlmException(RejectedMessage, ex),
+    };
+
+    /// <summary>
+    /// Classifies a status-bearing <see cref="AnthropicApiException"/> by HTTP status: 408/409/429
+    /// and 5xx are Transient (the SDK would have retried them); other 4xx are Permanent.
+    /// </summary>
+    private static CoachingLlmException ClassifyApiStatus(AnthropicApiException ex)
+    {
+        var status = (int)ex.StatusCode;
+        var transient = status is 408 or 409 or 429 || status >= 500;
+        return transient
+            ? new TransientCoachingLlmException(UnavailableMessage, RetryAfterCapture.CurrentSeconds, ex)
+            : new PermanentCoachingLlmException(RejectedMessage, ex);
+    }
+
+    /// <summary>
+    /// Classifies a mid-stream <see cref="AnthropicSseException"/>. The SDK 12.29.1 exposes no
+    /// structured error-type accessor; the error <c>type</c> string is carried verbatim in the
+    /// message (e.g. <c>SSE error returned from server: '{"type":"error","error":{"type":"overloaded_error",…}}'</c>),
+    /// so classification matches on that token. <c>invalid_request_error</c> /
+    /// <c>authentication_error</c> / <c>permission_error</c> are terminal (Permanent); the
+    /// retryable service-side types (<c>overloaded_error</c> / <c>rate_limit_error</c> /
+    /// <c>api_error</c> / <c>timeout_error</c>) and any unrecognized type default to Transient
+    /// (recall-over-precision). There is no <c>Retry-After</c> header once SSE headers are flushed,
+    /// so a transient mid-stream error carries no delay hint (the SSE endpoint applies a configured
+    /// default).
+    /// </summary>
+    private static CoachingLlmException ClassifySseError(AnthropicSseException sse)
+    {
+        var message = sse.Message;
+        var permanent = message.Contains("invalid_request_error", StringComparison.Ordinal)
+            || message.Contains("authentication_error", StringComparison.Ordinal)
+            || message.Contains("permission_error", StringComparison.Ordinal);
+
+        return permanent
+            ? new PermanentCoachingLlmException(RejectedMessage, sse)
+            : new TransientCoachingLlmException(UnavailableMessage, retryAfterSeconds: null, sse);
+    }
+
+    /// <summary>
     /// Validates that required settings are present.
     /// Throws <see cref="InvalidOperationException"/> if the API key is missing.
     /// </summary>
@@ -531,18 +694,17 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
 
     /// <summary>
     /// Issues the Anthropic <c>messages.create</c> call inside a <see cref="RetryAfterCapture"/>
-    /// scope and translates the SDK 12.24.1 failure surface into the adapter-owned
+    /// scope and translates the SDK failure surface into the adapter-owned
     /// <see cref="TransientCoachingLlmException"/> / <see cref="PermanentCoachingLlmException"/>
-    /// (DEC-073) so callers never see an <c>Anthropic.Exceptions</c> type. The SDK has already
-    /// applied its own bounded retries (<see cref="CoachingLlmSettings.MaxRetries"/>) and honored
-    /// <c>Retry-After</c> backoff by the time any of these catches fire. Genuine caller
-    /// cancellation propagates unwrapped and is never reclassified as a service failure; the
-    /// filtered <c>OperationCanceledException</c> catch only fires when the caller's token is NOT
-    /// cancelled — i.e. the SDK's per-attempt timeout (<c>ClientOptions.Timeout</c>), which the
-    /// SDK 12.24.1 surfaces as a raw <see cref="TaskCanceledException"/> from a linked CTS with no
-    /// timeout exception type of its own. Catch order is significant:
-    /// <see cref="AnthropicRateLimitException"/> derives from
-    /// <see cref="Anthropic4xxException"/> which derives from <see cref="AnthropicApiException"/>.
+    /// (DEC-073) via the shared <see cref="TranslateAnthropicFailure"/> classifier, so callers never
+    /// see an <c>Anthropic.Exceptions</c> type and this path cannot drift from
+    /// <see cref="StreamAsync"/>. The SDK has already applied its own bounded retries
+    /// (<see cref="CoachingLlmSettings.MaxRetries"/>) and honored <c>Retry-After</c> backoff by the
+    /// time any catch fires. Genuine caller cancellation propagates unwrapped and is never
+    /// reclassified; the filtered <c>OperationCanceledException</c> catch only fires when the caller's
+    /// token is NOT cancelled — i.e. the SDK's per-attempt timeout (<c>ClientOptions.Timeout</c>),
+    /// which surfaces as a raw <see cref="TaskCanceledException"/> from a linked CTS with no timeout
+    /// exception type of its own.
     /// </summary>
     private async Task<Message> CreateMessageAsync(MessageCreateParams createParams, CancellationToken ct)
     {
@@ -558,38 +720,12 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
                 // overlong Anthropic call is a transient service failure, not a user cancellation.
                 throw new TransientCoachingLlmException(UnavailableMessage, retryAfterSeconds: null, ex);
             }
-            catch (AnthropicRateLimitException ex)
-            {
-                throw new TransientCoachingLlmException(BusyMessage, RetryAfterCapture.CurrentSeconds, ex);
-            }
-            catch (Anthropic5xxException ex)
-            {
-                throw new TransientCoachingLlmException(UnavailableMessage, RetryAfterCapture.CurrentSeconds, ex);
-            }
-            catch (AnthropicIOException ex)
-            {
-                // Transport failure — no HTTP response, so no Retry-After to read.
-                throw new TransientCoachingLlmException(UnavailableMessage, retryAfterSeconds: null, ex);
-            }
-            catch (AnthropicInvalidDataException ex)
-            {
-                throw new PermanentCoachingLlmException(RejectedMessage, ex);
-            }
-            catch (AnthropicApiException ex)
-            {
-                // Remaining HTTP errors: 408/409 land on the non-leaf Anthropic4xxException, so
-                // classify by status rather than leaf type. 408/409/429/5xx are transient (the
-                // SDK would have retried them); 400/401/403/404/422 are permanent.
-                var status = (int)ex.StatusCode;
-                var transient = status is 408 or 409 or 429 || status >= 500;
-                throw transient
-                    ? new TransientCoachingLlmException(UnavailableMessage, RetryAfterCapture.CurrentSeconds, ex)
-                    : new PermanentCoachingLlmException(RejectedMessage, ex);
-            }
             catch (AnthropicException ex)
             {
-                // Defensive catch-all for any unmodeled SDK exception (e.g. a bare service error).
-                throw new PermanentCoachingLlmException(RejectedMessage, ex);
+                // Status / leaf-type classification lives in the shared translator so this path and
+                // StreamAsync cannot drift (DEC-073). Genuine caller cancellation is unaffected — it
+                // surfaces as OperationCanceledException, which is not an AnthropicException.
+                throw TranslateAnthropicFailure(ex);
             }
         }
     }

--- a/backend/src/RunCoach.Api/Modules/Coaching/ClaudeCoachingLlm.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/ClaudeCoachingLlm.cs
@@ -517,6 +517,43 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
     }
 
     /// <summary>
+    /// Harvests token-usage telemetry from a streamed update's raw event so the streaming path logs
+    /// the same cost-tracking counters as the non-streaming flow. <c>input_tokens</c> (and the model
+    /// id) ride the <c>message_start</c> event; the authoritative cumulative <c>output_tokens</c>
+    /// rides <c>message_delta</c>. Reads defensively from the raw JSON (M.E.AI's update surface does
+    /// not expose Anthropic usage) and leaves the running totals untouched for any other event.
+    /// </summary>
+    private static void HarvestStreamUsage(ChatResponseUpdate update, ref StreamUsage usage)
+    {
+        if (update.RawRepresentation is not RawMessageStreamEvent raw || raw.Json.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        // message_start: { "message": { "model": ..., "usage": { "input_tokens": .. } } }
+        if (raw.Json.TryGetProperty("message", out var message) && message.ValueKind == JsonValueKind.Object)
+        {
+            if (message.TryGetProperty("model", out var model) && model.ValueKind == JsonValueKind.String)
+            {
+                usage.Model = model.GetString();
+            }
+
+            if (message.TryGetProperty("usage", out var startUsage) && startUsage.ValueKind == JsonValueKind.Object
+                && startUsage.TryGetProperty("input_tokens", out var input) && input.TryGetInt64(out var inputTokens))
+            {
+                usage.InputTokens = inputTokens;
+            }
+        }
+
+        // message_delta: { "usage": { "output_tokens": .. } } — cumulative; last write wins.
+        if (raw.Json.TryGetProperty("usage", out var deltaUsage) && deltaUsage.ValueKind == JsonValueKind.Object
+            && deltaUsage.TryGetProperty("output_tokens", out var output) && output.TryGetInt64(out var outputTokens))
+        {
+            usage.OutputTokens = outputTokens;
+        }
+    }
+
+    /// <summary>
     /// Raises the errored-turn signal (<see cref="IncompleteCoachingLlmException"/>) when a stream
     /// ended cleanly on an incomplete stop reason. <c>max_tokens</c> is retryable (a fresh turn may
     /// fit); context overflow and a refusal are not (re-sending the same input fails the same way).
@@ -537,10 +574,7 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
             return;
         }
 
-        throw new IncompleteCoachingLlmException(
-            IncompleteMessage,
-            incompleteReason,
-            retryable: incompleteReason == IncompleteReason.MaxTokens);
+        throw new IncompleteCoachingLlmException(IncompleteMessage, incompleteReason);
     }
 
     /// <summary>
@@ -663,6 +697,9 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
                 .GetAsyncEnumerator(ct);
 
             string? terminalStopReason = null;
+            var usage = default(StreamUsage);
+            var scrubber = new StreamingTrademarkScrubber();
+            var responseLength = 0;
 
             while (true)
             {
@@ -688,21 +725,47 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
                     throw TranslateAnthropicFailure(ex);
                 }
 
+                HarvestStreamUsage(update, ref usage);
+
                 // The terminal stop reason rides the message_delta update (and may repeat on
                 // trailing updates — last-write-wins keeps that idempotent). Captured here, acted
                 // on after the stream ends cleanly.
-                var stopReason = TryGetTerminalStopReason(update);
-                if (stopReason is not null)
-                {
-                    terminalStopReason = stopReason;
-                }
+                terminalStopReason = TryGetTerminalStopReason(update) ?? terminalStopReason;
 
-                var delta = update.Text;
-                if (!string.IsNullOrEmpty(delta))
+                // Scrub the trademarked pace-index term before any chunk reaches the consumer, the
+                // same boundary GenerateAsync enforces on complete responses. The scrubber holds
+                // back only a trailing run that could still complete into the term across deltas, so
+                // a clean stream keeps its natural chunking.
+                var safe = scrubber.Push(update.Text);
+                if (safe.Length > 0)
                 {
-                    yield return delta;
+                    responseLength += safe.Length;
+                    yield return safe;
                 }
             }
+
+            var tail = scrubber.Flush();
+            if (tail.Length > 0)
+            {
+                responseLength += tail.Length;
+                yield return tail;
+            }
+
+            if (scrubber.Occurrences > 0)
+            {
+                LogScrubbedTrademarkedTerm(_logger, scrubber.Occurrences, "stream");
+            }
+
+            // Mirror the non-streaming cost-tracking invariant: log model, response length, stop
+            // reason, and token counts once the stream ends — before the errored-turn check so the
+            // telemetry is captured even on an incomplete finish.
+            LogReceivedResponse(
+                _logger,
+                usage.Model ?? _settings.ModelId,
+                responseLength,
+                terminalStopReason ?? "unknown",
+                usage.InputTokens,
+                usage.OutputTokens);
 
             // A clean enumeration end on an incomplete stop reason (truncation, context overflow,
             // or a refusal) is the errored-turn signal: the partial just yielded is unusable as a
@@ -747,5 +810,17 @@ public sealed partial class ClaudeCoachingLlm : ICoachingLlm, IDisposable
                 throw TranslateAnthropicFailure(ex);
             }
         }
+    }
+
+    /// <summary>
+    /// Mutable accumulator for token-usage telemetry harvested across stream events
+    /// (see <see cref="HarvestStreamUsage"/>). Nested because it is a private implementation
+    /// detail of the streaming path with no meaning outside it.
+    /// </summary>
+    private struct StreamUsage
+    {
+        public string? Model;
+        public long InputTokens;
+        public long OutputTokens;
     }
 }

--- a/backend/src/RunCoach.Api/Modules/Coaching/CoachingLlmException.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/CoachingLlmException.cs
@@ -4,8 +4,12 @@ namespace RunCoach.Api.Modules.Coaching;
 /// Base type for the only exceptions <see cref="ICoachingLlm"/> surfaces to callers under
 /// DEC-073 (first live in Slice 3). The adapter translates every Anthropic SDK failure — and
 /// every post-response failure (per-attempt timeout, <c>max_tokens</c> truncation, malformed
-/// structured output) — into one of the two concrete subtypes so callers never take a dependency
-/// on SDK exception types and can branch on retryability alone.
+/// structured output) — into one of the concrete subtypes so callers never take a dependency
+/// on SDK exception types and can branch on retryability alone:
+/// <see cref="TransientCoachingLlmException"/> (retry the call) and
+/// <see cref="PermanentCoachingLlmException"/> (do not), plus
+/// <see cref="IncompleteCoachingLlmException"/> on the streaming path (the call succeeded but the
+/// turn ended without a usable, complete reply).
 /// </summary>
 public abstract class CoachingLlmException : Exception
 {

--- a/backend/src/RunCoach.Api/Modules/Coaching/ICoachingLlm.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/ICoachingLlm.cs
@@ -79,8 +79,8 @@ public interface ICoachingLlm
         CancellationToken ct);
 
     /// <summary>
-    /// Streams the LLM's free-text reply token-by-token for the interactive
-    /// coaching conversation (Slice 4B). Yields each text delta as it arrives.
+    /// Streams the LLM's free-text reply as text deltas for interactive
+    /// coaching conversations. Yields each text delta as it arrives.
     /// </summary>
     /// <remarks>
     /// Totality contract (DEC-073, extended for streaming): the only exceptions

--- a/backend/src/RunCoach.Api/Modules/Coaching/ICoachingLlm.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/ICoachingLlm.cs
@@ -77,4 +77,30 @@ public interface ICoachingLlm
         IReadOnlyDictionary<string, JsonElement>? schema,
         CacheControl? cacheControl,
         CancellationToken ct);
+
+    /// <summary>
+    /// Streams the LLM's free-text reply token-by-token for the interactive
+    /// coaching conversation (Slice 4B). Yields each text delta as it arrives.
+    /// </summary>
+    /// <remarks>
+    /// Totality contract (DEC-073, extended for streaming): the only exceptions
+    /// that escape this method are
+    /// <see cref="TransientCoachingLlmException"/> /
+    /// <see cref="PermanentCoachingLlmException"/> (the call failed — retryable
+    /// or not), <see cref="IncompleteCoachingLlmException"/> (the stream ended
+    /// without a usable, complete reply — <c>max_tokens</c> truncation, context
+    /// overflow, or a model refusal; the caller must discard the partial and
+    /// persist an errored marker, never a complete turn), and an unwrapped
+    /// <see cref="OperationCanceledException"/> when the caller's own token is
+    /// cancelled (a client abort — <em>not</em> a service fault). A clean
+    /// completion simply ends the enumeration after the final delta.
+    /// </remarks>
+    /// <param name="systemPrompt">The coaching system prompt.</param>
+    /// <param name="userMessage">The assembled conversation user message.</param>
+    /// <param name="ct">Cancellation token (propagate the request-aborted token).</param>
+    /// <returns>An async stream of text deltas in arrival order.</returns>
+    IAsyncEnumerable<string> StreamAsync(
+        string systemPrompt,
+        string userMessage,
+        CancellationToken ct);
 }

--- a/backend/src/RunCoach.Api/Modules/Coaching/IncompleteCoachingLlmException.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/IncompleteCoachingLlmException.cs
@@ -1,0 +1,44 @@
+namespace RunCoach.Api.Modules.Coaching;
+
+/// <summary>
+/// Thrown by <see cref="ICoachingLlm.StreamAsync"/> when a stream ends without a
+/// usable, complete reply (R-084 errored-turn path): the output was truncated at
+/// <c>max_tokens</c>, the context window was exceeded, or the model refused. The
+/// SDK reports these as a clean enumeration end (not an exception), so the adapter
+/// detects the terminal finish reason and raises this type explicitly.
+///
+/// It is deliberately distinct from
+/// <see cref="TransientCoachingLlmException"/> / <see cref="PermanentCoachingLlmException"/>,
+/// which answer "should the caller retry the call?" — this answers "this turn's
+/// content is unusable: discard the partial and persist an errored marker, never a
+/// complete turn." <see cref="Retryable"/> reflects whether re-sending the turn (with
+/// a fresh idempotency GUID) could plausibly succeed: <see langword="true"/> for
+/// <see cref="IncompleteReason.MaxTokens"/>; <see langword="false"/> for context
+/// overflow or a refusal (re-sending the same input fails the same way).
+/// </summary>
+public sealed class IncompleteCoachingLlmException : CoachingLlmException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IncompleteCoachingLlmException"/> class.
+    /// </summary>
+    /// <param name="message">A user-safe description of the incomplete reply.</param>
+    /// <param name="reason">Why the reply did not complete normally.</param>
+    /// <param name="retryable">Whether re-sending the turn could plausibly succeed.</param>
+    /// <param name="innerException">The optional underlying cause (usually none — the SDK ends cleanly).</param>
+    public IncompleteCoachingLlmException(
+        string message,
+        IncompleteReason reason,
+        bool retryable,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        Reason = reason;
+        Retryable = retryable;
+    }
+
+    /// <summary>Gets the reason the reply did not complete normally.</summary>
+    public IncompleteReason Reason { get; }
+
+    /// <summary>Gets a value indicating whether re-sending the turn could plausibly succeed.</summary>
+    public bool Retryable { get; }
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/IncompleteCoachingLlmException.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/IncompleteCoachingLlmException.cs
@@ -23,17 +23,20 @@ public sealed class IncompleteCoachingLlmException : CoachingLlmException
     /// </summary>
     /// <param name="message">A user-safe description of the incomplete reply.</param>
     /// <param name="reason">Why the reply did not complete normally.</param>
-    /// <param name="retryable">Whether re-sending the turn could plausibly succeed.</param>
     /// <param name="innerException">The optional underlying cause (usually none — the SDK ends cleanly).</param>
     public IncompleteCoachingLlmException(
         string message,
         IncompleteReason reason,
-        bool retryable,
         Exception? innerException = null)
         : base(message, innerException)
     {
         Reason = reason;
-        Retryable = retryable;
+
+        // Retryability is a function of the reason, not an independent caller choice — only a
+        // max_tokens truncation can plausibly succeed on a fresh turn; context overflow and a
+        // refusal fail the same way on re-send. Deriving it here makes the documented invariant
+        // unbreakable at construction.
+        Retryable = reason == IncompleteReason.MaxTokens;
     }
 
     /// <summary>Gets the reason the reply did not complete normally.</summary>

--- a/backend/src/RunCoach.Api/Modules/Coaching/IncompleteReason.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/IncompleteReason.cs
@@ -2,7 +2,7 @@ namespace RunCoach.Api.Modules.Coaching;
 
 /// <summary>
 /// Why a streamed coaching reply ended without a usable, complete turn
-/// (Slice 4B / R-084). The SDK reports each of these as a clean enumeration end
+/// (R-084). The SDK reports each of these as a clean enumeration end
 /// rather than an exception, so <see cref="ICoachingLlm.StreamAsync"/> detects the
 /// terminal finish reason and raises <see cref="IncompleteCoachingLlmException"/>.
 /// Explicitly numbered for stable wire/telemetry encoding.

--- a/backend/src/RunCoach.Api/Modules/Coaching/IncompleteReason.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/IncompleteReason.cs
@@ -1,0 +1,20 @@
+namespace RunCoach.Api.Modules.Coaching;
+
+/// <summary>
+/// Why a streamed coaching reply ended without a usable, complete turn
+/// (Slice 4B / R-084). The SDK reports each of these as a clean enumeration end
+/// rather than an exception, so <see cref="ICoachingLlm.StreamAsync"/> detects the
+/// terminal finish reason and raises <see cref="IncompleteCoachingLlmException"/>.
+/// Explicitly numbered for stable wire/telemetry encoding.
+/// </summary>
+public enum IncompleteReason
+{
+    /// <summary>The reply hit the output token cap (<c>stop_reason=max_tokens</c>) and is truncated.</summary>
+    MaxTokens = 0,
+
+    /// <summary>The conversation exceeded the model context window (<c>model_context_window_exceeded</c>).</summary>
+    ContextWindowExceeded = 1,
+
+    /// <summary>The model declined to answer (<c>stop_reason=refusal</c>).</summary>
+    Refusal = 2,
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/StreamingTrademarkScrubber.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/StreamingTrademarkScrubber.cs
@@ -1,0 +1,108 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace RunCoach.Api.Modules.Coaching;
+
+/// <summary>
+/// Streaming-aware companion to <see cref="TrademarkScrubber"/> that guarantees the trademarked
+/// pace-index term never reaches a consumer even when it is split across stream deltas. A naive
+/// per-delta <see cref="TrademarkScrubber.Scrub(string, out int)"/> would miss a term whose
+/// characters straddle a delta boundary (e.g. <c>"…V"</c> then <c>"DOT…"</c>), so this buffer
+/// holds back only the trailing run that could still grow into a match, scrubs everything safe to
+/// emit, and flushes the remainder when the stream ends.
+/// </summary>
+/// <remarks>
+/// The held-back tail is computed precisely: it is the longest word-bounded suffix that is a viable
+/// prefix of the term pattern (<c>V[.-]?DOTs?</c>). A delta that does not end on such a prefix —
+/// the overwhelmingly common case — is emitted whole, so clean streams keep their natural delta
+/// chunking and incur no added latency. Not thread-safe: drive it from a single enumeration.
+/// </remarks>
+internal sealed partial class StreamingTrademarkScrubber
+{
+    /// <summary>Longest scrubbable token is <c>V.DOTs</c> (6 chars); never hold back more.</summary>
+    private const int MaxTermLength = 6;
+
+    private readonly StringBuilder _pending = new();
+
+    /// <summary>Gets the running count of trademarked occurrences scrubbed so far.</summary>
+    public int Occurrences { get; private set; }
+
+    /// <summary>
+    /// Appends a delta and returns the scrubbed text that is now safe to emit, retaining any
+    /// trailing run that could still complete into a match on a later delta. Returns
+    /// <see cref="string.Empty"/> when nothing is safe to emit yet.
+    /// </summary>
+    public string Push(string? delta)
+    {
+        if (!string.IsNullOrEmpty(delta))
+        {
+            _pending.Append(delta);
+        }
+
+        var hold = ComputePotentialMatchTail();
+        var emitLength = _pending.Length - hold;
+        if (emitLength <= 0)
+        {
+            return string.Empty;
+        }
+
+        var emit = _pending.ToString(0, emitLength);
+        _pending.Remove(0, emitLength);
+        return ScrubAndCount(emit);
+    }
+
+    /// <summary>
+    /// Scrubs and returns whatever remains buffered, clearing the buffer. Call once the stream has
+    /// ended cleanly so the final partial cannot hide a complete term.
+    /// </summary>
+    public string Flush()
+    {
+        if (_pending.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var remainder = _pending.ToString();
+        _pending.Clear();
+        return ScrubAndCount(remainder);
+    }
+
+    private static bool IsWordChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+
+    [GeneratedRegex(@"^[vV][.-]?[dD]?[oO]?[tT]?[sS]?$", RegexOptions.CultureInvariant)]
+    private static partial Regex ViableTermPrefix();
+
+    private string ScrubAndCount(string text)
+    {
+        var scrubbed = TrademarkScrubber.Scrub(text, out var hits);
+        Occurrences += hits;
+        return scrubbed;
+    }
+
+    /// <summary>
+    /// Returns the number of trailing characters that form a word-bounded, viable prefix of the
+    /// term pattern (and so must be held back), or 0 when the buffer cannot end mid-term.
+    /// </summary>
+    private int ComputePotentialMatchTail()
+    {
+        var n = _pending.Length;
+        var max = Math.Min(MaxTermLength, n);
+        for (var k = max; k >= 1; k--)
+        {
+            // The leading boundary must hold: the char before the candidate run must be absent or a
+            // non-word char, else `\bV` could never match here and the run is safe to emit.
+            var boundaryIndex = n - k - 1;
+            if (boundaryIndex >= 0 && IsWordChar(_pending[boundaryIndex]))
+            {
+                continue;
+            }
+
+            if (ViableTermPrefix().IsMatch(_pending.ToString(n - k, k)))
+            {
+                return k;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Infrastructure/StubCoachingLlm.cs
+++ b/backend/tests/RunCoach.Api.Tests/Infrastructure/StubCoachingLlm.cs
@@ -84,8 +84,8 @@ public sealed class StubCoachingLlm : ICoachingLlm
     public IAsyncEnumerable<string> StreamAsync(string systemPrompt, string userMessage, CancellationToken ct) =>
         throw new InvalidOperationException(
             "StubCoachingLlm.StreamAsync was called: no integration-tier flow scripts streaming "
-            + "generation yet. Streaming unit coverage lives in ClaudeCoachingLlmStreamingTests; "
-            + "end-to-end conversation coverage lands with the Slice 4B SSE endpoint.");
+            + "generation. Streaming coverage lives in the ClaudeCoachingLlm streaming tests; add a "
+            + "dedicated streaming test seam if an integration flow needs it.");
 
     /// <inheritdoc />
     public Task<(T Result, AnthropicUsage Usage)> GenerateStructuredAsync<T>(

--- a/backend/tests/RunCoach.Api.Tests/Infrastructure/StubCoachingLlm.cs
+++ b/backend/tests/RunCoach.Api.Tests/Infrastructure/StubCoachingLlm.cs
@@ -81,6 +81,13 @@ public sealed class StubCoachingLlm : ICoachingLlm
             + "generation. Script the structured surface instead, or move the coverage to the eval tier.");
 
     /// <inheritdoc />
+    public IAsyncEnumerable<string> StreamAsync(string systemPrompt, string userMessage, CancellationToken ct) =>
+        throw new InvalidOperationException(
+            "StubCoachingLlm.StreamAsync was called: no integration-tier flow scripts streaming "
+            + "generation yet. Streaming unit coverage lives in ClaudeCoachingLlmStreamingTests; "
+            + "end-to-end conversation coverage lands with the Slice 4B SSE endpoint.");
+
+    /// <inheritdoc />
     public Task<(T Result, AnthropicUsage Usage)> GenerateStructuredAsync<T>(
         string systemPrompt,
         string userMessage,

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ClaudeCoachingLlmStreamingTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ClaudeCoachingLlmStreamingTests.cs
@@ -46,6 +46,23 @@ public sealed class ClaudeCoachingLlmStreamingTests
         deltas.Should().Equal("Easy ", "does ", "it.");
     }
 
+    [Theory]
+    [InlineData("  ", "user")]
+    [InlineData("system", "  ")]
+    public void StreamAsync_BlankArgument_ThrowsEagerlyAtCallSite(string systemPrompt, string userMessage)
+    {
+        // The argument guards must run at call time — like the other (async Task) ICoachingLlm
+        // methods — not be deferred to the first MoveNextAsync of the returned enumerable. A caller
+        // that constructs the stream and enumerates later must still see the validation immediately.
+        using var llm = BuildStreamingLlm(_ => ToAsyncStream(TextDelta("ignored")));
+
+        // Act — calling the method (without enumerating) must throw.
+        var act = () => llm.StreamAsync(systemPrompt, userMessage, TestContext.Current.CancellationToken);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
     [Fact]
     public async Task StreamAsync_ClientAbort_PropagatesCancellationUnwrapped()
     {

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ClaudeCoachingLlmStreamingTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ClaudeCoachingLlmStreamingTests.cs
@@ -1,0 +1,108 @@
+using Anthropic;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using RunCoach.Api.Modules.Coaching;
+
+namespace RunCoach.Api.Tests.Modules.Coaching;
+
+/// <summary>
+/// Slice 4B Unit 1: <see cref="ClaudeCoachingLlm.StreamAsync"/> streams free-text
+/// deltas and translates the Anthropic SDK streaming failure surface (R-084) into
+/// the DEC-073 totality contract — only
+/// <see cref="TransientCoachingLlmException"/> /
+/// <see cref="PermanentCoachingLlmException"/> /
+/// <see cref="IncompleteCoachingLlmException"/> escape, with a client abort
+/// (<see cref="OperationCanceledException"/>) propagating unwrapped as not-an-error.
+/// These unit tests drive a controllable stub <see cref="IChatClient"/> injected
+/// through the streaming-client factory seam; the SSE wire behavior (whether
+/// <c>AnthropicSseException</c> exposes the structured error type) is pinned by the
+/// companion integration test through the real SDK.
+/// </summary>
+public sealed class ClaudeCoachingLlmStreamingTests
+{
+    private static readonly CoachingLlmSettings Settings = new()
+    {
+        ApiKey = "test-key",
+        ModelId = "claude-sonnet-4-6",
+        MaxTokens = 1024,
+    };
+
+    [Fact]
+    public async Task StreamAsync_YieldsEachTextDeltaInArrivalOrder()
+    {
+        // Arrange — a clean stream of three text deltas.
+        using var llm = BuildStreamingLlm(_ => ToAsyncStream(
+            TextDelta("Easy "),
+            TextDelta("does "),
+            TextDelta("it.")));
+
+        // Act
+        var deltas = await CollectAsync(llm);
+
+        // Assert
+        deltas.Should().Equal("Easy ", "does ", "it.");
+    }
+
+    private static async Task<List<string>> CollectAsync(ClaudeCoachingLlm llm)
+    {
+        var deltas = new List<string>();
+        await foreach (var delta in llm.StreamAsync("system", "user", TestContext.Current.CancellationToken))
+        {
+            deltas.Add(delta);
+        }
+
+        return deltas;
+    }
+
+    private static ChatResponseUpdate TextDelta(string text) => new(ChatRole.Assistant, text);
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> ToAsyncStream(params ChatResponseUpdate[] updates)
+    {
+        foreach (var update in updates)
+        {
+            await Task.Yield();
+            yield return update;
+        }
+    }
+
+    /// <summary>
+    /// Builds an adapter whose streaming path is fed by the supplied stub stream.
+    /// The substitute <see cref="IAnthropicClient"/> only satisfies the constructor;
+    /// the injected factory short-circuits <see cref="ClaudeCoachingLlm.AsIChatClient"/>
+    /// so no live transport is touched.
+    /// </summary>
+    private static ClaudeCoachingLlm BuildStreamingLlm(
+        Func<CancellationToken, IAsyncEnumerable<ChatResponseUpdate>> stream)
+    {
+        var anthropic = Substitute.For<IAnthropicClient>();
+        return new ClaudeCoachingLlm(
+            anthropic,
+            Settings,
+            NullLogger<ClaudeCoachingLlm>.Instance,
+            () => new StubStreamingChatClient(stream));
+    }
+
+    private sealed class StubStreamingChatClient(
+        Func<CancellationToken, IAsyncEnumerable<ChatResponseUpdate>> stream) : IChatClient
+    {
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => stream(cancellationToken);
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Streaming tests use GetStreamingResponseAsync only.");
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ClaudeCoachingLlmStreamingTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ClaudeCoachingLlmStreamingTests.cs
@@ -1,4 +1,5 @@
 using Anthropic;
+using Anthropic.Exceptions;
 using FluentAssertions;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -45,6 +46,73 @@ public sealed class ClaudeCoachingLlmStreamingTests
         deltas.Should().Equal("Easy ", "does ", "it.");
     }
 
+    [Fact]
+    public async Task StreamAsync_ClientAbort_PropagatesCancellationUnwrapped()
+    {
+        // Arrange — the caller's token is cancelled and the stream surfaces an OperationCanceledException
+        // (the RequestAborted shape). A genuine client abort is not-an-error: it must propagate
+        // unwrapped, never reclassified into a Transient/Permanent service fault.
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        using var llm = BuildStreamingLlm(_ => ThrowingStream(new OperationCanceledException(cts.Token)));
+
+        // Act
+        var act = async () =>
+        {
+            await foreach (var delta in llm.StreamAsync("system", "user", cts.Token))
+            {
+                _ = delta;
+            }
+        };
+
+        // Assert
+        var thrown = await act.Should().ThrowAsync<OperationCanceledException>();
+        thrown.Which.Should().NotBeAssignableTo<CoachingLlmException>();
+    }
+
+    [Fact]
+    public async Task StreamAsync_SdkPerAttemptTimeout_TranslatesToTransient()
+    {
+        // Arrange — an OperationCanceledException arrives while the caller's token is NOT cancelled:
+        // the SDK's per-attempt timeout fired. That is a transient service failure, not a user abort.
+        using var llm = BuildStreamingLlm(_ => ThrowingStream(new OperationCanceledException()));
+
+        // Act
+        var act = async () => await CollectAsync(llm);
+
+        // Assert
+        await act.Should().ThrowAsync<TransientCoachingLlmException>();
+    }
+
+    [Fact]
+    public async Task StreamAsync_TransportIOException_TranslatesToTransient()
+    {
+        // Arrange — a transport drop mid-stream (no Retry-After header to read).
+        using var llm = BuildStreamingLlm(_ => ThrowingStream(
+            new AnthropicIOException("connection reset", new HttpRequestException())));
+
+        // Act
+        var act = async () => await CollectAsync(llm);
+
+        // Assert
+        await act.Should().ThrowAsync<TransientCoachingLlmException>();
+    }
+
+    [Fact]
+    public async Task StreamAsync_UnmodeledAnthropicException_TranslatesToPermanent()
+    {
+        // Arrange — any Anthropic SDK exception outside the modeled cases is terminal; the totality
+        // contract still holds (only CoachingLlmException subtypes escape StreamAsync).
+        using var llm = BuildStreamingLlm(_ => ThrowingStream(
+            new AnthropicException("unmodeled", new InvalidOperationException())));
+
+        // Act
+        var act = async () => await CollectAsync(llm);
+
+        // Assert
+        await act.Should().ThrowAsync<PermanentCoachingLlmException>();
+    }
+
     private static async Task<List<string>> CollectAsync(ClaudeCoachingLlm llm)
     {
         var deltas = new List<string>();
@@ -54,6 +122,24 @@ public sealed class ClaudeCoachingLlmStreamingTests
         }
 
         return deltas;
+    }
+
+    /// <summary>
+    /// A stub stream that yields the supplied updates (if any) and then throws — exercising the
+    /// translator's mid-enumeration catch.
+    /// </summary>
+    private static async IAsyncEnumerable<ChatResponseUpdate> ThrowingStream(
+        Exception toThrow,
+        params ChatResponseUpdate[] before)
+    {
+        foreach (var update in before)
+        {
+            await Task.Yield();
+            yield return update;
+        }
+
+        await Task.Yield();
+        throw toThrow;
     }
 
     private static ChatResponseUpdate TextDelta(string text) => new(ChatRole.Assistant, text);

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ClaudeCoachingLlmStreamingTransportTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ClaudeCoachingLlmStreamingTransportTests.cs
@@ -31,10 +31,11 @@ public sealed class ClaudeCoachingLlmStreamingTransportTests
         MaxTokens = 1024,
     };
 
-    // R-084 mid-stream SSE error-type → DEC-073 classification. The SDK reports a post-200 error
-    // as AnthropicSseException whose message carries the structured error `type` verbatim; the
-    // adapter classifies on that token. Retryable service-side errors are Transient; client/auth
-    // errors are Permanent; an unknown type defaults to Transient (recall-over-precision).
+    // R-084 mid-stream SSE error type maps to the DEC-073 classification. The SDK reports a
+    // post-200 error as an AnthropicSseException carrying a strongly-typed error-type enum parsed
+    // from the SSE payload, and the adapter classifies on that enum rather than on message text.
+    // Retryable service-side errors are Transient, client/auth/not-found/billing errors are
+    // Permanent, and an unknown type defaults to Transient for recall over precision.
     [Theory]
     [InlineData("overloaded_error", true)]
     [InlineData("rate_limit_error", true)]
@@ -44,16 +45,20 @@ public sealed class ClaudeCoachingLlmStreamingTransportTests
     [InlineData("invalid_request_error", false)]
     [InlineData("authentication_error", false)]
     [InlineData("permission_error", false)]
+    [InlineData("not_found_error", false)]
+    [InlineData("billing_error", false)]
     public async Task StreamAsync_MidStreamError_ClassifiesByErrorType(string errorType, bool expectTransient)
     {
         // Arrange — a 200 that streams two text deltas then an `error` SSE event of the given type,
         // which the SDK rethrows mid-enumeration as AnthropicSseException.
         using var llm = BuildLlm(SseBuilder.WithMidStreamError(errorType));
 
-        // Act
-        var act = async () => await CollectAsync(llm);
+        // Act — capture deltas into an external sink so the partial survives the throw.
+        var deltas = new List<string>();
+        var act = () => DrainIntoAsync(llm, deltas);
 
-        // Assert — the SDK type never escapes; it maps to the DEC-073 Transient/Permanent type.
+        // Assert — the SDK type never escapes; it maps to the DEC-073 Transient/Permanent type, and
+        // the partial deltas reached the consumer (incremental yield-then-throw) before it.
         if (expectTransient)
         {
             await act.Should().ThrowAsync<TransientCoachingLlmException>();
@@ -62,6 +67,25 @@ public sealed class ClaudeCoachingLlmStreamingTransportTests
         {
             await act.Should().ThrowAsync<PermanentCoachingLlmException>();
         }
+
+        deltas.Should().Equal("Easy ", "does it.");
+    }
+
+    [Fact]
+    public async Task StreamAsync_MidStreamError_ClassifiesOnStructuredTypeNotMessageText()
+    {
+        // Arrange — a transient rate_limit_error whose server-controlled `message` text happens to
+        // contain the literal token "permission_error". Classification must key off the SDK's
+        // structured error type (RateLimitError -> Transient), not a naive full-message substring
+        // match that would see "permission_error" and wrongly mark it Permanent (non-retryable).
+        using var llm = BuildLlm(SseBuilder.WithMidStreamError(
+            "rate_limit_error", "slow down; this is not a permission_error situation"));
+
+        // Act
+        var act = async () => await CollectAsync(llm);
+
+        // Assert
+        await act.Should().ThrowAsync<TransientCoachingLlmException>();
     }
 
     [Theory]
@@ -94,14 +118,17 @@ public sealed class ClaudeCoachingLlmStreamingTransportTests
         // Arrange — a stream that delivers text then ends on an incomplete-finish stop reason.
         using var llm = BuildLlm(SseBuilder.WithStopReason(stopReason));
 
-        // Act
-        var act = async () => await CollectAsync(llm);
+        // Act — capture deltas into an external sink so the partial survives the throw.
+        var deltas = new List<string>();
+        var act = () => DrainIntoAsync(llm, deltas);
 
-        // Assert — the partial is unusable: an IncompleteCoachingLlmException carrying the precise
-        // reason and retryability, never a clean completion.
+        // Assert — the partial reached the consumer (so the caller can discard it per the contract),
+        // then an IncompleteCoachingLlmException carrying the precise reason and retryability, never
+        // a clean completion.
         var thrown = await act.Should().ThrowAsync<IncompleteCoachingLlmException>();
         thrown.Which.Reason.Should().Be(expectedReason);
         thrown.Which.Retryable.Should().Be(expectedRetryable);
+        deltas.Should().Equal("Easy ", "does it.");
     }
 
     // Pre-first-byte HTTP failures (the SDK throws an AnthropicApiException before any SSE byte) reuse
@@ -185,12 +212,21 @@ public sealed class ClaudeCoachingLlmStreamingTransportTests
     private static async Task<List<string>> CollectAsync(ClaudeCoachingLlm llm)
     {
         var deltas = new List<string>();
+        await DrainIntoAsync(llm, deltas);
+        return deltas;
+    }
+
+    /// <summary>
+    /// Enumerates the stream into an external <paramref name="sink"/> so that, when the stream
+    /// throws mid-enumeration, the partial deltas already delivered survive for assertion (proving
+    /// the incremental yield-then-throw property).
+    /// </summary>
+    private static async Task DrainIntoAsync(ClaudeCoachingLlm llm, List<string> sink)
+    {
         await foreach (var delta in llm.StreamAsync("system", "user", TestContext.Current.CancellationToken))
         {
-            deltas.Add(delta);
+            sink.Add(delta);
         }
-
-        return deltas;
     }
 
     /// <summary>
@@ -225,11 +261,11 @@ public sealed class ClaudeCoachingLlmStreamingTransportTests
             return sb.ToString();
         }
 
-        public static string WithMidStreamError(string errorType)
+        public static string WithMidStreamError(string errorType, string message = "simulated")
         {
             var sb = new StringBuilder();
             AppendPreamble(sb);
-            Event(sb, "error", "{\"type\":\"error\",\"error\":{\"type\":\"" + errorType + "\",\"message\":\"simulated\"}}");
+            Event(sb, "error", "{\"type\":\"error\",\"error\":{\"type\":\"" + errorType + "\",\"message\":\"" + message + "\"}}");
             return sb.ToString();
         }
 

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ClaudeCoachingLlmStreamingTransportTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ClaudeCoachingLlmStreamingTransportTests.cs
@@ -131,6 +131,30 @@ public sealed class ClaudeCoachingLlmStreamingTransportTests
         deltas.Should().Equal("Easy ", "does it.");
     }
 
+    // R-084 edge: an incomplete finish can carry zero text deltas (a max_tokens/refusal that emits
+    // no content before stopping). ThrowIfIncompleteFinish must still fire — a future refactor that
+    // gated the throw on "a delta was yielded" would pass every other test yet silently drop the
+    // errored-turn signal for an empty truncation. This pins that the signal is delta-independent.
+    [Theory]
+    [InlineData("max_tokens", IncompleteReason.MaxTokens, true)]
+    [InlineData("refusal", IncompleteReason.Refusal, false)]
+    public async Task StreamAsync_IncompleteFinishWithNoTextDeltas_StillRaisesIncomplete(
+        string stopReason, IncompleteReason expectedReason, bool expectedRetryable)
+    {
+        // Arrange — a stream that ends on an incomplete stop reason without emitting any text.
+        using var llm = BuildLlm(SseBuilder.WithStopReasonAndNoTextDeltas(stopReason));
+
+        // Act
+        var deltas = new List<string>();
+        var act = () => DrainIntoAsync(llm, deltas);
+
+        // Assert — no deltas reached the consumer, yet the errored-turn signal still surfaces.
+        var thrown = await act.Should().ThrowAsync<IncompleteCoachingLlmException>();
+        thrown.Which.Reason.Should().Be(expectedReason);
+        thrown.Which.Retryable.Should().Be(expectedRetryable);
+        deltas.Should().BeEmpty();
+    }
+
     // Pre-first-byte HTTP failures (the SDK throws an AnthropicApiException before any SSE byte) reuse
     // the request/response status classifier unchanged (R-084 carry-over): 408/409/429/5xx → Transient,
     // other 4xx → Permanent.
@@ -209,6 +233,25 @@ public sealed class ClaudeCoachingLlmStreamingTransportTests
         tags.Should().ContainKey("openinference.span.kind").WhoseValue.Should().Be("GUARDRAIL");
     }
 
+    // Trademark scrub parity with GenerateAsync (which scrubs complete responses): the streaming
+    // path must scrub the pace-index term before any chunk reaches the consumer, including when the
+    // term is split across deltas. The joined stream output must carry the approved vocabulary, not
+    // the trademarked term. This test spells the term to prove it is scrubbed (carve-out-exempt).
+    [Fact]
+    public async Task StreamAsync_ScrubsTrademarkedTerm_EvenWhenSplitAcrossDeltas()
+    {
+        // Arrange — "VDOT" straddles the delta boundary ("Your V" | "DOT is 38.").
+        using var llm = BuildLlm(SseBuilder.WithTextDeltas("Your V", "DOT is 38."));
+
+        // Act
+        var deltas = await CollectAsync(llm);
+
+        // Assert
+        var joined = string.Concat(deltas);
+        joined.Should().Be("Your pace-zone index is 38.");
+        joined.Should().NotContainEquivalentOf("vdot");
+    }
+
     private static async Task<List<string>> CollectAsync(ClaudeCoachingLlm llm)
     {
         var deltas = new List<string>();
@@ -257,6 +300,35 @@ public sealed class ClaudeCoachingLlmStreamingTransportTests
             AppendPreamble(sb);
             Event(sb, "content_block_stop", """{"type":"content_block_stop","index":0}""");
             Event(sb, "message_delta", "{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"" + stopReason + "\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":15}}");
+            Event(sb, "message_stop", """{"type":"message_stop"}""");
+            return sb.ToString();
+        }
+
+        public static string WithTextDeltas(params string[] textDeltas)
+        {
+            // A clean end_turn stream carrying the supplied raw text deltas verbatim, so a test can
+            // drive trademarked text through the real bridge and assert the adapter scrubs it.
+            var sb = new StringBuilder();
+            Event(sb, "message_start", """{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}""");
+            Event(sb, "content_block_start", """{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}""");
+            foreach (var text in textDeltas)
+            {
+                Event(sb, "content_block_delta", "{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"" + text + "\"}}");
+            }
+
+            Event(sb, "content_block_stop", """{"type":"content_block_stop","index":0}""");
+            Event(sb, "message_delta", """{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":15}}""");
+            Event(sb, "message_stop", """{"type":"message_stop"}""");
+            return sb.ToString();
+        }
+
+        public static string WithStopReasonAndNoTextDeltas(string stopReason)
+        {
+            // An incomplete finish that emits no text: message_start → message_delta(stop) →
+            // message_stop with no content_block events in between.
+            var sb = new StringBuilder();
+            Event(sb, "message_start", """{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}""");
+            Event(sb, "message_delta", "{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"" + stopReason + "\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":0}}");
             Event(sb, "message_stop", """{"type":"message_stop"}""");
             return sb.ToString();
         }

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ClaudeCoachingLlmStreamingTransportTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/ClaudeCoachingLlmStreamingTransportTests.cs
@@ -1,0 +1,277 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using RunCoach.Api.Modules.Coaching;
+using RunCoach.Api.Modules.Coaching.Sanitization;
+
+namespace RunCoach.Api.Tests.Modules.Coaching;
+
+/// <summary>
+/// Slice 4B Unit 1 (R-084): <see cref="ClaudeCoachingLlm.StreamAsync"/> driven through the
+/// <em>real</em> Anthropic SDK 12.29.1 + Microsoft.Extensions.AI streaming bridge over a stub
+/// HTTP transport that emits a hand-crafted <c>text/event-stream</c> body. This pins the wire
+/// truth the unit-level translator tests cannot: that a mid-stream <c>error</c> SSE event
+/// surfaces as <c>AnthropicSseException</c> whose message carries the structured error
+/// <c>type</c> (resolving R-084's lone open caveat), that <c>max_tokens</c> /
+/// <c>model_context_window_exceeded</c> / <c>refusal</c> end the enumeration <em>cleanly</em>
+/// and must be detected from the raw <c>stop_reason</c>, and that pre-first-byte HTTP failures
+/// reuse the request/response status classifier. The pipeline is built through
+/// <see cref="ClaudeCoachingLlm.CreateClientPipeline"/> — the production seam — with the default
+/// streaming factory, so the audit-wrapped bridge under test cannot drift from production.
+/// </summary>
+public sealed class ClaudeCoachingLlmStreamingTransportTests
+{
+    private static readonly CoachingLlmSettings Settings = new()
+    {
+        ApiKey = "test-key",
+        ModelId = "claude-sonnet-4-6",
+        MaxTokens = 1024,
+    };
+
+    // R-084 mid-stream SSE error-type → DEC-073 classification. The SDK reports a post-200 error
+    // as AnthropicSseException whose message carries the structured error `type` verbatim; the
+    // adapter classifies on that token. Retryable service-side errors are Transient; client/auth
+    // errors are Permanent; an unknown type defaults to Transient (recall-over-precision).
+    [Theory]
+    [InlineData("overloaded_error", true)]
+    [InlineData("rate_limit_error", true)]
+    [InlineData("api_error", true)]
+    [InlineData("timeout_error", true)]
+    [InlineData("some_unmapped_error", true)]
+    [InlineData("invalid_request_error", false)]
+    [InlineData("authentication_error", false)]
+    [InlineData("permission_error", false)]
+    public async Task StreamAsync_MidStreamError_ClassifiesByErrorType(string errorType, bool expectTransient)
+    {
+        // Arrange — a 200 that streams two text deltas then an `error` SSE event of the given type,
+        // which the SDK rethrows mid-enumeration as AnthropicSseException.
+        using var llm = BuildLlm(SseBuilder.WithMidStreamError(errorType));
+
+        // Act
+        var act = async () => await CollectAsync(llm);
+
+        // Assert — the SDK type never escapes; it maps to the DEC-073 Transient/Permanent type.
+        if (expectTransient)
+        {
+            await act.Should().ThrowAsync<TransientCoachingLlmException>();
+        }
+        else
+        {
+            await act.Should().ThrowAsync<PermanentCoachingLlmException>();
+        }
+    }
+
+    [Theory]
+    [InlineData("end_turn")]
+    [InlineData("stop_sequence")]
+    public async Task StreamAsync_CleanCompletion_YieldsFullTextAndDoesNotThrow(string stopReason)
+    {
+        // Arrange — a normal stream that ends on a clean stop reason.
+        using var llm = BuildLlm(SseBuilder.WithStopReason(stopReason));
+
+        // Act
+        var deltas = await CollectAsync(llm);
+
+        // Assert — every text delta is yielded in order; the enumeration ends without throwing.
+        deltas.Should().Equal("Easy ", "does it.");
+    }
+
+    // R-084: max_tokens / model_context_window_exceeded / refusal end the enumeration *cleanly*
+    // (no exception). A truncated free-text reply is incomplete, not unparseable, so the adapter
+    // detects the terminal stop_reason and raises the errored-turn signal. model_context_window_
+    // exceeded is the trap: the M.E.AI bridge maps it to ChatFinishReason.Stop (identical to a
+    // clean end_turn), so detection must read the raw Anthropic stop_reason, not the finish reason.
+    [Theory]
+    [InlineData("max_tokens", IncompleteReason.MaxTokens, true)]
+    [InlineData("model_context_window_exceeded", IncompleteReason.ContextWindowExceeded, false)]
+    [InlineData("refusal", IncompleteReason.Refusal, false)]
+    public async Task StreamAsync_IncompleteFinish_RaisesIncompleteWithReason(
+        string stopReason, IncompleteReason expectedReason, bool expectedRetryable)
+    {
+        // Arrange — a stream that delivers text then ends on an incomplete-finish stop reason.
+        using var llm = BuildLlm(SseBuilder.WithStopReason(stopReason));
+
+        // Act
+        var act = async () => await CollectAsync(llm);
+
+        // Assert — the partial is unusable: an IncompleteCoachingLlmException carrying the precise
+        // reason and retryability, never a clean completion.
+        var thrown = await act.Should().ThrowAsync<IncompleteCoachingLlmException>();
+        thrown.Which.Reason.Should().Be(expectedReason);
+        thrown.Which.Retryable.Should().Be(expectedRetryable);
+    }
+
+    // Pre-first-byte HTTP failures (the SDK throws an AnthropicApiException before any SSE byte) reuse
+    // the request/response status classifier unchanged (R-084 carry-over): 408/409/429/5xx → Transient,
+    // other 4xx → Permanent.
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest, false)]
+    [InlineData(HttpStatusCode.Unauthorized, false)]
+    [InlineData(HttpStatusCode.NotFound, false)]
+    [InlineData(HttpStatusCode.TooManyRequests, true)]
+    [InlineData(HttpStatusCode.ServiceUnavailable, true)]
+    [InlineData(HttpStatusCode.RequestTimeout, true)]
+    [InlineData(HttpStatusCode.Conflict, true)]
+    public async Task StreamAsync_PreFirstByteHttpError_ClassifiesByStatus(HttpStatusCode status, bool expectTransient)
+    {
+        // Arrange — a non-200 before any SSE event opens.
+        using var llm = BuildLlm(new StatusStubHttpMessageHandler(status));
+
+        // Act
+        var act = async () => await CollectAsync(llm);
+
+        // Assert
+        if (expectTransient)
+        {
+            await act.Should().ThrowAsync<TransientCoachingLlmException>();
+        }
+        else
+        {
+            await act.Should().ThrowAsync<PermanentCoachingLlmException>();
+        }
+    }
+
+    [Fact]
+    public async Task StreamAsync_PreFirstByte429_CapturesRetryAfterFromRawHeader()
+    {
+        // Arrange — a pre-stream 429 carrying Retry-After: 30. Before headers are flushed the owned
+        // pipeline can still read the raw header (the SDK exposes no accessor).
+        using var llm = BuildLlm(new StatusStubHttpMessageHandler(HttpStatusCode.TooManyRequests, retryAfterSeconds: 30));
+
+        // Act
+        var act = async () => await CollectAsync(llm);
+
+        // Assert
+        var thrown = await act.Should().ThrowAsync<TransientCoachingLlmException>();
+        thrown.Which.RetryAfterSeconds.Should().Be(30);
+    }
+
+    [Fact]
+    public async Task StreamAsync_RoutesThroughSanitizationAuditClient_OpeningOneGuardrailSpan()
+    {
+        // Arrange — the production streaming factory wraps the M.E.AI bridge in
+        // SanitizationAuditChatClient, so a stream opens exactly one GUARDRAIL rollup span at the
+        // LLM-call boundary. Listening on the RunCoach.Llm source proves the production wiring.
+        var captured = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "RunCoach.Llm",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activity =>
+            {
+                lock (captured)
+                {
+                    captured.Add(activity);
+                }
+            },
+        };
+        ActivitySource.AddActivityListener(listener);
+        using var llm = BuildLlm(SseBuilder.WithStopReason("end_turn"));
+
+        // Act
+        var deltas = await CollectAsync(llm);
+
+        // Assert
+        deltas.Should().Equal("Easy ", "does it.");
+        var auditSpans = captured.Where(a => a.OperationName == SanitizationAuditChatClient.AuditSpanName).ToList();
+        auditSpans.Should().ContainSingle("the production streaming factory wraps the bridge in the audit client");
+        var tags = auditSpans[0].TagObjects.ToDictionary(kv => kv.Key, kv => kv.Value);
+        tags.Should().ContainKey("openinference.span.kind").WhoseValue.Should().Be("GUARDRAIL");
+    }
+
+    private static async Task<List<string>> CollectAsync(ClaudeCoachingLlm llm)
+    {
+        var deltas = new List<string>();
+        await foreach (var delta in llm.StreamAsync("system", "user", TestContext.Current.CancellationToken))
+        {
+            deltas.Add(delta);
+        }
+
+        return deltas;
+    }
+
+    /// <summary>
+    /// Builds an adapter whose real SDK client talks to the supplied SSE transport, using the
+    /// production streaming factory (audit-wrapped M.E.AI bridge) so the path under test matches
+    /// production.
+    /// </summary>
+    private static ClaudeCoachingLlm BuildLlm(string sseBody) =>
+        BuildLlm(new SseStubHttpMessageHandler(sseBody));
+
+    private static ClaudeCoachingLlm BuildLlm(HttpMessageHandler transport)
+    {
+        var settings = Settings with { MaxRetries = 0 };
+        var (anthropic, _) = ClaudeCoachingLlm.CreateClientPipeline(settings, transport);
+        return new ClaudeCoachingLlm(anthropic, settings, NullLogger<ClaudeCoachingLlm>.Instance);
+    }
+
+    /// <summary>
+    /// Assembles minimal Anthropic Messages streaming bodies in the documented SSE event order
+    /// (<c>message_start</c> → <c>content_block_*</c> → <c>message_delta</c> → <c>message_stop</c>),
+    /// or a truncated stream ending in an <c>error</c> event.
+    /// </summary>
+    private static class SseBuilder
+    {
+        public static string WithStopReason(string stopReason)
+        {
+            var sb = new StringBuilder();
+            AppendPreamble(sb);
+            Event(sb, "content_block_stop", """{"type":"content_block_stop","index":0}""");
+            Event(sb, "message_delta", "{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"" + stopReason + "\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":15}}");
+            Event(sb, "message_stop", """{"type":"message_stop"}""");
+            return sb.ToString();
+        }
+
+        public static string WithMidStreamError(string errorType)
+        {
+            var sb = new StringBuilder();
+            AppendPreamble(sb);
+            Event(sb, "error", "{\"type\":\"error\",\"error\":{\"type\":\"" + errorType + "\",\"message\":\"simulated\"}}");
+            return sb.ToString();
+        }
+
+        private static void AppendPreamble(StringBuilder sb)
+        {
+            Event(sb, "message_start", """{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}""");
+            Event(sb, "content_block_start", """{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}""");
+            Event(sb, "content_block_delta", """{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Easy "}}""");
+            Event(sb, "content_block_delta", """{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"does it."}}""");
+        }
+
+        private static void Event(StringBuilder sb, string name, string data) =>
+            sb.Append("event: ").Append(name).Append('\n').Append("data: ").Append(data).Append("\n\n");
+    }
+
+    private sealed class SseStubHttpMessageHandler(string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "text/event-stream"),
+            });
+    }
+
+    private sealed class StatusStubHttpMessageHandler(HttpStatusCode status, int? retryAfterSeconds = null) : HttpMessageHandler
+    {
+        private const string ErrorBody =
+            "{\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"simulated\"}}";
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(status)
+            {
+                Content = new StringContent(ErrorBody, Encoding.UTF8, "application/json"),
+            };
+
+            if (retryAfterSeconds is { } seconds)
+            {
+                response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(seconds));
+            }
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/StreamingTrademarkScrubberTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/StreamingTrademarkScrubberTests.cs
@@ -1,0 +1,121 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching;
+
+namespace RunCoach.Api.Tests.Modules.Coaching;
+
+/// <summary>
+/// Tests for <see cref="StreamingTrademarkScrubber"/> — the streaming-aware boundary guard that
+/// keeps the trademarked term "VDOT" out of streamed coaching deltas even when its characters are
+/// split across delta boundaries. This test file is carve-out-exempt from the repo-wide trademark
+/// scan (like <c>TrademarkScrubberTests</c>): it must spell the term out to prove it is scrubbed.
+/// </summary>
+public class StreamingTrademarkScrubberTests
+{
+    [Fact]
+    public void Push_CleanDeltas_PreserveNaturalChunkingWithNoHoldback()
+    {
+        // Arrange
+        var scrubber = new StreamingTrademarkScrubber();
+
+        // Act — neither delta ends on a viable term prefix, so each is emitted whole.
+        var first = scrubber.Push("Easy ");
+        var second = scrubber.Push("does it.");
+        var tail = scrubber.Flush();
+
+        // Assert
+        first.Should().Be("Easy ");
+        second.Should().Be("does it.");
+        tail.Should().BeEmpty();
+        scrubber.Occurrences.Should().Be(0);
+    }
+
+    [Fact]
+    public void Push_TermWithinASingleDelta_IsScrubbed()
+    {
+        // Arrange
+        var scrubber = new StreamingTrademarkScrubber();
+
+        // Act
+        var emitted = scrubber.Push("Your VDOT is 38. ") + scrubber.Flush();
+
+        // Assert
+        emitted.Should().Be("Your pace-zone index is 38. ");
+        scrubber.Occurrences.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("Your V", "DOT is 38.")]
+    [InlineData("Your VD", "OT is 38.")]
+    [InlineData("Your VDO", "T is 38.")]
+    [InlineData("Your V.", "DOT is 38.")]
+    public void Push_TermSplitAcrossDeltas_IsScrubbed(string first, string second)
+    {
+        // Arrange
+        var scrubber = new StreamingTrademarkScrubber();
+
+        // Act — the term straddles the delta boundary; the held-back tail keeps the partial buffered
+        // until the rest arrives, then the whole term is scrubbed.
+        var output = scrubber.Push(first) + scrubber.Push(second) + scrubber.Flush();
+
+        // Assert
+        output.Should().Be("Your pace-zone index is 38.");
+        scrubber.Occurrences.Should().Be(1);
+    }
+
+    [Fact]
+    public void Push_TermAsTheVeryLastChunk_IsScrubbedOnFlush()
+    {
+        // Arrange
+        var scrubber = new StreamingTrademarkScrubber();
+
+        // Act — the term arrives at the end with no trailing text; only Flush can confirm the
+        // trailing word boundary and emit the scrubbed replacement.
+        var output = scrubber.Push("Your zone is V") + scrubber.Push("DOT") + scrubber.Flush();
+
+        // Assert
+        output.Should().Be("Your zone is pace-zone index");
+        scrubber.Occurrences.Should().Be(1);
+    }
+
+    [Fact]
+    public void Push_WordStartingWithVButNotTheTerm_IsNotHeldBack()
+    {
+        // Arrange
+        var scrubber = new StreamingTrademarkScrubber();
+
+        // Act — "Very" ends in a non-viable prefix, so nothing is held back or scrubbed.
+        var output = scrubber.Push("Run Very") + scrubber.Flush();
+
+        // Assert
+        output.Should().Be("Run Very");
+        scrubber.Occurrences.Should().Be(0);
+    }
+
+    [Fact]
+    public void Push_VPrecededByWordChar_DoesNotTriggerHoldback()
+    {
+        // Arrange — a leading word char means `\bV` can never match, so "...aV" is emitted, not held.
+        var scrubber = new StreamingTrademarkScrubber();
+
+        // Act
+        var first = scrubber.Push("HRVaV");
+        var rest = scrubber.Flush();
+
+        // Assert
+        first.Should().Be("HRVaV");
+        rest.Should().BeEmpty();
+        scrubber.Occurrences.Should().Be(0);
+    }
+
+    [Fact]
+    public void Flush_OnEmptyBuffer_ReturnsEmpty()
+    {
+        // Arrange
+        var scrubber = new StreamingTrademarkScrubber();
+
+        // Act & Assert
+        scrubber.Flush().Should().BeEmpty();
+        scrubber.Push(null).Should().BeEmpty();
+        scrubber.Push(string.Empty).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Slice 4B — PR1 (Unit 1): Streaming LLM adapter + DEC-073 stream-error translation

First piece of the streaming conversation core (DEC-085). Adds `ICoachingLlm.StreamAsync` — a net-new streaming method over the Anthropic 12.29.1 + Microsoft.Extensions.AI streaming bridge — and translates the streaming failure surface (R-084) into the DEC-073 totality contract. No orchestration consumes it yet (PR4 wires the SSE endpoint); this is the foundational adapter and lands behind an unreferenced method.

### What's in it
- **`ICoachingLlm.StreamAsync`** (`IAsyncEnumerable<string>` text deltas) + the net-new **`IncompleteCoachingLlmException`** / `IncompleteReason` errored-turn contract.
- **`ClaudeCoachingLlm.StreamAsync`** drives the bridge via a manual enumerator (`MoveNextAsync` in try/catch, `yield` outside), routed through `SanitizationAuditChatClient` for the GUARDRAIL span; argument validation is eager (split into a private `StreamCore` iterator, sonar S4456).
- **Totality contract** — only `Transient` / `Permanent` / `Incomplete` CoachingLlmException, plus an unwrapped `OperationCanceledException` on a genuine client abort, can escape:
  - mid-stream `AnthropicSseException` → classified on the SDK's **typed `ErrorType` enum** (rate-limit / overloaded / api / timeout / unknown → Transient; invalid-request / auth / permission / not-found / billing → Permanent);
  - pre-first-byte `AnthropicApiException` → the shared request/response status classifier (408/409/429/5xx → Transient, else Permanent), with the pre-stream 429 `Retry-After` captured via the owned pipeline;
  - `max_tokens` / `model_context_window_exceeded` / `refusal` end the stream **cleanly** → `IncompleteCoachingLlmException` with the right `Reason` + `Retryable`, detected from the raw `stop_reason` (the bridge maps context-window to `FinishReason.Stop`);
  - client abort propagates unwrapped (not-an-error); the SDK per-attempt timeout → Transient.
- **DRY:** `CreateMessageAsync` and `StreamAsync` now share one `TranslateAnthropicFailure` classifier.

### Verification
- R-084's open caveat resolved **empirically** against the real SDK (the inherited `AnthropicServiceException.ErrorType` accessor + the context-window→`Stop` mapping), not from docs.
- **TDD throughout:** stub-`IChatClient` translator unit tests + real-SDK-over-SSE-stub transport tests (mid-stream classification incl. message-text independence, incomplete finishes, pre-first-byte status + Retry-After, abort, eager arg validation, GUARDRAIL audit-span wiring).
- An adversarial multi-lens self-review (find → blind-challenge) ran on the diff; its 6 confirmed findings are all addressed in `342205f` (typed `ErrorType` classification, eager-validation split, `ValueKind` guard, partial-deltas-before-throw tests, AsyncLocal-scope clarification).
- **Full backend suite 1835/1835 green in Replay** (integration via Testcontainers).

Per the stacked-train plan this is a root PR (PR2 is the parallel root; PR4 is the integration gate that first wires `StreamAsync`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `StreamAsync` for coaching to stream text deltas as they arrive.
  * Introduced `IncompleteCoachingLlmException` and `IncompleteReason` to report when a stream ends without a usable complete reply.
* **Bug Fixes**
  * Improved streaming error handling with correct transient vs permanent classification, proper propagation of cancellation, and preservation of already-received deltas.
  * Enhanced trademark scrubbing to correctly redact terms even when split across streamed chunks.
* **Tests**
  * Added coverage for streaming yields, eager validation, cancellation behavior, transport/SSE failure classification, incomplete-stop handling, and scrub boundary edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->