### PR TITLE
chore(deps): bump dotnet/sdk and dotnet/aspnet base image digests

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,7 +20,7 @@
 # contributors use Path B (host-run API + Compose for infra only) per
 # CONTRIBUTING.md and DEC-045. Remove this comment and retry Path A on the
 # first .NET 11 SDK bump.
-FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:548d93f8a18a1acbe6cc127bc4f47281430d34a9e35c18afa80a8d6741c2adc3 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5 AS build
 
 # Defensive belt-and-suspenders against #122608-class regressions if this
 # Dockerfile is ever accidentally built on arm64. Exhaustive ARM64 SVE/SVE2
@@ -48,7 +48,7 @@ RUN dotnet restore RunCoach.slnx
 COPY . .
 RUN dotnet publish src/RunCoach.Api/RunCoach.Api.csproj -c Release -o /app/publish --no-restore
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:ddcf70ad1ab963a4fcd41fbd722a6b660e404e87567cfbd46fd2809c21b02088 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:7644f992230d35cf230017189d4038c0ae0f7388b13f4f7ae1900a155bafb597 AS runtime
 
 WORKDIR /app
 COPY --from=build /app/publish .


### PR DESCRIPTION
Bumps both .NET base image digests in `backend/Dockerfile`:
- `dotnet/sdk:10.0` `548d93f` → `ea8bde3` (supersedes #221)
- `dotnet/aspnet:10.0` `ddcf70a` → `7644f99` (supersedes #222)

Combined into one PR because both edit the same Dockerfile and would otherwise rebase-cascade against each other. Closing #221 and #222 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s underlying .NET container images to newer pinned versions for build and runtime.
  * This helps keep the deployment environment current and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->