### PR TITLE
feat(slice-4b): user-scoped conversation stream + composed timeline read (pr2)

### DIFF
--- a/backend/openapi/swagger.json
+++ b/backend/openapi/swagger.json
@@ -418,6 +418,61 @@
         ]
       }
     },
+    "/api/v1/conversation/timeline": {
+      "get": {
+        "tags": [
+          "Conversation"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationTimelineDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationTimelineDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationTimelineDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": [ ],
+            "bearerAuth": [ ]
+          }
+        ]
+      }
+    },
     "/api/v1/onboarding/turns": {
       "post": {
         "tags": [
@@ -1159,6 +1214,61 @@
         "type": "integer",
         "format": "int32"
       },
+      "ConversationTimelineDto": {
+        "required": [
+          "turns"
+        ],
+        "type": "object",
+        "properties": {
+          "turns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConversationTimelineTurnDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ConversationTimelineTurnDto": {
+        "required": [
+          "createdAt",
+          "interactive",
+          "kind",
+          "proactive",
+          "turnId"
+        ],
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/ConversationTimelineTurnKind"
+          },
+          "turnId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "interactive": {
+            "$ref": "#/components/schemas/InteractiveTurnDto"
+          },
+          "proactive": {
+            "$ref": "#/components/schemas/ConversationTurnDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ConversationTimelineTurnKind": {
+        "enum": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
       "ConversationTurnDto": {
         "required": [
           "adaptationKind",
@@ -1379,6 +1489,22 @@
           "Repetition"
         ],
         "type": "string"
+      },
+      "InteractiveTurnDto": {
+        "required": [
+          "content",
+          "isErrored"
+        ],
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "isErrored": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
       },
       "LoginRequestDto": {
         "required": [

--- a/backend/src/RunCoach.Api/Infrastructure/MartenConfiguration.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/MartenConfiguration.cs
@@ -73,6 +73,8 @@ public static class MartenConfiguration
         typeof(PlanAdaptedFromLog),
         typeof(SafetySignalRaised),
         typeof(ClientErrorReported),
+        typeof(UserMessagePosted),
+        typeof(CoachMessagePosted),
     ];
 
     /// <summary>
@@ -148,6 +150,14 @@ public static class MartenConfiguration
         // mutates — the explanation stays atomic with the plan change (DEC-060).
         opts.Schema.For<ConversationLogView>().Identity(x => x.PlanId);
         opts.Projections.Add(new ConversationProjection(), ProjectionLifecycle.Inline);
+
+        // Interactive conversation read-model (Slice 4B Unit 3, DEC-085) — a net-new
+        // inline single-stream projection over the user-scoped `Conversation` stream,
+        // keyed by user id so the conversation survives plan regeneration (the plan-
+        // scoped ConversationLogView above resets with each new plan). Identity comes
+        // from the `Id` property convention (set to UserId by the projection), like
+        // the OnboardingView — no explicit `Schema.For<ConversationView>().Identity`.
+        opts.Projections.Add(new InteractiveConversationProjection(), ProjectionLifecycle.Inline);
 
         // Per-plan adaptation signal state (Slice 3 Unit 5, DEC-078 resolution) —
         // a directly-stored document, not a projection: the evaluation handler

--- a/backend/src/RunCoach.Api/Infrastructure/MartenConfiguration.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/MartenConfiguration.cs
@@ -151,7 +151,7 @@ public static class MartenConfiguration
         opts.Schema.For<ConversationLogView>().Identity(x => x.PlanId);
         opts.Projections.Add(new ConversationProjection(), ProjectionLifecycle.Inline);
 
-        // Interactive conversation read-model (Slice 4B Unit 3, DEC-085) — a net-new
+        // Interactive conversation read-model (DEC-085) — a net-new
         // inline single-stream projection over the user-scoped `Conversation` stream,
         // keyed by user id so the conversation survives plan regeneration (the plan-
         // scoped ConversationLogView above resets with each new plan). Identity comes

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/CoachMessagePosted.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/CoachMessagePosted.cs
@@ -1,0 +1,34 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Event recorded when the coach's reply to an interactive turn completes (Slice 4B
+/// Unit 3, DEC-085). Appended to the user-scoped <c>Conversation</c> stream as the
+/// <b>second</b> of two separate idempotent writes — the user turn is durable first
+/// (<see cref="UserMessagePosted"/>), the coach turn appends only once the stream
+/// finishes. The co-transactional <c>IIdempotencyStore</c> + single-Wolverine-
+/// <c>SaveChanges</c> model cannot span a multi-second stream, so these are two
+/// writes, not one transaction.
+/// </summary>
+/// <param name="UserId">The runner's user id — also the <c>Conversation</c> stream id.</param>
+/// <param name="TurnId">
+/// The <b>server-derived</b> turn id, deterministic from the user turn's client
+/// message id (see <see cref="ConversationTurnId.DeriveCoachTurnId"/>). Doubles as
+/// the idempotency key for the coach-turn write: a duplicate completion for the same
+/// user turn re-derives the same id and short-circuits, so the coach turn is never
+/// appended twice.
+/// </param>
+/// <param name="Content">
+/// The coach's complete reply text. <b>Empty</b> when <paramref name="IsErrored"/>
+/// is <see langword="true"/> — a stream that died mid-flight never persists its
+/// partial text as a complete turn (a HARD safety rule: truncated coaching advice
+/// must not render as complete).
+/// </param>
+/// <param name="IsErrored">
+/// <see langword="true"/> for an errored-turn marker (the stream failed mid-flight);
+/// <see langword="false"/> for a normal, complete reply.
+/// </param>
+public sealed record CoachMessagePosted(
+    Guid UserId,
+    Guid TurnId,
+    string Content,
+    bool IsErrored);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationController.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationController.cs
@@ -83,6 +83,72 @@ public sealed class ConversationController(
         return Ok(new ConversationTurnsResponseDto(turns));
     }
 
+    /// <summary>
+    /// GET /api/v1/conversation/timeline — the runner's composed conversation
+    /// (Slice 4B Unit 3, DEC-085): their user-scoped interactive turns unioned with
+    /// the current plan's proactive adaptation/safety turns, oldest-first for a chat
+    /// composer. The interactive turns survive plan regeneration; the proactive turns
+    /// reset with the plan. User-scoped via the per-request tenanted Marten session;
+    /// no antiforgery (read). Returns the interactive turns alone until the current
+    /// plan has proactive turns (or none until PR4 wires the interactive appends).
+    /// </summary>
+    /// <param name="ct">Request cancellation token.</param>
+    /// <returns>200 with the oldest-first timeline (possibly empty); 401 when the user claim is missing or malformed.</returns>
+    [HttpGet("timeline")]
+    [ProducesResponseType(typeof(ConversationTimelineDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetTimeline(CancellationToken ct)
+    {
+        if (!TryGetUserId(out var userId))
+        {
+            return MissingUserClaim();
+        }
+
+        // Conjoined tenancy: one per-request tenanted session loads both the
+        // user-scoped interactive stream (keyed by user id) and the plan-scoped
+        // proactive log (keyed by the active plan id) — both under the same tenant.
+        await using var session = store.LightweightSession(userId.ToString());
+
+        // Interactive turns — keyed by user id, so they persist across plan regens.
+        var conversation = await session
+            .LoadAsync<ConversationView>(userId, ct)
+            .ConfigureAwait(false);
+        IReadOnlyList<InteractiveTurnView> interactive = conversation?.Turns ?? [];
+
+        // Proactive turns for the runner's active plan — keyed by plan id, reset on regen.
+        var currentPlanId = await EntityFrameworkQueryableExtensions
+            .SingleOrDefaultAsync(
+                db.RunnerOnboardingProfiles
+                    .AsNoTracking()
+                    .Where(p => p.UserId == userId)
+                    .Select(p => p.CurrentPlanId),
+                ct)
+            .ConfigureAwait(false);
+
+        IReadOnlyList<ConversationTurnView> proactive = [];
+        if (currentPlanId is not null)
+        {
+            var log = await session
+                .LoadAsync<ConversationLogView>(currentPlanId.Value, ct)
+                .ConfigureAwait(false);
+            proactive = log?.Turns ?? [];
+        }
+
+        // Union oldest-first. CreatedAt (the Marten event timestamp) is the cross-stream
+        // ordering key; the per-stream EventVersion then the TurnId are deterministic
+        // tiebreakers for turns that share a transaction_timestamp().
+        var turns = interactive
+            .Select(MapInteractiveTurn)
+            .Concat(proactive.Select(MapProactiveTurn))
+            .OrderBy(x => x.CreatedAt)
+            .ThenBy(x => x.EventVersion)
+            .ThenBy(x => x.TurnId)
+            .Select(x => x.Dto)
+            .ToArray();
+
+        return Ok(new ConversationTimelineDto(turns));
+    }
+
     private static ConversationTurnDto MapTurn(ConversationTurnView turn) =>
         new(
             turn.TriggeringPlanEventId,
@@ -95,6 +161,30 @@ public sealed class ConversationController(
             turn.Diff,
             turn.TriggeringWorkoutLogId,
             turn.CreatedAt);
+
+    private static (DateTimeOffset CreatedAt, long EventVersion, Guid TurnId, ConversationTimelineTurnDto Dto)
+        MapInteractiveTurn(InteractiveTurnView turn) =>
+        (turn.CreatedAt, turn.EventVersion, turn.TurnId,
+            new ConversationTimelineTurnDto(
+                turn.Participant == ConversationParticipant.User
+                    ? ConversationTimelineTurnKind.User
+                    : ConversationTimelineTurnKind.Coach,
+                turn.TurnId,
+                turn.CreatedAt,
+                new InteractiveTurnDto(turn.Content, turn.IsErrored),
+                Proactive: null));
+
+    private static (DateTimeOffset CreatedAt, long EventVersion, Guid TurnId, ConversationTimelineTurnDto Dto)
+        MapProactiveTurn(ConversationTurnView turn) =>
+        (turn.CreatedAt, turn.EventVersion, turn.TriggeringPlanEventId,
+            new ConversationTimelineTurnDto(
+                turn.Role == ConversationRole.AssistantAdaptation
+                    ? ConversationTimelineTurnKind.Adaptation
+                    : ConversationTimelineTurnKind.Safety,
+                turn.TriggeringPlanEventId,
+                turn.CreatedAt,
+                Interactive: null,
+                MapTurn(turn)));
 
     private bool TryGetUserId(out Guid userId)
     {

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationController.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationController.cs
@@ -89,8 +89,8 @@ public sealed class ConversationController(
     /// the current plan's proactive adaptation/safety turns, oldest-first for a chat
     /// composer. The interactive turns survive plan regeneration; the proactive turns
     /// reset with the plan. User-scoped via the per-request tenanted Marten session;
-    /// no antiforgery (read). Returns the interactive turns alone until the current
-    /// plan has proactive turns (or none until PR4 wires the interactive appends).
+    /// no antiforgery (read). Returns the interactive turns alone when the current
+    /// plan has no proactive turns (and an empty timeline when neither stream exists).
     /// </summary>
     /// <param name="ct">Request cancellation token.</param>
     /// <returns>200 with the oldest-first timeline (possibly empty); 401 when the user claim is missing or malformed.</returns>
@@ -134,15 +134,15 @@ public sealed class ConversationController(
             proactive = log?.Turns ?? [];
         }
 
-        // Union oldest-first. CreatedAt (the Marten event timestamp) is the cross-stream
-        // ordering key; the per-stream EventVersion then the TurnId are deterministic
-        // tiebreakers for turns that share a transaction_timestamp().
+        // Union oldest-first. Dto.CreatedAt (the Marten event timestamp) is the
+        // cross-stream ordering key; the per-stream EventVersion then Dto.TurnId are
+        // deterministic tiebreakers for turns that share a transaction_timestamp().
         var turns = interactive
             .Select(MapInteractiveTurn)
             .Concat(proactive.Select(MapProactiveTurn))
-            .OrderBy(x => x.CreatedAt)
+            .OrderBy(x => x.Dto.CreatedAt)
             .ThenBy(x => x.EventVersion)
-            .ThenBy(x => x.TurnId)
+            .ThenBy(x => x.Dto.TurnId)
             .Select(x => x.Dto)
             .ToArray();
 
@@ -162,9 +162,9 @@ public sealed class ConversationController(
             turn.TriggeringWorkoutLogId,
             turn.CreatedAt);
 
-    private static (DateTimeOffset CreatedAt, long EventVersion, Guid TurnId, ConversationTimelineTurnDto Dto)
+    private static (long EventVersion, ConversationTimelineTurnDto Dto)
         MapInteractiveTurn(InteractiveTurnView turn) =>
-        (turn.CreatedAt, turn.EventVersion, turn.TurnId,
+        (turn.EventVersion,
             new ConversationTimelineTurnDto(
                 turn.Participant == ConversationParticipant.User
                     ? ConversationTimelineTurnKind.User
@@ -174,9 +174,9 @@ public sealed class ConversationController(
                 new InteractiveTurnDto(turn.Content, turn.IsErrored),
                 Proactive: null));
 
-    private static (DateTimeOffset CreatedAt, long EventVersion, Guid TurnId, ConversationTimelineTurnDto Dto)
+    private static (long EventVersion, ConversationTimelineTurnDto Dto)
         MapProactiveTurn(ConversationTurnView turn) =>
-        (turn.CreatedAt, turn.EventVersion, turn.TriggeringPlanEventId,
+        (turn.EventVersion,
             new ConversationTimelineTurnDto(
                 turn.Role == ConversationRole.AssistantAdaptation
                     ? ConversationTimelineTurnKind.Adaptation

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationParticipant.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationParticipant.cs
@@ -1,0 +1,19 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// The author of an interactive conversation turn (Slice 4B Unit 3, DEC-085).
+/// Distinct from <see cref="ConversationRole"/> (which discriminates the proactive
+/// adaptation/safety turns of the plan-scoped log): this enum covers the free-chat
+/// interactive stream. Values are explicitly numbered and append-only so reordering
+/// or adding members never shifts the stored/serialized integer encoding (matching
+/// the <see cref="ConversationRole"/> / <see cref="Training.Safety.SafetyTier"/>
+/// convention).
+/// </summary>
+public enum ConversationParticipant
+{
+    /// <summary>A message the runner posted.</summary>
+    User = 0,
+
+    /// <summary>A reply the coach streamed back.</summary>
+    Coach = 1,
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTimelineDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTimelineDto.cs
@@ -1,0 +1,16 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Response envelope for <c>GET /api/v1/conversation/timeline</c> (Slice 4B Unit 3,
+/// DEC-085) — the runner's composed conversation, unioning their user-scoped
+/// interactive turns with the current plan's proactive adaptation/safety turns into
+/// one <b>oldest-first</b> ordered list (a chat composer wants chronological flow;
+/// the sibling <c>GET /conversation/turns</c> stays newest-first and untouched).
+/// </summary>
+/// <param name="Turns">The composed turns, ordered oldest-first.</param>
+public sealed record ConversationTimelineDto(
+    IReadOnlyList<ConversationTimelineTurnDto> Turns)
+{
+    /// <summary>Gets the empty timeline — no turns yet.</summary>
+    public static ConversationTimelineDto Empty { get; } = new([]);
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTimelineTurnDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTimelineTurnDto.cs
@@ -1,0 +1,25 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// One turn in the composed conversation timeline (Slice 4B Unit 3, DEC-085) — a
+/// discriminated union over the interactive user/coach turns and the proactive
+/// adaptation/safety turns, unioned oldest-first by <c>GET /api/v1/conversation/timeline</c>.
+/// <see cref="Kind"/> says which payload is populated: <see cref="Interactive"/> for
+/// <see cref="ConversationTimelineTurnKind.User"/>/<see cref="ConversationTimelineTurnKind.Coach"/>,
+/// <see cref="Proactive"/> (the existing <see cref="ConversationTurnDto"/> shape, reused)
+/// for <see cref="ConversationTimelineTurnKind.Adaptation"/>/<see cref="ConversationTimelineTurnKind.Safety"/>.
+/// The non-active payload is null. (The OpenAPI schema filter cannot express that
+/// per-member nullability on a <c>$ref</c>, so the frontend hand-writes the discriminated
+/// model; the generated Zod is a tripwire only.)
+/// </summary>
+/// <param name="Kind">Which of the four turn variants this is — the render discriminator.</param>
+/// <param name="TurnId">The stable per-turn id (the interactive turn id, or the proactive turn's source event id).</param>
+/// <param name="CreatedAt">The turn's timestamp — the union's oldest-first ordering key.</param>
+/// <param name="Interactive">The interactive payload when <see cref="Kind"/> is User/Coach; otherwise null.</param>
+/// <param name="Proactive">The proactive adaptation/safety payload when <see cref="Kind"/> is Adaptation/Safety; otherwise null.</param>
+public sealed record ConversationTimelineTurnDto(
+    ConversationTimelineTurnKind Kind,
+    Guid TurnId,
+    DateTimeOffset CreatedAt,
+    InteractiveTurnDto? Interactive,
+    ConversationTurnDto? Proactive);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTimelineTurnKind.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTimelineTurnKind.cs
@@ -1,0 +1,25 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Discriminates the four turn variants the composed conversation timeline unions
+/// (Slice 4B Unit 3, DEC-085): the interactive user/coach turns from the user-scoped
+/// <c>Conversation</c> stream, and the proactive adaptation/safety turns from the
+/// current plan's <see cref="ConversationLogView"/>. The frontend switches on this to
+/// pick a renderer — chat bubbles for interactive turns, the existing
+/// adaptation/safety components for proactive turns. Explicitly numbered and
+/// append-only for wire stability.
+/// </summary>
+public enum ConversationTimelineTurnKind
+{
+    /// <summary>An interactive message the runner posted.</summary>
+    User = 0,
+
+    /// <summary>An interactive reply the coach streamed back.</summary>
+    Coach = 1,
+
+    /// <summary>A proactive adaptation explanation from the current plan's log.</summary>
+    Adaptation = 2,
+
+    /// <summary>A proactive deterministic safety message from the current plan's log.</summary>
+    Safety = 3,
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTurnId.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTurnId.cs
@@ -1,0 +1,48 @@
+using System.Security.Cryptography;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Derives the deterministic <b>server-side</b> turn id for a coach reply from the
+/// user turn's client message id (Slice 4B Unit 3, DEC-085). The coach-turn write
+/// is idempotent on this derived id: a duplicate completion for the same user turn
+/// re-derives the same id and short-circuits via <c>IIdempotencyStore</c>, so the
+/// coach turn is never appended twice. The user turn already consumes the client id
+/// as its own idempotency key, so the coach turn <b>must</b> use a distinct key —
+/// re-using the client id would collide on the idempotency marker insert.
+/// </summary>
+/// <remarks>
+/// A name-based (RFC 4122 §4.3-style) hash of a fixed namespace + the client id,
+/// never random, so the derivation is stable across processes and deploys. A
+/// re-send after mid-stream death uses a <em>fresh</em> client id (D5), which
+/// derives a fresh coach id — the original turn keeps its errored marker and the
+/// re-send is a separate turn, by design.
+/// </remarks>
+public static class ConversationTurnId
+{
+    // Fixed namespace GUID so the derivation is deterministic and distinct from the
+    // user/client GUID space. Arbitrary but stable — never change it, or in-flight
+    // idempotency keys would shift.
+    private static readonly Guid CoachTurnNamespace = new("7d3f1b2a-9c84-4f6e-b1a2-2c5d6e7f8a90");
+
+    /// <summary>Derives the deterministic coach-turn id for a given user-turn client message id.</summary>
+    /// <param name="clientMessageId">The user turn's client-generated message id.</param>
+    /// <returns>A stable, well-formed GUID distinct from <paramref name="clientMessageId"/>.</returns>
+    public static Guid DeriveCoachTurnId(Guid clientMessageId)
+    {
+        Span<byte> buffer = stackalloc byte[32];
+        _ = CoachTurnNamespace.TryWriteBytes(buffer[..16]);
+        _ = clientMessageId.TryWriteBytes(buffer[16..]);
+
+        Span<byte> hash = stackalloc byte[32];
+        _ = SHA256.HashData(buffer, hash);
+
+        Span<byte> guidBytes = hash[..16];
+
+        // Stamp RFC 4122 version (8 = custom/hash-based) + variant bits so the value
+        // is a well-formed UUID rather than a raw hash slice.
+        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x80);
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);
+        return new Guid(guidBytes);
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTurnId.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTurnId.cs
@@ -40,8 +40,11 @@ public static class ConversationTurnId
         Span<byte> guidBytes = hash[..16];
 
         // Stamp RFC 4122 version (8 = custom/hash-based) + variant bits so the value
-        // is a well-formed UUID rather than a raw hash slice.
-        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x80);
+        // is a well-formed UUID rather than a raw hash slice. The version nibble lives
+        // in the high 4 bits of byte 7 — `Guid(ReadOnlySpan<byte>)` reads Data3
+        // (bytes 6-7) little-endian, so byte 7 is the high byte shown at the canonical
+        // string position `XXXXXXXX-XXXX-Vxxx`.
+        guidBytes[7] = (byte)((guidBytes[7] & 0x0F) | 0x80);
         guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);
         return new Guid(guidBytes);
     }

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTurnPostedResponse.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTurnPostedResponse.cs
@@ -1,0 +1,15 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Response from the two interactive-turn persistence handlers
+/// (<see cref="PostUserConversationTurn"/> / <see cref="PostCoachConversationTurn"/>),
+/// Slice 4B Unit 3. Carries the persisted turn id back to the caller (the SSE
+/// endpoint, PR4). Recorded by <c>IIdempotencyStore</c> so a retried write returns
+/// the byte-identical prior response without re-appending. Not a wire DTO — never
+/// surfaced directly on a controller.
+/// </summary>
+/// <param name="TurnId">
+/// The persisted turn id — the client message id for a user turn, the server-derived
+/// id for a coach turn.
+/// </param>
+public sealed record ConversationTurnPostedResponse(Guid TurnId);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationView.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationView.cs
@@ -1,0 +1,44 @@
+using Marten.Metadata;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// The Marten document read-model accumulating a runner's <b>interactive</b>
+/// conversation turns (Slice 4B Unit 3, DEC-085). Keyed by <see cref="Id"/> = the
+/// runner's user id (the <c>Conversation</c> stream id), so the conversation
+/// <b>persists across plan regenerations</b> — RunCoach is "my coach", not "a coach
+/// for this plan". Materialized inline by <see cref="InteractiveConversationProjection"/>
+/// from <see cref="UserMessagePosted"/> / <see cref="CoachMessagePosted"/> events.
+/// </summary>
+/// <remarks>
+/// Distinct from the plan-scoped <see cref="ConversationLogView"/> (keyed by
+/// <c>PlanId</c>), which holds the proactive adaptation/safety turns and is left
+/// untouched by this slice. A composed timeline read unions the two. Implements
+/// <see cref="ITenanted"/> so Marten conjoined tenancy auto-populates
+/// <see cref="TenantId"/> with the runner's user id (mirroring
+/// <see cref="Onboarding.OnboardingView"/>, the only other user-keyed projection).
+/// </remarks>
+public sealed class ConversationView : ITenanted
+{
+    /// <summary>Gets or sets the document/stream id (the runner's user id; equal to <see cref="UserId"/>).</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the runner's user id.</summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the conjoined-tenancy tenant id auto-populated by Marten from the
+    /// session's tenant context. Always equal to <see cref="UserId"/> stringified.
+    /// The setter is required by <see cref="ITenanted"/>; the projection never assigns it.
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the interactive turns in append (chronological) order. Each turn is
+    /// keyed by its <see cref="InteractiveTurnView.TurnId"/> so the projection is
+    /// idempotent under replay — exactly one turn per logical message. Typed
+    /// <see cref="IReadOnlyList{T}"/> (mutated by whole-collection reassignment in the
+    /// projection) for parity with the other read-model idioms.
+    /// </summary>
+    public IReadOnlyList<InteractiveTurnView> Turns { get; set; } = [];
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/InteractiveConversationProjection.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/InteractiveConversationProjection.cs
@@ -1,0 +1,94 @@
+using JasperFx.Events;
+using Marten.Events.Aggregation;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Inline single-stream projection that materializes the runner's <b>interactive</b>
+/// conversation read-model (<see cref="ConversationView"/>) from the user-scoped
+/// <c>Conversation</c> stream (Slice 4B Unit 3, DEC-085). NET-NEW, keyed by user id
+/// (the stream id) so the conversation survives plan regeneration. Mirrors the
+/// only other user-keyed precedent, <see cref="Onboarding.OnboardingProjection"/>:
+/// the first <see cref="UserMessagePosted"/> <c>Create</c>s the view, and every
+/// subsequent <see cref="UserMessagePosted"/> / <see cref="CoachMessagePosted"/>
+/// <c>Apply</c>s one turn. Marten 9's JasperFx source generator dispatches the
+/// convention methods below, which is why this class is <c>partial</c>.
+/// </summary>
+/// <remarks>
+/// Each turn is keyed by <see cref="InteractiveTurnView.TurnId"/>, so a projection
+/// rebuild re-applies the same events and upserts the same turns — exactly one turn
+/// per logical message, no duplicates. The user turn is durable-first and the coach
+/// turn appends on completion, so the stream is always created by a
+/// <see cref="UserMessagePosted"/>; a coach turn only ever appends to an existing
+/// stream. Registered with <c>ProjectionLifecycle.Inline</c> in
+/// <see cref="Infrastructure.MartenConfiguration"/>. This projection does <b>not</b>
+/// touch the plan-scoped <see cref="ConversationLogView"/> / <see cref="ConversationProjection"/>.
+/// </remarks>
+public sealed partial class InteractiveConversationProjection : SingleStreamProjection<ConversationView, Guid>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InteractiveConversationProjection"/>
+    /// class. Pins the projection name so the schema-artifact / projection-state row
+    /// name survives rename refactors.
+    /// </summary>
+    public InteractiveConversationProjection()
+    {
+        Name = "InteractiveConversationProjection";
+    }
+
+    /// <summary>
+    /// Seeds the conversation view on the first turn (always a
+    /// <see cref="UserMessagePosted"/>, since the user turn is durable-first) and
+    /// records that first turn. Accepts the <see cref="IEvent{T}"/> wrapper to read
+    /// the stream id (= user id) plus the event timestamp/version the turn carries.
+    /// </summary>
+    /// <param name="event">The stream-creation user-message event with Marten metadata.</param>
+    /// <returns>The initial <see cref="ConversationView"/> for the stream.</returns>
+    public static ConversationView Create(IEvent<UserMessagePosted> @event)
+    {
+        var view = new ConversationView
+        {
+            Id = @event.Data.UserId,
+            UserId = @event.Data.UserId,
+        };
+        Upsert(view, InteractiveTurnView.FromUser(@event));
+        return view;
+    }
+
+    /// <summary>Appends a runner-authored turn for a subsequent <see cref="UserMessagePosted"/> event.</summary>
+    /// <param name="event">The user-message event with Marten metadata.</param>
+    /// <param name="view">The conversation view being mutated.</param>
+    public static void Apply(IEvent<UserMessagePosted> @event, ConversationView view)
+    {
+        Upsert(view, InteractiveTurnView.FromUser(@event));
+    }
+
+    /// <summary>Appends a coach-authored (or errored) turn for a <see cref="CoachMessagePosted"/> event.</summary>
+    /// <param name="event">The coach-message event with Marten metadata.</param>
+    /// <param name="view">The conversation view being mutated.</param>
+    public static void Apply(IEvent<CoachMessagePosted> @event, ConversationView view)
+    {
+        Upsert(view, InteractiveTurnView.FromCoach(@event));
+    }
+
+    private static void Upsert(ConversationView view, InteractiveTurnView turn)
+    {
+        // Find-or-replace by the per-turn id keeps the projection idempotent under
+        // replay and against a duplicate coach append (the two-write idempotency at
+        // the handler layer is the primary guard; this is the projection-side backstop).
+        // Mutate by whole-collection reassignment (the read-model idiom) since Turns
+        // is exposed as an IReadOnlyList.
+        var turns = view.Turns.ToList();
+        var existing = turns.FindIndex(t => t.TurnId == turn.TurnId);
+        if (existing >= 0)
+        {
+            turns[existing] = turn;
+        }
+        else
+        {
+            turns.Add(turn);
+        }
+
+        view.Turns = turns;
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/InteractiveTurnDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/InteractiveTurnDto.cs
@@ -1,0 +1,15 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// The interactive-turn payload of a <see cref="ConversationTimelineTurnDto"/> — the
+/// text of a user message or a coach reply (Slice 4B Unit 3, DEC-085). Present only
+/// when the wrapper's <see cref="ConversationTimelineTurnDto.Kind"/> is
+/// <see cref="ConversationTimelineTurnKind.User"/> or
+/// <see cref="ConversationTimelineTurnKind.Coach"/>. The wrapper carries the id and
+/// timestamp; this carries only the kind-specific fields.
+/// </summary>
+/// <param name="Content">The turn text. Empty for an errored coach turn.</param>
+/// <param name="IsErrored">True when this coach turn is an errored marker (the stream died mid-flight); always false for a user turn.</param>
+public sealed record InteractiveTurnDto(
+    string Content,
+    bool IsErrored);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/InteractiveTurnView.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/InteractiveTurnView.cs
@@ -1,0 +1,75 @@
+using JasperFx.Events;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// One persisted turn in a runner's <b>interactive</b> conversation read-model
+/// (Slice 4B Unit 3, DEC-085), projected from exactly one user-scoped
+/// <c>Conversation</c> stream event. Distinct from the plan-scoped
+/// <see cref="ConversationTurnView"/> (proactive adaptation/safety turns).
+/// <see cref="TurnId"/> is the per-turn idempotency/replay key, so the projection
+/// upserts exactly one entry per logical message.
+/// </summary>
+public sealed record InteractiveTurnView
+{
+    /// <summary>Gets the per-turn id — the client GUID for a user turn, the server-derived GUID for a coach turn.</summary>
+    public required Guid TurnId { get; init; }
+
+    /// <summary>Gets whether the runner or the coach authored this turn.</summary>
+    public required ConversationParticipant Participant { get; init; }
+
+    /// <summary>Gets the turn text. Empty for an errored coach turn (never a partial-as-complete reply).</summary>
+    public required string Content { get; init; }
+
+    /// <summary>Gets a value indicating whether this coach turn is an errored marker (the stream died mid-flight). Always false for a user turn.</summary>
+    public required bool IsErrored { get; init; }
+
+    /// <summary>Gets the wall-clock time the source event was appended (Marten event timestamp).</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>
+    /// Gets the source event's per-stream Marten version (1-based, strictly increasing
+    /// with append order) — the deterministic tiebreaker for turns sharing a
+    /// <see cref="CreatedAt"/>.
+    /// </summary>
+    public required long EventVersion { get; init; }
+
+    /// <summary>Builds a runner-authored turn from a <see cref="UserMessagePosted"/> event and its Marten metadata.</summary>
+    /// <param name="event">The user-message event with Marten metadata.</param>
+    /// <returns>The projected user turn.</returns>
+    public static InteractiveTurnView FromUser(IEvent<UserMessagePosted> @event)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+
+        return new InteractiveTurnView
+        {
+            TurnId = @event.Data.TurnId,
+            Participant = ConversationParticipant.User,
+            Content = @event.Data.Content,
+            IsErrored = false,
+            CreatedAt = @event.Timestamp,
+            EventVersion = @event.Version,
+        };
+    }
+
+    /// <summary>Builds a coach-authored turn from a <see cref="CoachMessagePosted"/> event and its Marten metadata.</summary>
+    /// <param name="event">The coach-message event with Marten metadata.</param>
+    /// <returns>The projected coach turn. Content is forced empty for an errored marker.</returns>
+    public static InteractiveTurnView FromCoach(IEvent<CoachMessagePosted> @event)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+
+        return new InteractiveTurnView
+        {
+            TurnId = @event.Data.TurnId,
+            Participant = ConversationParticipant.Coach,
+
+            // Defense-in-depth: an errored marker never renders partial coaching advice
+            // as complete, regardless of what content the event happens to carry.
+            Content = @event.Data.IsErrored ? string.Empty : @event.Data.Content,
+            IsErrored = @event.Data.IsErrored,
+            CreatedAt = @event.Timestamp,
+            EventVersion = @event.Version,
+        };
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostCoachConversationTurn.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostCoachConversationTurn.cs
@@ -1,0 +1,23 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Command to persist the coach's reply as the <b>second</b> of the two-write
+/// conversation turn pair (Slice 4B Unit 3, DEC-085). Handled by
+/// <see cref="PostCoachConversationTurnHandler"/> as a tenant-scoped Wolverine
+/// handler. The SSE endpoint (PR4) dispatches this <b>once on completion</b> (or with
+/// <see cref="IsErrored"/> set when the stream died mid-flight). Idempotent on the
+/// server-derived turn id (<see cref="ConversationTurnId.DeriveCoachTurnId"/> over
+/// <see cref="ClientMessageId"/>), so a duplicate completion never double-appends.
+/// </summary>
+/// <param name="UserId">The runner's user id — the <c>Conversation</c> stream id and the Wolverine tenant id.</param>
+/// <param name="ClientMessageId">
+/// The originating user turn's client message id. The coach turn id is derived from
+/// it deterministically; the coach write is idempotent on that derived id.
+/// </param>
+/// <param name="Content">The coach's complete reply text. Ignored (forced empty) when <see cref="IsErrored"/> is true.</param>
+/// <param name="IsErrored">True to persist an errored-turn marker (the stream failed mid-flight); false for a complete reply.</param>
+public sealed record PostCoachConversationTurn(
+    Guid UserId,
+    Guid ClientMessageId,
+    string Content,
+    bool IsErrored);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostCoachConversationTurn.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostCoachConversationTurn.cs
@@ -4,8 +4,8 @@ namespace RunCoach.Api.Modules.Coaching.Conversation;
 /// Command to persist the coach's reply as the <b>second</b> of the two-write
 /// conversation turn pair (Slice 4B Unit 3, DEC-085). Handled by
 /// <see cref="PostCoachConversationTurnHandler"/> as a tenant-scoped Wolverine
-/// handler. The SSE endpoint (PR4) dispatches this <b>once on completion</b> (or with
-/// <see cref="IsErrored"/> set when the stream died mid-flight). Idempotent on the
+/// handler. Dispatched <b>once on completion</b> (or with
+/// <see cref="IsErrored"/> set when the reply stream died mid-flight). Idempotent on the
 /// server-derived turn id (<see cref="ConversationTurnId.DeriveCoachTurnId"/> over
 /// <see cref="ClientMessageId"/>), so a duplicate completion never double-appends.
 /// </summary>

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostCoachConversationTurnHandler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostCoachConversationTurnHandler.cs
@@ -1,0 +1,79 @@
+using Marten;
+using Microsoft.Extensions.Logging;
+using RunCoach.Api.Infrastructure.Idempotency;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Wolverine command handler for <see cref="PostCoachConversationTurn"/> (Slice 4B
+/// Unit 3, DEC-085) — the on-completion coach-turn write (or an errored-turn marker).
+/// Idempotent on the server-derived turn id, so a duplicate completion for the same
+/// user turn never double-appends. Appends to the user-scoped <c>Conversation</c>
+/// stream the user turn already created (durable-first ordering). Wolverine's
+/// transactional middleware brackets a single Marten <c>SaveChangesAsync</c>.
+/// </summary>
+/// <remarks>
+/// Never persists a partial as complete: when <see cref="PostCoachConversationTurn.IsErrored"/>
+/// is set, the appended turn carries empty content and an errored flag, so a stream
+/// that died mid-flight leaves an explicit marker rather than truncated advice.
+/// </remarks>
+public sealed partial class PostCoachConversationTurnHandler
+{
+    // See PostUserConversationTurnHandler — Wolverine codegen needs a non-static
+    // logical handler type; the private constructor blocks instantiation.
+    private PostCoachConversationTurnHandler()
+    {
+    }
+
+    /// <summary>Persists the coach turn on completion, idempotent on the server-derived turn id.</summary>
+    /// <param name="cmd">The post-coach-turn command.</param>
+    /// <param name="session">Marten session bracketed by Wolverine's transactional middleware.</param>
+    /// <param name="idempotency">Idempotency store backed by the same <paramref name="session"/>.</param>
+    /// <param name="logger">Logger.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The persisted coach turn id (server-derived).</returns>
+    public static async Task<ConversationTurnPostedResponse> Handle(
+        PostCoachConversationTurn cmd,
+        IDocumentSession session,
+        IIdempotencyStore idempotency,
+        ILogger<PostCoachConversationTurnHandler> logger,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(cmd);
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(idempotency);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        // The coach turn id is derived from the user turn's client id, never random,
+        // so a duplicate completion re-derives the same id and short-circuits here.
+        var coachTurnId = ConversationTurnId.DeriveCoachTurnId(cmd.ClientMessageId);
+
+        var prior = await idempotency
+            .SeenAsync<ConversationTurnPostedResponse>(coachTurnId, ct)
+            .ConfigureAwait(false);
+        if (prior is not null)
+        {
+            LogIdempotentReplay(logger, coachTurnId, cmd.UserId);
+            return prior;
+        }
+
+        // An errored marker never carries partial text — a truncated reply is recorded
+        // as incomplete, not stored as a complete turn.
+        var content = cmd.IsErrored ? string.Empty : cmd.Content;
+
+        // The user turn is durable-first, so the stream already exists — append.
+        session.Events.Append(
+            cmd.UserId,
+            new CoachMessagePosted(cmd.UserId, coachTurnId, content, cmd.IsErrored));
+
+        var response = new ConversationTurnPostedResponse(coachTurnId);
+        idempotency.Record(coachTurnId, response);
+        return response;
+    }
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Information,
+        Message = "Interactive coach turn idempotent replay coachTurnId={CoachTurnId} user={UserId}")]
+    private static partial void LogIdempotentReplay(ILogger logger, Guid coachTurnId, Guid userId);
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostUserConversationTurn.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostUserConversationTurn.cs
@@ -5,8 +5,8 @@ namespace RunCoach.Api.Modules.Coaching.Conversation;
 /// two-write conversation turn pair (Slice 4B Unit 3, DEC-085). Handled by
 /// <see cref="PostUserConversationTurnHandler"/> as a tenant-scoped Wolverine handler
 /// (<c>InvokeForTenantAsync</c>) so the co-transactional <c>IIdempotencyStore</c> sees
-/// a tenanted session. The SSE endpoint (PR4) dispatches this <b>before</b> opening the
-/// stream, so the user message is durable first.
+/// a tenanted session. Dispatched <b>before</b> the coach reply stream opens, so the
+/// user message is durable first.
 /// </summary>
 /// <param name="UserId">The runner's user id — the <c>Conversation</c> stream id and the Wolverine tenant id.</param>
 /// <param name="ClientMessageId">The client-generated message id — the turn id and the idempotency key.</param>

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostUserConversationTurn.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostUserConversationTurn.cs
@@ -1,0 +1,17 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Command to persist a runner's interactive chat message as the <b>first</b> of the
+/// two-write conversation turn pair (Slice 4B Unit 3, DEC-085). Handled by
+/// <see cref="PostUserConversationTurnHandler"/> as a tenant-scoped Wolverine handler
+/// (<c>InvokeForTenantAsync</c>) so the co-transactional <c>IIdempotencyStore</c> sees
+/// a tenanted session. The SSE endpoint (PR4) dispatches this <b>before</b> opening the
+/// stream, so the user message is durable first.
+/// </summary>
+/// <param name="UserId">The runner's user id — the <c>Conversation</c> stream id and the Wolverine tenant id.</param>
+/// <param name="ClientMessageId">The client-generated message id — the turn id and the idempotency key.</param>
+/// <param name="Content">The runner's message text.</param>
+public sealed record PostUserConversationTurn(
+    Guid UserId,
+    Guid ClientMessageId,
+    string Content);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostUserConversationTurnHandler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostUserConversationTurnHandler.cs
@@ -21,8 +21,8 @@ namespace RunCoach.Api.Modules.Coaching.Conversation;
 /// </remarks>
 public sealed partial class PostUserConversationTurnHandler
 {
-    // Wolverine codegen emits a non-static handler stub that calls the static Handle
-    // method; ILogger<PostUserConversationTurnHandler> needs a non-static type. The
+    // Wolverine codegen emits a non-static handler stub that calls the static `Handle`
+    // method; `ILogger<PostUserConversationTurnHandler>` needs a non-static type. The
     // private constructor prevents instantiation in test code.
     private PostUserConversationTurnHandler()
     {

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostUserConversationTurnHandler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostUserConversationTurnHandler.cs
@@ -1,0 +1,89 @@
+using Marten;
+using Microsoft.Extensions.Logging;
+using RunCoach.Api.Infrastructure.Idempotency;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Wolverine command handler for <see cref="PostUserConversationTurn"/> (Slice 4B
+/// Unit 3, DEC-085) — the durable-first user-turn write. Idempotent on the client
+/// message id, so a retried POST appends nothing the second time. Bootstraps the
+/// user-scoped <c>Conversation</c> stream on the runner's first message, then
+/// appends to it on subsequent turns. Wolverine's transactional middleware brackets
+/// a single Marten <c>SaveChangesAsync</c> around the handler; it never calls
+/// <c>SaveChangesAsync</c> itself.
+/// </summary>
+/// <remarks>
+/// Two-write persistence (DEC-085): this user-turn write and the
+/// <see cref="PostCoachConversationTurnHandler"/> coach-turn write are two separate
+/// idempotent transactions, because the co-transactional idempotency + single-
+/// <c>SaveChanges</c> model cannot span a multi-second stream.
+/// </remarks>
+public sealed partial class PostUserConversationTurnHandler
+{
+    // Wolverine codegen emits a non-static handler stub that calls the static Handle
+    // method; ILogger<PostUserConversationTurnHandler> needs a non-static type. The
+    // private constructor prevents instantiation in test code.
+    private PostUserConversationTurnHandler()
+    {
+    }
+
+    /// <summary>Persists the user turn (durable-first), idempotent on the client message id.</summary>
+    /// <param name="cmd">The post-user-turn command.</param>
+    /// <param name="session">Marten session bracketed by Wolverine's transactional middleware.</param>
+    /// <param name="idempotency">Idempotency store backed by the same <paramref name="session"/>.</param>
+    /// <param name="logger">Logger.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The persisted turn id (= the client message id).</returns>
+    public static async Task<ConversationTurnPostedResponse> Handle(
+        PostUserConversationTurn cmd,
+        IDocumentSession session,
+        IIdempotencyStore idempotency,
+        ILogger<PostUserConversationTurnHandler> logger,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(cmd);
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(idempotency);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        // Idempotency short-circuit: a retried POST returns the byte-identical prior
+        // response and appends nothing.
+        var prior = await idempotency
+            .SeenAsync<ConversationTurnPostedResponse>(cmd.ClientMessageId, ct)
+            .ConfigureAwait(false);
+        if (prior is not null)
+        {
+            LogIdempotentReplay(logger, cmd.ClientMessageId, cmd.UserId);
+            return prior;
+        }
+
+        var streamId = cmd.UserId;
+        var view = await session
+            .LoadAsync<ConversationView>(streamId, ct)
+            .ConfigureAwait(false);
+
+        var @event = new UserMessagePosted(cmd.UserId, cmd.ClientMessageId, cmd.Content);
+
+        // First message bootstraps the stream; subsequent messages append. The inline
+        // InteractiveConversationProjection materializes the view in the same transaction.
+        if (view is null)
+        {
+            session.Events.StartStream<ConversationView>(streamId, @event);
+        }
+        else
+        {
+            session.Events.Append(streamId, @event);
+        }
+
+        var response = new ConversationTurnPostedResponse(cmd.ClientMessageId);
+        idempotency.Record(cmd.ClientMessageId, response);
+        return response;
+    }
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Information,
+        Message = "Interactive user turn idempotent replay clientMessageId={ClientMessageId} user={UserId}")]
+    private static partial void LogIdempotentReplay(ILogger logger, Guid clientMessageId, Guid userId);
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/UserMessagePosted.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/UserMessagePosted.cs
@@ -1,0 +1,27 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Event recorded when a runner posts an interactive chat message to their coach
+/// (Slice 4B Unit 3, DEC-085). Appended to the user-scoped <c>Conversation</c>
+/// stream (stream id = <see cref="UserId"/>) <b>durably first</b>, before the
+/// streaming reply opens, so a crash mid-stream still leaves a recoverable record
+/// of what the runner asked. The interactive stream survives plan regeneration —
+/// it is keyed by the user, not the plan (unlike the proactive
+/// <see cref="ConversationLogView"/>).
+/// </summary>
+/// <param name="UserId">
+/// The runner's user id — also the <c>Conversation</c> stream id. Carried on the
+/// event (mirroring <c>OnboardingStarted</c> / <c>PlanGenerated</c>) so the
+/// projection's <c>Create</c> can seed <see cref="ConversationView.Id"/> without
+/// reading Marten stream metadata.
+/// </param>
+/// <param name="TurnId">
+/// The client-generated message id (a GUID) that uniquely identifies this user
+/// turn. Doubles as the idempotency key for the user-turn write so a retried POST
+/// never double-appends.
+/// </param>
+/// <param name="Content">The runner's message text (sanitized at the prompt boundary, not here).</param>
+public sealed record UserMessagePosted(
+    Guid UserId,
+    Guid TurnId,
+    string Content);

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/ConversationTimelineControllerIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/ConversationTimelineControllerIntegrationTests.cs
@@ -1,0 +1,297 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using FluentAssertions;
+using Marten;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using RunCoach.Api.Infrastructure;
+using RunCoach.Api.Modules.Coaching.Conversation;
+using RunCoach.Api.Modules.Coaching.Onboarding.Entities;
+using RunCoach.Api.Modules.Identity.Entities;
+using RunCoach.Api.Modules.Training.Adaptation;
+using RunCoach.Api.Modules.Training.Plan;
+using RunCoach.Api.Modules.Training.Plan.Models;
+using RunCoach.Api.Modules.Training.Safety;
+using RunCoach.Api.Tests.Infrastructure;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Integration coverage for the composed timeline endpoint
+/// <c>GET /api/v1/conversation/timeline</c> (Slice 4B Unit 3, DEC-085). Drives the
+/// real <see cref="RunCoachAppFactory"/> SUT so the CookieOrBearer gate, the
+/// user-scoped interactive <see cref="ConversationView"/> load, the EF
+/// <c>CurrentPlanId</c> resolve, and the plan-scoped <see cref="ConversationLogView"/>
+/// union are exercised end-to-end. The read is a GET (no antiforgery), user-scoped via
+/// the tenanted Marten session.
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public class ConversationTimelineControllerIntegrationTests(RunCoachAppFactory factory)
+    : DbBackedIntegrationTestBase(factory)
+{
+    private static readonly Uri BaseUri = new("https://localhost");
+    private static readonly DateTimeOffset PlanGeneratedAt = new(2026, 4, 25, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task GetTimeline_Anonymous_Returns401()
+    {
+        // Arrange
+        using var client = CreateAnonymousClient(Factory);
+
+        // Act
+        var response = await client.GetAsync("/api/v1/conversation/timeline", TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetTimeline_NoActivePlan_ReturnsInteractiveTurnsOnly_OldestFirst()
+    {
+        // Arrange — a runner with interactive turns but no active plan. The bearer GET
+        // carries no antiforgery token (it is a read) and must still succeed.
+        var userId = await SeedUserAsync();
+        await SeedUserProfileAsync(userId, currentPlanId: null);
+        await SeedInteractiveTurnsAsync(userId, "What's on for today?", "Easy 5, keep it conversational.");
+        using var client = CreateBearerClient(Factory, MintBearerToken(userId));
+
+        // Act
+        var body = await GetTimelineAsync(client);
+
+        // Assert — both interactive turns, oldest-first, no proactive turns.
+        body.Turns.Should().HaveCount(2);
+        body.Turns.Should().BeInAscendingOrder(t => t.CreatedAt, because: "the chat composer renders oldest-first");
+        body.Turns[0].Kind.Should().Be(ConversationTimelineTurnKind.User);
+        body.Turns[0].Interactive!.Content.Should().Be("What's on for today?");
+        body.Turns[0].Proactive.Should().BeNull();
+        body.Turns[1].Kind.Should().Be(ConversationTimelineTurnKind.Coach);
+        body.Turns[1].Interactive!.Content.Should().Be("Easy 5, keep it conversational.");
+    }
+
+    [Fact]
+    public async Task GetTimeline_UnionsInteractiveAndProactiveTurns_OldestFirst()
+    {
+        // Arrange — interactive turns first, then a proactive adaptation on the plan
+        // stream (a later, separate transaction → a later timestamp).
+        var userId = await SeedUserAsync();
+        var planId = Guid.NewGuid();
+        await SeedPlanStreamAsync(userId, planId);
+        await SeedInteractiveTurnsAsync(userId, "Logged my long run, felt strong.", "Good — that earns Tuesday's tempo.");
+        var adaptationLogId = Guid.NewGuid();
+        await AppendProactiveAsync(userId, planId, new PlanAdaptedFromLog(
+            adaptationLogId,
+            AdaptationKind.Nudge,
+            EscalationLevel.MicroAdjust,
+            SafetyTier.Green,
+            "Bumped Tuesday's tempo a notch.",
+            PlanAdaptationDiff.Empty));
+        await SeedUserProfileAsync(userId, currentPlanId: planId);
+        using var client = CreateBearerClient(Factory, MintBearerToken(userId));
+
+        // Act
+        var body = await GetTimelineAsync(client);
+
+        // Assert — three turns, oldest-first, unioning interactive + proactive.
+        body.Turns.Should().HaveCount(3);
+        body.Turns.Should().BeInAscendingOrder(t => t.CreatedAt);
+        body.Turns[0].Kind.Should().Be(ConversationTimelineTurnKind.User);
+        body.Turns[1].Kind.Should().Be(ConversationTimelineTurnKind.Coach);
+
+        var proactiveTurn = body.Turns[2];
+        proactiveTurn.Kind.Should().Be(ConversationTimelineTurnKind.Adaptation);
+        proactiveTurn.Interactive.Should().BeNull();
+        proactiveTurn.Proactive.Should().NotBeNull(because: "the proactive turn reuses the existing adaptation turn shape");
+        proactiveTurn.Proactive!.Role.Should().Be(ConversationRole.AssistantAdaptation);
+        proactiveTurn.Proactive.AdaptationKind.Should().Be(AdaptationKind.Nudge);
+        proactiveTurn.Proactive.TriggeringWorkoutLogId.Should().Be(adaptationLogId);
+    }
+
+    [Fact]
+    public async Task GetTimeline_InteractiveTurns_SurvivePlanRegeneration()
+    {
+        // Arrange — interactive turns + a proactive adaptation under plan A.
+        var userId = await SeedUserAsync();
+        var planA = Guid.NewGuid();
+        await SeedPlanStreamAsync(userId, planA);
+        await SeedInteractiveTurnsAsync(userId, "Are we still on track for the half?", "Yes — the build's holding.");
+        await AppendProactiveAsync(userId, planA, new PlanAdaptedFromLog(
+            Guid.NewGuid(), AdaptationKind.Nudge, EscalationLevel.MicroAdjust, SafetyTier.Green, "A's nudge.", PlanAdaptationDiff.Empty));
+        await SeedUserProfileAsync(userId, currentPlanId: planA);
+        using var client = CreateBearerClient(Factory, MintBearerToken(userId));
+
+        var before = await GetTimelineAsync(client);
+        before.Turns.Should().HaveCount(3, because: "two interactive turns + one proactive turn under plan A");
+
+        // Act — regenerate to plan B (a fresh plan-scoped log, no proactive turns).
+        var planB = Guid.NewGuid();
+        await SeedPlanStreamAsync(userId, planB);
+        await UpdateCurrentPlanAsync(userId, planB);
+
+        // Assert — the interactive turns survive; the plan A proactive turn is gone.
+        var after = await GetTimelineAsync(client);
+        after.Turns.Should().HaveCount(2, because: "the interactive conversation persists across plan regeneration; proactive turns reset");
+        after.Turns.Should().OnlyContain(
+            t => t.Kind == ConversationTimelineTurnKind.User || t.Kind == ConversationTimelineTurnKind.Coach,
+            because: "only the user-scoped interactive turns remain after the plan reset");
+    }
+
+    [Fact]
+    public async Task GetTimeline_OtherRunnersInteractiveTurns_NotVisible()
+    {
+        // Arrange — runner A has interactive turns; runner B (the caller) has none.
+        // Conjoined tenancy keys the interactive ConversationView by user id, so B's
+        // tenanted session can never load A's conversation.
+        var userAId = await SeedUserAsync();
+        await SeedInteractiveTurnsAsync(userAId, "A's question", "A's answer");
+        await SeedUserProfileAsync(userAId, currentPlanId: null);
+
+        var userBId = await SeedUserAsync();
+        await SeedUserProfileAsync(userBId, currentPlanId: null);
+        using var client = CreateBearerClient(Factory, MintBearerToken(userBId));
+
+        // Act
+        var body = await GetTimelineAsync(client);
+
+        // Assert
+        body.Turns.Should().BeEmpty(because: "the timeline is user-scoped — B never sees A's interactive turns");
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        await Factory.Services.ResetAllMartenDataAsync();
+        await base.DisposeAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    private static async Task<ConversationTimelineDto> GetTimelineAsync(HttpClient client)
+    {
+        var response = await client.GetAsync("/api/v1/conversation/timeline", TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ConversationTimelineDto>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        body.Should().NotBeNull();
+        return body!;
+    }
+
+    private static HttpClient CreateAnonymousClient(RunCoachAppFactory factory)
+    {
+        var client = factory.CreateClient();
+        client.BaseAddress = BaseUri;
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        return client;
+    }
+
+    private static HttpClient CreateBearerClient(RunCoachAppFactory factory, string token)
+    {
+        var client = CreateAnonymousClient(factory);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private static string MintBearerToken(Guid userId)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(RunCoachAppFactory.TestJwtSigningKey))
+        {
+            KeyId = RunCoachAppFactory.TestJwtKeyId,
+        };
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: RunCoachAppFactory.TestJwtIssuer,
+            audience: RunCoachAppFactory.TestJwtAudience,
+            claims: [new Claim(JwtRegisteredClaimNames.Sub, userId.ToString())],
+            notBefore: DateTime.UtcNow,
+            expires: DateTime.UtcNow.AddMinutes(5),
+            signingCredentials: credentials);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private async Task<Guid> SeedUserAsync()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var email = $"timeline-{Guid.NewGuid():N}@example.test";
+        var user = new ApplicationUser { Email = email, UserName = email };
+        var result = await users.CreateAsync(user, "Str0ngTestPassw0rd!");
+        result.Succeeded.Should()
+            .BeTrue(because: $"seed must succeed — got [{string.Join(", ", result.Errors.Select(e => e.Code))}]");
+        return user.Id;
+    }
+
+    private async Task SeedUserProfileAsync(Guid userId, Guid? currentPlanId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<RunCoachDbContext>();
+        var now = DateTimeOffset.UtcNow;
+        db.RunnerOnboardingProfiles.Add(new RunnerOnboardingProfile
+        {
+            UserId = userId,
+            CurrentPlanId = currentPlanId,
+            CreatedOn = now,
+            ModifiedOn = now,
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task UpdateCurrentPlanAsync(Guid userId, Guid currentPlanId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<RunCoachDbContext>();
+
+        // Call EF Core's SingleAsync via the explicit class — both Marten and EF Core
+        // expose a SingleAsync extension, so an unqualified call is ambiguous.
+        var profile = await EntityFrameworkQueryableExtensions.SingleAsync(
+            db.RunnerOnboardingProfiles.Where(p => p.UserId == userId),
+            TestContext.Current.CancellationToken);
+        profile.CurrentPlanId = currentPlanId;
+        profile.ModifiedOn = DateTimeOffset.UtcNow;
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task SeedInteractiveTurnsAsync(Guid userId, string userMessage, string coachMessage)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+
+        // Durable-first user turn (creates the stream), then the coach turn — separate
+        // transactions, mirroring the two-write persistence so timestamps are distinct.
+        await using (var session = store.LightweightSession(userId.ToString()))
+        {
+            session.Events.StartStream<ConversationView>(userId, new UserMessagePosted(userId, Guid.NewGuid(), userMessage));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = store.LightweightSession(userId.ToString()))
+        {
+            session.Events.Append(userId, new CoachMessagePosted(userId, Guid.NewGuid(), coachMessage, false));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    private async Task SeedPlanStreamAsync(Guid userId, Guid planId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        var sequence = StubPlanGenerationService.BuildCanonicalSequence(
+            planId, userId, goal: "Half Marathon", PlanGeneratedAt, previousPlanId: null);
+        session.Events.StartStream<PlanProjectionDto>(planId, [.. sequence.ToEvents()]);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task AppendProactiveAsync(Guid userId, Guid planId, params object[] events)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        session.Events.Append(planId, events);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/ConversationTurnHandlersIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/ConversationTurnHandlersIntegrationTests.cs
@@ -9,8 +9,8 @@ namespace RunCoach.Api.Tests.Modules.Coaching.Conversation;
 
 /// <summary>
 /// Integration coverage for the two-write interactive-turn persistence handlers
-/// (Slice 4B Unit 3, DEC-085) driven through the live Wolverine bus the SSE endpoint
-/// will use (PR4) — <see cref="PostUserConversationTurn"/> then
+/// (Slice 4B Unit 3, DEC-085) driven through the live Wolverine bus —
+/// <see cref="PostUserConversationTurn"/> then
 /// <see cref="PostCoachConversationTurn"/>. Proves the user turn is durable-first, the
 /// coach turn appends on completion, and each write is independently idempotent on its
 /// own key (client id for the user turn, server-derived id for the coach turn) — two

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/ConversationTurnHandlersIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/ConversationTurnHandlersIntegrationTests.cs
@@ -1,0 +1,144 @@
+using FluentAssertions;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using RunCoach.Api.Modules.Coaching.Conversation;
+using RunCoach.Api.Tests.Infrastructure;
+using Wolverine;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Integration coverage for the two-write interactive-turn persistence handlers
+/// (Slice 4B Unit 3, DEC-085) driven through the live Wolverine bus the SSE endpoint
+/// will use (PR4) — <see cref="PostUserConversationTurn"/> then
+/// <see cref="PostCoachConversationTurn"/>. Proves the user turn is durable-first, the
+/// coach turn appends on completion, and each write is independently idempotent on its
+/// own key (client id for the user turn, server-derived id for the coach turn) — two
+/// separate idempotent writes, never one transaction spanning the stream.
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public class ConversationTurnHandlersIntegrationTests(RunCoachAppFactory factory)
+    : DbBackedIntegrationTestBase(factory)
+{
+    [Fact]
+    public async Task PostUserTurn_ThenPostCoachTurn_AsTwoSeparateWrites_MaterializeTwoTurns()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var clientMessageId = Guid.NewGuid();
+
+        // Act — two separate bus invocations (two transactions), durable-first.
+        var userResponse = await PostUserTurnAsync(userId, clientMessageId, "Did my 5 easy, knee felt tight.");
+        var coachResponse = await PostCoachTurnAsync(userId, clientMessageId, "Noted — ice it; we'll watch Thursday.", isErrored: false);
+
+        // Assert — the responses carry the expected turn ids (client id / derived id).
+        userResponse.TurnId.Should().Be(clientMessageId);
+        coachResponse.TurnId.Should().Be(
+            ConversationTurnId.DeriveCoachTurnId(clientMessageId),
+            because: "the coach turn id is derived deterministically from the user turn's client id");
+
+        // Assert — the view holds both turns in order.
+        var view = await LoadConversationAsync(userId);
+        view!.Turns.Should().HaveCount(2);
+        view.Turns[0].Participant.Should().Be(ConversationParticipant.User);
+        view.Turns[0].TurnId.Should().Be(clientMessageId);
+        view.Turns[1].Participant.Should().Be(ConversationParticipant.Coach);
+        view.Turns[1].Content.Should().Be("Noted — ice it; we'll watch Thursday.");
+    }
+
+    [Fact]
+    public async Task PostUserTurn_Twice_IsIdempotentOnClientMessageId()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var clientMessageId = Guid.NewGuid();
+
+        // Act — a retried user-turn POST (same client id).
+        var first = await PostUserTurnAsync(userId, clientMessageId, "How's my week look?");
+        var second = await PostUserTurnAsync(userId, clientMessageId, "How's my week look?");
+
+        // Assert — one turn, the byte-identical prior response replayed.
+        second.Should().Be(first, because: "the retried write returns the recorded response");
+        var view = await LoadConversationAsync(userId);
+        view!.Turns.Should().ContainSingle().Which.Participant.Should().Be(ConversationParticipant.User);
+    }
+
+    [Fact]
+    public async Task PostCoachTurn_Twice_IsIdempotentOnServerDerivedId()
+    {
+        // Arrange — a user turn, then the coach completion delivered twice for the
+        // same user turn (same client id → same derived coach id).
+        var userId = Guid.NewGuid();
+        var clientMessageId = Guid.NewGuid();
+        await PostUserTurnAsync(userId, clientMessageId, "ping");
+
+        // Act
+        var first = await PostCoachTurnAsync(userId, clientMessageId, "first reply", isErrored: false);
+        var second = await PostCoachTurnAsync(userId, clientMessageId, "second reply", isErrored: false);
+
+        // Assert — exactly one coach turn; the duplicate completion did not double-append.
+        second.Should().Be(first);
+        var view = await LoadConversationAsync(userId);
+        view!.Turns.Should().HaveCount(2, because: "one user turn + one coach turn — the duplicate coach write is idempotent");
+        view.Turns.Single(t => t.Participant == ConversationParticipant.Coach).Content.Should().Be("first reply");
+    }
+
+    [Fact]
+    public async Task PostCoachTurn_Errored_PersistsErroredMarker_WithoutPartialText()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var clientMessageId = Guid.NewGuid();
+        await PostUserTurnAsync(userId, clientMessageId, "How's the build going?");
+
+        // Act — the stream died mid-flight: persist an errored marker, not the partial.
+        await PostCoachTurnAsync(userId, clientMessageId, "partial advice cut off", isErrored: true);
+
+        // Assert
+        var view = await LoadConversationAsync(userId);
+        var coachTurn = view!.Turns.Single(t => t.Participant == ConversationParticipant.Coach);
+        coachTurn.IsErrored.Should().BeTrue();
+        coachTurn.Content.Should().BeEmpty(because: "an errored marker never persists a partial as complete");
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        await Factory.Services.ResetAllMartenDataAsync();
+        await base.DisposeAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<ConversationTurnPostedResponse> PostUserTurnAsync(Guid userId, Guid clientMessageId, string content)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+        return await bus
+            .InvokeForTenantAsync<ConversationTurnPostedResponse>(
+                userId.ToString(),
+                new PostUserConversationTurn(userId, clientMessageId, content),
+                TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<ConversationTurnPostedResponse> PostCoachTurnAsync(Guid userId, Guid clientMessageId, string content, bool isErrored)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+        return await bus
+            .InvokeForTenantAsync<ConversationTurnPostedResponse>(
+                userId.ToString(),
+                new PostCoachConversationTurn(userId, clientMessageId, content, isErrored),
+                TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<ConversationView?> LoadConversationAsync(Guid userId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        return await session.LoadAsync<ConversationView>(userId, TestContext.Current.CancellationToken);
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/ConversationTurnIdTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/ConversationTurnIdTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching.Conversation;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Pure-function tests over <see cref="ConversationTurnId.DeriveCoachTurnId"/> — the
+/// deterministic server-side coach-turn id derived from the user turn's client
+/// message id (Slice 4B Unit 3, DEC-085). The derivation must be stable (a duplicate
+/// completion re-derives the same idempotency key), distinct from the client id (the
+/// user turn already consumed it), and collision-free across distinct client ids.
+/// </summary>
+public sealed class ConversationTurnIdTests
+{
+    private static readonly Guid ClientMessageId = new("11111111-1111-1111-1111-111111111111");
+
+    [Fact]
+    public void DeriveCoachTurnId_IsDeterministic_SameInputSameOutput()
+    {
+        // Act
+        var first = ConversationTurnId.DeriveCoachTurnId(ClientMessageId);
+        var second = ConversationTurnId.DeriveCoachTurnId(ClientMessageId);
+
+        // Assert
+        second.Should().Be(
+            first,
+            because: "a duplicate completion must re-derive the same idempotency key so the coach turn is never double-appended");
+    }
+
+    [Fact]
+    public void DeriveCoachTurnId_DiffersFromClientMessageId()
+    {
+        // Act
+        var actual = ConversationTurnId.DeriveCoachTurnId(ClientMessageId);
+
+        // Assert
+        actual.Should().NotBe(
+            ClientMessageId,
+            because: "the user turn already keyed its idempotency marker on the client id; the coach turn needs a distinct key");
+        actual.Should().NotBe(Guid.Empty, because: "the derived id must be a usable, non-empty GUID");
+    }
+
+    [Fact]
+    public void DeriveCoachTurnId_DistinctClientIds_ProduceDistinctCoachIds()
+    {
+        // Arrange
+        var otherClientId = new Guid("22222222-2222-2222-2222-222222222222");
+
+        // Act
+        var first = ConversationTurnId.DeriveCoachTurnId(ClientMessageId);
+        var second = ConversationTurnId.DeriveCoachTurnId(otherClientId);
+
+        // Assert
+        second.Should().NotBe(
+            first,
+            because: "a re-send with a fresh client id must derive a separate coach turn, not collide with the original");
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/InteractiveConversationProjectionIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/InteractiveConversationProjectionIntegrationTests.cs
@@ -1,0 +1,157 @@
+using FluentAssertions;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using RunCoach.Api.Modules.Coaching.Conversation;
+using RunCoach.Api.Tests.Infrastructure;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Integration coverage for the net-new user-scoped <c>Conversation</c> stream
+/// (Slice 4B Unit 3, DEC-085) over the real <see cref="RunCoachAppFactory"/> SUT +
+/// Testcontainers Postgres: appending <see cref="UserMessagePosted"/> /
+/// <see cref="CoachMessagePosted"/> to the user-keyed stream materializes the inline
+/// <see cref="ConversationView"/> via <see cref="InteractiveConversationProjection"/>.
+/// These fail loudly if either event is unregistered or the projection is not wired
+/// (<c>SkipUnknownEvents=true</c> would otherwise drop an unhandled event silently).
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public class InteractiveConversationProjectionIntegrationTests(RunCoachAppFactory factory)
+    : DbBackedIntegrationTestBase(factory)
+{
+    [Fact]
+    public async Task UserThenCoachMessage_MaterializesTwoInteractiveTurns_KeyedByUserId()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var userTurnId = Guid.NewGuid();
+        var coachTurnId = Guid.NewGuid();
+
+        // Act — durable-first user turn creates the stream; the coach turn appends.
+        await StartConversationAsync(userId, new UserMessagePosted(userId, userTurnId, "Did my 5 easy, knee felt tight."));
+        await AppendConversationAsync(userId, new CoachMessagePosted(userId, coachTurnId, "Noted. Ice it; we'll watch Thursday.", false));
+
+        // Assert — the view is keyed by user id and holds the two turns in order.
+        var view = await LoadConversationAsync(userId);
+        view!.Id.Should().Be(userId);
+        view.UserId.Should().Be(userId);
+        view.Turns.Should().HaveCount(2);
+
+        var first = view.Turns[0];
+        first.Participant.Should().Be(ConversationParticipant.User);
+        first.TurnId.Should().Be(userTurnId);
+        first.Content.Should().Be("Did my 5 easy, knee felt tight.");
+        first.IsErrored.Should().BeFalse();
+        first.CreatedAt.Should().NotBe(default);
+
+        var second = view.Turns[1];
+        second.Participant.Should().Be(ConversationParticipant.Coach);
+        second.TurnId.Should().Be(coachTurnId);
+        second.Content.Should().Be("Noted. Ice it; we'll watch Thursday.");
+    }
+
+    [Fact]
+    public async Task CoachTurn_AppendedTwiceWithSameTurnId_UpsertsToOneTurn()
+    {
+        // Arrange — user turn, then the SAME coach turn id appended twice (two distinct
+        // Marten events). The projection's per-turn-id upsert collapses them to one.
+        var userId = Guid.NewGuid();
+        var coachTurnId = Guid.NewGuid();
+        await StartConversationAsync(userId, new UserMessagePosted(userId, Guid.NewGuid(), "ping"));
+
+        // Act
+        await AppendConversationAsync(userId, new CoachMessagePosted(userId, coachTurnId, "first", false));
+        await AppendConversationAsync(userId, new CoachMessagePosted(userId, coachTurnId, "second", false));
+
+        // Assert — one user + one coach turn; the coach turn carries the latest payload.
+        var view = await LoadConversationAsync(userId);
+        view!.Turns.Should().HaveCount(2, because: "the duplicate coach turn id upserts in place");
+        var coachTurn = view.Turns.Single(t => t.Participant == ConversationParticipant.Coach);
+        coachTurn.TurnId.Should().Be(coachTurnId);
+        coachTurn.Content.Should().Be("second");
+    }
+
+    [Fact]
+    public async Task ErroredCoachTurn_MaterializesErroredTurn_NeverComplete()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        await StartConversationAsync(userId, new UserMessagePosted(userId, Guid.NewGuid(), "How's the build going?"));
+
+        // Act — a mid-flight failure persists an errored marker carrying no usable text.
+        await AppendConversationAsync(
+            userId,
+            new CoachMessagePosted(userId, Guid.NewGuid(), "partial advice cut off mid-sentence", true));
+
+        // Assert
+        var view = await LoadConversationAsync(userId);
+        var coachTurn = view!.Turns.Single(t => t.Participant == ConversationParticipant.Coach);
+        coachTurn.IsErrored.Should().BeTrue();
+        coachTurn.Content.Should().BeEmpty(because: "an errored marker never renders partial coaching advice as complete");
+        view.Turns.Should().NotContain(
+            t => t.Participant == ConversationParticipant.Coach && !t.IsErrored,
+            because: "no complete coach turn is materialized for the failed message");
+    }
+
+    [Fact]
+    public async Task IdempotentReplay_AggregatingTheStream_YieldsExactlyOneTurnPerEvent()
+    {
+        // Arrange — one user + one coach turn on the stream.
+        var userId = Guid.NewGuid();
+        await StartConversationAsync(userId, new UserMessagePosted(userId, Guid.NewGuid(), "morning"));
+        await AppendConversationAsync(userId, new CoachMessagePosted(userId, Guid.NewGuid(), "morning — easy day today", false));
+
+        var inline = await LoadConversationAsync(userId);
+        inline!.Turns.Should().HaveCount(2);
+
+        // Act — live-aggregate the stream from scratch through the projection.
+        using var scope = Factory.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        var replayed = await session.Events.AggregateStreamAsync<ConversationView>(
+            userId,
+            token: TestContext.Current.CancellationToken);
+
+        // Assert — replay yields exactly one turn per event, no duplicates.
+        replayed.Should().NotBeNull();
+        replayed!.Turns.Should().HaveCount(2, because: "replay produces exactly one turn per event");
+        replayed.Turns.Select(t => t.TurnId).Should().OnlyHaveUniqueItems();
+        replayed.Turns.Should().ContainSingle(t => t.Participant == ConversationParticipant.User);
+        replayed.Turns.Should().ContainSingle(t => t.Participant == ConversationParticipant.Coach);
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        await Factory.Services.ResetAllMartenDataAsync();
+        await base.DisposeAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task StartConversationAsync(Guid userId, params object[] events)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        session.Events.StartStream<ConversationView>(userId, events);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task AppendConversationAsync(Guid userId, params object[] events)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        session.Events.Append(userId, events);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<ConversationView?> LoadConversationAsync(Guid userId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        return await session.LoadAsync<ConversationView>(userId, TestContext.Current.CancellationToken);
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/InteractiveConversationProjectionTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/InteractiveConversationProjectionTests.cs
@@ -1,0 +1,147 @@
+using FluentAssertions;
+using JasperFx.Events;
+using RunCoach.Api.Infrastructure;
+using RunCoach.Api.Modules.Coaching.Conversation;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Pure-function tests over the <see cref="InteractiveConversationProjection"/>
+/// Create/Apply methods and the event-type registration (Slice 4B Unit 3, DEC-085).
+/// The Marten wiring (inline projection over a real stream) is covered by
+/// <see cref="InteractiveConversationProjectionIntegrationTests"/>; these exercise the
+/// in-memory view mutation directly, including the per-turn-id <c>Upsert</c> dedup
+/// that backstops the two-write handler idempotency.
+/// </summary>
+public sealed class InteractiveConversationProjectionTests
+{
+    private static readonly Guid UserId = new("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly DateTimeOffset CreatedAt = new(2026, 6, 24, 9, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Create_FromUserMessage_SeedsViewKeyedByUserId_WithFirstTurn()
+    {
+        // Arrange
+        var turnId = Guid.NewGuid();
+        var @event = UserEvent(turnId, "Did my 5 easy, knee felt tight.", version: 1);
+
+        // Act
+        var view = InteractiveConversationProjection.Create(@event);
+
+        // Assert — the stream id (= user id) becomes the document identity, and the
+        // first user turn is recorded.
+        view.Id.Should().Be(UserId, because: "the user-scoped stream is keyed by user id");
+        view.UserId.Should().Be(UserId);
+        var turn = view.Turns.Should().ContainSingle().Subject;
+        turn.TurnId.Should().Be(turnId);
+        turn.Participant.Should().Be(ConversationParticipant.User);
+        turn.Content.Should().Be("Did my 5 easy, knee felt tight.");
+        turn.IsErrored.Should().BeFalse();
+        turn.EventVersion.Should().Be(1);
+        turn.CreatedAt.Should().Be(CreatedAt);
+    }
+
+    [Fact]
+    public void Apply_UserThenCoach_AppendsBothTurnsInOrder()
+    {
+        // Arrange
+        var userTurnId = Guid.NewGuid();
+        var coachTurnId = Guid.NewGuid();
+        var view = InteractiveConversationProjection.Create(UserEvent(userTurnId, "How's my week look?", version: 1));
+
+        // Act
+        InteractiveConversationProjection.Apply(
+            CoachEvent(coachTurnId, "Solid. Tempo holds Thursday.", isErrored: false, version: 2),
+            view);
+
+        // Assert
+        view.Turns.Should().HaveCount(2);
+        view.Turns[0].Participant.Should().Be(ConversationParticipant.User);
+        view.Turns[1].Participant.Should().Be(ConversationParticipant.Coach);
+        view.Turns[1].TurnId.Should().Be(coachTurnId);
+        view.Turns[1].Content.Should().Be("Solid. Tempo holds Thursday.");
+    }
+
+    [Fact]
+    public void Apply_CoachWithSameTurnId_ReplacesInPlace_OneTurn()
+    {
+        // Arrange — the per-turn-id dedup overwrites a turn re-applied under the same
+        // id (replay, or a duplicate coach append the handler idempotency should have
+        // caught) rather than appending a duplicate.
+        var coachTurnId = Guid.NewGuid();
+        var view = InteractiveConversationProjection.Create(UserEvent(Guid.NewGuid(), "ping", version: 1));
+
+        // Act
+        InteractiveConversationProjection.Apply(CoachEvent(coachTurnId, "first", isErrored: false, version: 2), view);
+        InteractiveConversationProjection.Apply(CoachEvent(coachTurnId, "second", isErrored: false, version: 2), view);
+
+        // Assert — still one coach turn, carrying the replacement payload.
+        view.Turns.Should().HaveCount(2, because: "the duplicate coach id replaces in place rather than appending");
+        var coachTurn = view.Turns.Single(t => t.Participant == ConversationParticipant.Coach);
+        coachTurn.TurnId.Should().Be(coachTurnId);
+        coachTurn.Content.Should().Be("second");
+    }
+
+    [Fact]
+    public void Apply_ErroredCoach_MaterializesErroredTurn_WithEmptyContent()
+    {
+        // Arrange
+        var view = InteractiveConversationProjection.Create(UserEvent(Guid.NewGuid(), "ping", version: 1));
+
+        // Act — a mid-flight failure persists an errored marker; its partial text must
+        // never render as a complete reply.
+        InteractiveConversationProjection.Apply(
+            CoachEvent(Guid.NewGuid(), "partial text that must be discarded", isErrored: true, version: 2),
+            view);
+
+        // Assert
+        var coachTurn = view.Turns.Single(t => t.Participant == ConversationParticipant.Coach);
+        coachTurn.IsErrored.Should().BeTrue();
+        coachTurn.Content.Should().BeEmpty(because: "a truncated reply is never stored as complete content");
+        view.Turns.Should().NotContain(
+            t => t.Participant == ConversationParticipant.Coach && !t.IsErrored,
+            because: "no complete coach turn is materialized for an errored message");
+    }
+
+    [Fact]
+    public void Apply_DistinctTurnIds_AppendOneTurnEach()
+    {
+        // Arrange
+        var view = InteractiveConversationProjection.Create(UserEvent(Guid.NewGuid(), "one", version: 1));
+
+        // Act
+        InteractiveConversationProjection.Apply(CoachEvent(Guid.NewGuid(), "two", isErrored: false, version: 2), view);
+        InteractiveConversationProjection.Apply(UserEvent(Guid.NewGuid(), "three", version: 3), view);
+
+        // Assert
+        view.Turns.Should().HaveCount(3);
+        view.Turns.Select(t => t.TurnId).Should().OnlyHaveUniqueItems();
+        view.Turns.Select(t => t.EventVersion).Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public void RegisteredEventTypes_IncludesInteractiveConversationEvents()
+    {
+        // The composition guard (MartenStoreOptionsCompositionTests) tags every
+        // registered event `_v1`; this asserts the two interactive events are actually
+        // on that list, so removing either fails here (DEC-067 registration hygiene).
+        MartenConfiguration.RegisteredEventTypes.Should().Contain(typeof(UserMessagePosted));
+        MartenConfiguration.RegisteredEventTypes.Should().Contain(typeof(CoachMessagePosted));
+    }
+
+    private static Event<UserMessagePosted> UserEvent(Guid turnId, string content, long version) =>
+        new(new UserMessagePosted(UserId, turnId, content))
+        {
+            Id = Guid.NewGuid(),
+            Version = version,
+            Timestamp = CreatedAt,
+        };
+
+    private static Event<CoachMessagePosted> CoachEvent(Guid turnId, string content, bool isErrored, long version) =>
+        new(new CoachMessagePosted(UserId, turnId, content, isErrored))
+        {
+            Id = Guid.NewGuid(),
+            Version = version,
+            Timestamp = CreatedAt,
+        };
+}

--- a/frontend/src/app/api/generated/rtk/api.ts
+++ b/frontend/src/app/api/generated/rtk/api.ts
@@ -52,6 +52,12 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: () => ({ url: `/api/v1/conversation/turns` }),
     }),
+    getApiV1ConversationTimeline: build.query<
+      GetApiV1ConversationTimelineApiResponse,
+      GetApiV1ConversationTimelineApiArg
+    >({
+      query: () => ({ url: `/api/v1/conversation/timeline` }),
+    }),
     postApiV1OnboardingTurns: build.mutation<
       PostApiV1OnboardingTurnsApiResponse,
       PostApiV1OnboardingTurnsApiArg
@@ -135,6 +141,8 @@ export type PostApiV1ClientErrorsApiArg = {
 }
 export type GetApiV1ConversationTurnsApiResponse = /** status 200 OK */ ConversationTurnsResponseDto
 export type GetApiV1ConversationTurnsApiArg = void
+export type GetApiV1ConversationTimelineApiResponse = /** status 200 OK */ ConversationTimelineDto
+export type GetApiV1ConversationTimelineApiArg = void
 export type PostApiV1OnboardingTurnsApiResponse = /** status 200 OK */ OnboardingTurnResponseDto
 export type PostApiV1OnboardingTurnsApiArg = {
   onboardingTurnRequestDto: OnboardingTurnRequestDto
@@ -284,6 +292,21 @@ export type ConversationTurnDto = {
 }
 export type ConversationTurnsResponseDto = {
   turns: ConversationTurnDto[]
+}
+export type ConversationTimelineTurnKind = 0 | 1 | 2 | 3
+export type InteractiveTurnDto = {
+  content: string
+  isErrored: boolean
+}
+export type ConversationTimelineTurnDto = {
+  kind: ConversationTimelineTurnKind
+  turnId: string
+  createdAt: string
+  interactive: InteractiveTurnDto
+  proactive: ConversationTurnDto
+}
+export type ConversationTimelineDto = {
+  turns: ConversationTimelineTurnDto[]
 }
 export type OnboardingTurnKind = 0 | 1 | 2
 export type OnboardingTopic = 0 | 1 | 2 | 3 | 4 | 5
@@ -542,6 +565,7 @@ export const {
   usePostApiV1AuthLogoutMutation,
   usePostApiV1ClientErrorsMutation,
   useGetApiV1ConversationTurnsQuery,
+  useGetApiV1ConversationTimelineQuery,
   usePostApiV1OnboardingTurnsMutation,
   useGetApiV1OnboardingStateQuery,
   usePostApiV1OnboardingAnswersReviseMutation,

--- a/frontend/src/app/api/generated/zod/conversation/conversation.ts
+++ b/frontend/src/app/api/generated/zod/conversation/conversation.ts
@@ -198,3 +198,225 @@ export const GetApiV1ConversationTurnsResponse = zod.strictObject({
     }),
   ),
 })
+
+export const GetApiV1ConversationTimelineResponse = zod.strictObject({
+  turns: zod.array(
+    zod.strictObject({
+      kind: zod.union([zod.literal(0), zod.literal(1), zod.literal(2), zod.literal(3)]),
+      turnId: zod.uuid(),
+      createdAt: zod.iso.datetime({ offset: true }),
+      interactive: zod.strictObject({
+        content: zod.string(),
+        isErrored: zod.boolean(),
+      }),
+      proactive: zod.strictObject({
+        triggeringPlanEventId: zod.uuid(),
+        role: zod.union([zod.literal(0), zod.literal(1)]),
+        content: zod.string(),
+        escalationLevel: zod.union([
+          zod.literal(0),
+          zod.literal(1),
+          zod.literal(2),
+          zod.literal(3),
+          zod.literal(4),
+        ]),
+        safetyTier: zod.union([zod.literal(0), zod.literal(1), zod.literal(2)]),
+        referralCategory: zod.union([
+          zod.literal(0),
+          zod.literal(1),
+          zod.literal(2),
+          zod.literal(3),
+          zod.literal(4),
+        ]),
+        adaptationKind: zod.union([zod.literal(0), zod.literal(1), zod.literal(2)]),
+        diff: zod.strictObject({
+          workoutChanges: zod.array(
+            zod.strictObject({
+              weekNumber: zod.number(),
+              dayOfWeek: zod.number(),
+              before: zod.strictObject({
+                dayOfWeek: zod
+                  .number()
+                  .describe(
+                    'The day of the week as an integer: 0 = Sunday, 1 = Monday, ..., 6 = Saturday.',
+                  ),
+                workoutType: zod.enum([
+                  'Easy',
+                  'LongRun',
+                  'Tempo',
+                  'Interval',
+                  'Repetition',
+                  'Recovery',
+                  'CrossTrain',
+                ]),
+                title: zod
+                  .string()
+                  .describe(
+                    "A descriptive title for this workout, such as 'Easy Aerobic Run' or 'Threshold Intervals'.",
+                  ),
+                targetDistanceKm: zod
+                  .number()
+                  .describe('Target total distance for this workout in kilometers.'),
+                targetDurationMinutes: zod
+                  .number()
+                  .describe('Target total duration for this workout in minutes.'),
+                targetPaceEasySecPerKm: zod
+                  .number()
+                  .describe(
+                    'Target easy pace in seconds per kilometer for easy portions of this workout.',
+                  ),
+                targetPaceFastSecPerKm: zod
+                  .number()
+                  .describe(
+                    'Target fast pace in seconds per kilometer for hard portions of this workout.',
+                  ),
+                segments: zod
+                  .array(
+                    zod.strictObject({
+                      segmentType: zod.enum(['Warmup', 'Work', 'Recovery', 'Cooldown']),
+                      durationMinutes: zod
+                        .number()
+                        .describe('Duration of this segment in minutes.'),
+                      targetPaceSecPerKm: zod
+                        .number()
+                        .describe('Target pace in seconds per kilometer for this segment.'),
+                      intensity: zod.enum([
+                        'Easy',
+                        'Moderate',
+                        'Threshold',
+                        'VO2Max',
+                        'Repetition',
+                      ]),
+                      repetitions: zod
+                        .number()
+                        .describe(
+                          'Number of repetitions for interval segments, or 1 for continuous efforts.',
+                        ),
+                      notes: zod
+                        .string()
+                        .describe(
+                          'Coaching notes for this segment, such as effort cues or technique reminders.',
+                        ),
+                    }),
+                  )
+                  .describe(
+                    'The structured segments that make up this workout (warmup, work intervals, cooldown, etc.).',
+                  ),
+                warmupNotes: zod
+                  .string()
+                  .describe('Specific warmup instructions for this workout.'),
+                cooldownNotes: zod
+                  .string()
+                  .describe('Specific cooldown instructions for this workout.'),
+                coachingNotes: zod
+                  .string()
+                  .describe(
+                    'Coaching notes explaining the purpose and execution guidance for this workout.',
+                  ),
+                perceivedEffort: zod
+                  .number()
+                  .describe(
+                    'Expected perceived effort on a 1-10 scale, where 1 is very easy and 10 is maximal.',
+                  ),
+              }),
+              after: zod.strictObject({
+                dayOfWeek: zod
+                  .number()
+                  .describe(
+                    'The day of the week as an integer: 0 = Sunday, 1 = Monday, ..., 6 = Saturday.',
+                  ),
+                workoutType: zod.enum([
+                  'Easy',
+                  'LongRun',
+                  'Tempo',
+                  'Interval',
+                  'Repetition',
+                  'Recovery',
+                  'CrossTrain',
+                ]),
+                title: zod
+                  .string()
+                  .describe(
+                    "A descriptive title for this workout, such as 'Easy Aerobic Run' or 'Threshold Intervals'.",
+                  ),
+                targetDistanceKm: zod
+                  .number()
+                  .describe('Target total distance for this workout in kilometers.'),
+                targetDurationMinutes: zod
+                  .number()
+                  .describe('Target total duration for this workout in minutes.'),
+                targetPaceEasySecPerKm: zod
+                  .number()
+                  .describe(
+                    'Target easy pace in seconds per kilometer for easy portions of this workout.',
+                  ),
+                targetPaceFastSecPerKm: zod
+                  .number()
+                  .describe(
+                    'Target fast pace in seconds per kilometer for hard portions of this workout.',
+                  ),
+                segments: zod
+                  .array(
+                    zod.strictObject({
+                      segmentType: zod.enum(['Warmup', 'Work', 'Recovery', 'Cooldown']),
+                      durationMinutes: zod
+                        .number()
+                        .describe('Duration of this segment in minutes.'),
+                      targetPaceSecPerKm: zod
+                        .number()
+                        .describe('Target pace in seconds per kilometer for this segment.'),
+                      intensity: zod.enum([
+                        'Easy',
+                        'Moderate',
+                        'Threshold',
+                        'VO2Max',
+                        'Repetition',
+                      ]),
+                      repetitions: zod
+                        .number()
+                        .describe(
+                          'Number of repetitions for interval segments, or 1 for continuous efforts.',
+                        ),
+                      notes: zod
+                        .string()
+                        .describe(
+                          'Coaching notes for this segment, such as effort cues or technique reminders.',
+                        ),
+                    }),
+                  )
+                  .describe(
+                    'The structured segments that make up this workout (warmup, work intervals, cooldown, etc.).',
+                  ),
+                warmupNotes: zod
+                  .string()
+                  .describe('Specific warmup instructions for this workout.'),
+                cooldownNotes: zod
+                  .string()
+                  .describe('Specific cooldown instructions for this workout.'),
+                coachingNotes: zod
+                  .string()
+                  .describe(
+                    'Coaching notes explaining the purpose and execution guidance for this workout.',
+                  ),
+                perceivedEffort: zod
+                  .number()
+                  .describe(
+                    'Expected perceived effort on a 1-10 scale, where 1 is very easy and 10 is maximal.',
+                  ),
+              }),
+            }),
+          ),
+          weeklyTargetChanges: zod.array(
+            zod.strictObject({
+              weekNumber: zod.number(),
+              beforeWeeklyTargetKm: zod.number(),
+              afterWeeklyTargetKm: zod.number(),
+            }),
+          ),
+        }),
+        triggeringWorkoutLogId: zod.uuid(),
+        createdAt: zod.iso.datetime({ offset: true }),
+      }),
+    }),
+  ),
+})


### PR DESCRIPTION
## Slice 4B PR2 — Unit 3 (DEC-085)

Net-new **user-scoped `Conversation` event stream** + inline projection, two-write idempotent persistence handlers, and a composed **`GET /api/v1/conversation/timeline`** read that unions the interactive turns with the current plan's proactive adaptation/safety turns oldest-first. Root PR of the 4B stacked train (sibling of the merged PR1 #219). Ships unreferenced contracts behind an endpoint — PR4 wires the interactive appends.

### What's here
- **Events** `UserMessagePosted` / `CoachMessagePosted` (+ `IsErrored` marker), registered in `MartenConfiguration.RegisteredEventTypes` (auto `_v1`, composition-guard covered).
- **`ConversationView`** keyed by `UserId` via the Marten `Id`-property convention (mirrors `OnboardingView` — the only other user-keyed projection), materialized inline by **`InteractiveConversationProjection`** (upsert-by-`TurnId`, replay-safe). Survives plan regeneration; the shipped plan-scoped `ConversationLogView` is untouched.
- **Two-write persistence** (the co-transactional idempotency model can't span a multi-second stream): `PostUserConversationTurn` (durable-first, idempotent on the client GUID) and `PostCoachConversationTurn` (on completion, idempotent on a server-derived GUID via `ConversationTurnId.DeriveCoachTurnId`); both tenant-scoped Wolverine handlers. An errored marker never stores a partial as complete.
- **`GET /conversation/timeline`** — oldest-first union, no antiforgery, tenanted; reuses the shipped `ConversationTurnDto` for proactive turns via the existing `MapTurn`. The shipped `/turns` read is unchanged.
- **DTO codegen** regenerated (rtk + zod) so PR6 has types.

### Decisions (from the spec/pr-strategy builder checkpoints)
- Sibling `/timeline` (not extending `/turns`); new `ConversationParticipant` enum (not extending `ConversationRole`); oldest-first union.

### Verification
- **Backend: full suite 1870/1870 green** (Replay mode; integration via Testcontainers) — +22 new tests over the 1848 baseline.
- New coverage: id-derivation determinism (unit), projection Create/Apply + upsert dedup + errored marker (unit + integration), Wolverine two-write idempotency (integration), HTTP timeline union / survives-plan-regen / tenant-isolation / auth (integration).
- Frontend `npm run build` + codegen drift clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secured `GET /api/v1/conversation/timeline` endpoint that returns a chronological conversation timeline, combining interactive user/coach turns with plan-related adaptation/safety turns.
  * Timeline responses now include typed turn kinds and detailed metadata for consistent client rendering.
* **Bug Fixes**
  * Improved idempotency to prevent duplicate turns on repeated submissions.
  * Ensures errored coach turns never expose partial completed text; preserves interactive turns across plan regeneration while updating plan-related entries.
* **Documentation**
  * Updated the OpenAPI contract with the new timeline endpoint and related response schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->