### PR TITLE
chore(deps): bump backend nuget minor-and-patch group

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -14,7 +14,7 @@
     <!-- API -->
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <!-- Console / Hosting -->
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <!-- Auth — ASP.NET Core authentication -->
@@ -24,26 +24,26 @@
          10.0.7 transitively, which clears GHSA-9mv3-2cwr-p262 / CVE-2026-40372
          (affected <= 10.0.6). The runtime-shared DataProtection is intentionally
          not referenced directly (NU1510: redundant with the shared framework). -->
-    <PackageVersion Include="Aspire.Npgsql" Version="13.4.5" />
+    <PackageVersion Include="Aspire.Npgsql" Version="13.4.6" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <!-- Persistence — Marten + Wolverine (event-sourcing + outbox) -->
-    <PackageVersion Include="Marten" Version="9.9.0" />
-    <PackageVersion Include="Marten.EntityFrameworkCore" Version="9.9.0" />
-    <PackageVersion Include="WolverineFx" Version="6.12.0" />
-    <PackageVersion Include="WolverineFx.EntityFrameworkCore" Version="6.12.0" />
-    <PackageVersion Include="WolverineFx.Marten" Version="6.12.0" />
-    <PackageVersion Include="WolverineFx.RuntimeCompilation" Version="6.12.0" />
+    <PackageVersion Include="Marten" Version="9.10.0" />
+    <PackageVersion Include="Marten.EntityFrameworkCore" Version="9.10.0" />
+    <PackageVersion Include="WolverineFx" Version="6.14.0" />
+    <PackageVersion Include="WolverineFx.EntityFrameworkCore" Version="6.14.0" />
+    <PackageVersion Include="WolverineFx.Marten" Version="6.14.0" />
+    <PackageVersion Include="WolverineFx.RuntimeCompilation" Version="6.14.0" />
     <!-- Observability — OpenTelemetry -->
     <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <!-- LLM / Prompt -->
-    <PackageVersion Include="Anthropic" Version="12.29.1" />
+    <PackageVersion Include="Anthropic" Version="12.31.0" />
     <PackageVersion Include="YamlDotNet" Version="18.0.0" />
     <!-- Configuration (eval tests) -->
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />


### PR DESCRIPTION
Recreates Dependabot #225, which auto-closed when an `update-branch` edit broke its rebase ownership. Same 11 bumps in `backend/Directory.Packages.props`:

- Marten / Marten.EntityFrameworkCore `9.9.0` → `9.10.0`
- WolverineFx (+ EntityFrameworkCore / Marten / RuntimeCompilation) `6.12.0` → `6.14.0`
- Swashbuckle.AspNetCore `10.2.1` → `10.2.3`
- Aspire.Npgsql `13.4.5` → `13.4.6`
- OpenTelemetry.Instrumentation.AspNetCore `1.15.2` → `1.16.0`, .Http `1.15.1` → `1.16.0`
- Anthropic `12.29.1` → `12.31.0`

Verified locally: `dotnet build` clean, no `swagger.json` drift (patch-level Swashbuckle), 89 `ClaudeCoachingLlm*` streaming-adapter tests green against Anthropic 12.31. Full suite gated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)