### PR TITLE
feat(slice-4b): streaming q&a sse endpoint (pr4)

### DIFF
--- a/backend/openapi/swagger.json
+++ b/backend/openapi/swagger.json
@@ -499,7 +499,14 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request",

--- a/backend/openapi/swagger.json
+++ b/backend/openapi/swagger.json
@@ -473,6 +473,83 @@
         ]
       }
     },
+    "/api/v1/conversation/messages": {
+      "post": {
+        "tags": [
+          "Conversation"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConversationMessageRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConversationMessageRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConversationMessageRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": [ ],
+            "bearerAuth": [ ]
+          }
+        ]
+      }
+    },
     "/api/v1/onboarding/turns": {
       "post": {
         "tags": [
@@ -1205,6 +1282,23 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "ConversationMessageRequestDto": {
+        "required": [
+          "clientMessageId",
+          "message"
+        ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "clientMessageId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
       },
       "ConversationRole": {
         "enum": [

--- a/backend/src/RunCoach.Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using RunCoach.Api.Infrastructure.Idempotency;
 using RunCoach.Api.Modules.Coaching;
 using RunCoach.Api.Modules.Coaching.Conversation;
+using RunCoach.Api.Modules.Coaching.Conversation.Streaming;
 using RunCoach.Api.Modules.Coaching.Prompts;
 using RunCoach.Api.Modules.Coaching.Sanitization;
 using RunCoach.Api.Modules.Training.Adaptation;
@@ -102,6 +103,14 @@ public static class ServiceCollectionExtensions
         // Interactive-conversation intent classifier (Slice 4B / DEC-085 D3) — composes the
         // classifier prompt, runs the Pattern-B Haiku triage call, and validates the union.
         services.AddScoped<IMessageIntentClassifier, MessageIntentClassifier>();
+
+        // Streaming Q&A orchestrator (Slice 4B PR4) — the SSE endpoint's integration gate:
+        // safety gate -> classify -> route -> stream, with two-write idempotent persistence.
+        // Scoped (consumes IMessageBus + RunCoachDbContext + a per-request tenanted session).
+        services.Configure<ConversationStreamOptions>(
+            configuration.GetSection(ConversationStreamOptions.SectionName));
+        services.AddScoped<IConversationContextLoader, ConversationContextLoader>();
+        services.AddScoped<IConversationStreamService, ConversationStreamService>();
 
         // Prompt-injection sanitizer (Slice 1 § Unit 6 / DEC-059 / R-068).
         // Stateless layered sanitizer — singleton-safe; the pattern catalog

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/CandidatePrescriptionDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/CandidatePrescriptionDto.cs
@@ -1,0 +1,37 @@
+using RunCoach.Api.Modules.Training.Workouts;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Compact, server-authoritative summary of the prescribed workout a conversational
+/// log draft matched (Slice 4B PR4). Surfaced on the confirmation-card frame so the
+/// runner sees "this matches your scheduled session" before confirming; <c>null</c> on
+/// the card when the run matched no scheduled workout (an off-plan / unscheduled run),
+/// in which case Confirm still commits an off-plan log. Resolved via the unchanged
+/// <c>WorkoutLogService</c> prescription path, never from LLM extraction.
+/// </summary>
+/// <param name="WorkoutType">The prescribed workout type (e.g. Easy, Tempo, Long).</param>
+/// <param name="DistanceMeters">The prescribed total distance in meters.</param>
+/// <param name="DurationSeconds">The prescribed total duration in seconds.</param>
+/// <param name="PaceFastSecPerKm">The fast (lower sec/km) bound of the prescribed pace band.</param>
+/// <param name="PaceEasySecPerKm">The easy (higher sec/km) bound of the prescribed pace band.</param>
+public sealed record CandidatePrescriptionDto(
+    string WorkoutType,
+    double DistanceMeters,
+    double DurationSeconds,
+    double PaceFastSecPerKm,
+    double PaceEasySecPerKm)
+{
+    /// <summary>Projects a server-resolved <see cref="WorkoutPrescriptionSnapshot"/> onto the wire summary.</summary>
+    /// <param name="snapshot">The resolved prescription snapshot, or <c>null</c> for an off-plan run.</param>
+    /// <returns>The compact summary, or <c>null</c> when <paramref name="snapshot"/> is <c>null</c>.</returns>
+    public static CandidatePrescriptionDto? FromSnapshot(WorkoutPrescriptionSnapshot? snapshot) =>
+        snapshot is null
+            ? null
+            : new CandidatePrescriptionDto(
+                snapshot.WorkoutType.ToString(),
+                snapshot.PrescribedDistance.Meters,
+                snapshot.PrescribedDuration.TotalSeconds,
+                snapshot.PrescribedPaceFast.SecondsPerKm,
+                snapshot.PrescribedPaceSlow.SecondsPerKm);
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationController.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationController.cs
@@ -216,12 +216,15 @@ public sealed partial class ConversationController(
                 await writer.WriteEventAsync(frame.EventName, frame, ct);
             }
         }
-        catch (Exception) when (ct.IsCancellationRequested)
+        catch (Exception ex) when (ct.IsCancellationRequested && ex is OperationCanceledException or IOException)
         {
-            // Client disconnected — not a server fault. A mid-stream abort can surface as
-            // an OperationCanceledException OR an IOException (broken pipe / connection
-            // reset) depending on socket timing; both are a clean disconnect once
-            // RequestAborted is signalled, so neither is logged or framed.
+            // Client disconnected — not a server fault. A mid-stream abort surfaces as an
+            // OperationCanceledException OR an IOException (broken pipe / connection reset)
+            // depending on socket timing; both are a clean disconnect once RequestAborted is
+            // signalled, so neither is logged or framed. The filter is narrowed to those two
+            // types (not a bare `catch when (ct.IsCancellationRequested)`) so a genuine bug
+            // thrown during a cancelled request — an NRE, an InvalidCastException — still falls
+            // through to the logging catch below rather than being silently swallowed.
         }
         catch (Exception ex)
         {

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationController.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationController.cs
@@ -34,6 +34,7 @@ public sealed partial class ConversationController(
     ILogger<ConversationController> logger) : ControllerBase
 {
     private const string MissingUserType = "https://runcoach.app/problems/missing-user-claim";
+    private const string InvalidMessageType = "https://runcoach.app/problems/invalid-conversation-message";
 
     /// <summary>GET /api/v1/conversation/turns — read the runner's adaptation + safety turns, newest-first.</summary>
     /// <param name="ct">Request cancellation token.</param>
@@ -170,7 +171,7 @@ public sealed partial class ConversationController(
     /// <returns>An SSE stream; 401 when the user claim is missing; 400 when the antiforgery token is absent.</returns>
     [HttpPost("messages")]
     [RequireAntiforgeryToken]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK, "text/event-stream")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> PostMessage([FromBody] ConversationMessageRequestDto request, CancellationToken ct)
@@ -180,6 +181,17 @@ public sealed partial class ConversationController(
         if (!TryGetUserId(out var userId))
         {
             return MissingUserClaim();
+        }
+
+        // Boundary validation (server-side): a blank message wastes an LLM call, and an
+        // empty client message id would collide every empty-id post on the same derived
+        // idempotency keys. Reject both with a structured 400 before the stream opens.
+        if (string.IsNullOrWhiteSpace(request.Message) || request.ClientMessageId == Guid.Empty)
+        {
+            return Problem(
+                type: InvalidMessageType,
+                title: "The message must be non-empty and carry a non-empty client message id.",
+                statusCode: StatusCodes.Status400BadRequest);
         }
 
         // SSE headers + buffering off, set before the first body write (which starts the
@@ -204,9 +216,12 @@ public sealed partial class ConversationController(
                 await writer.WriteEventAsync(frame.EventName, frame, ct);
             }
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (Exception) when (ct.IsCancellationRequested)
         {
-            // Client disconnected — nothing more to write, and not a server fault.
+            // Client disconnected — not a server fault. A mid-stream abort can surface as
+            // an OperationCanceledException OR an IOException (broken pipe / connection
+            // reset) depending on socket timing; both are a clean disconnect once
+            // RequestAborted is signalled, so neither is logged or framed.
         }
         catch (Exception ex)
         {

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationController.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationController.cs
@@ -1,10 +1,14 @@
 using System.Security.Claims;
 using Marten;
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
 using RunCoach.Api.Infrastructure;
+using RunCoach.Api.Modules.Coaching.Conversation.Streaming;
 
 namespace RunCoach.Api.Modules.Coaching.Conversation;
 
@@ -22,9 +26,12 @@ namespace RunCoach.Api.Modules.Coaching.Conversation;
 [ApiController]
 [Route("api/v1/conversation")]
 [Authorize(Policy = AuthPolicies.CookieOrBearer)]
-public sealed class ConversationController(
+public sealed partial class ConversationController(
     IDocumentStore store,
-    RunCoachDbContext db) : ControllerBase
+    RunCoachDbContext db,
+    IConversationStreamService streamService,
+    IOptions<Microsoft.AspNetCore.Mvc.JsonOptions> jsonOptions,
+    ILogger<ConversationController> logger) : ControllerBase
 {
     private const string MissingUserType = "https://runcoach.app/problems/missing-user-claim";
 
@@ -149,6 +156,85 @@ public sealed class ConversationController(
         return Ok(new ConversationTimelineDto(turns));
     }
 
+    /// <summary>
+    /// POST /api/v1/conversation/messages — the streaming Q&amp;A endpoint (Slice 4B PR4,
+    /// the integration gate). Persists the user turn durable-first, runs the deterministic
+    /// safety gate, classifies intent, and streams the coach's response as Server-Sent
+    /// Events (<c>token</c> / <c>safety</c> / <c>card</c> / <c>error</c> / <c>done</c>
+    /// frames + an opening heartbeat). A mutation (it persists turns) ⇒ antiforgery-protected;
+    /// the response is <c>text/event-stream</c> with buffering off and a flush per frame. A
+    /// client disconnect is a clean abort, never a 500.
+    /// </summary>
+    /// <param name="request">The runner's message + client-generated message id.</param>
+    /// <param name="ct">The request-aborted token (MVC binds it to <c>HttpContext.RequestAborted</c>).</param>
+    /// <returns>An SSE stream; 401 when the user claim is missing; 400 when the antiforgery token is absent.</returns>
+    [HttpPost("messages")]
+    [RequireAntiforgeryToken]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> PostMessage([FromBody] ConversationMessageRequestDto request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryGetUserId(out var userId))
+        {
+            return MissingUserClaim();
+        }
+
+        // SSE headers + buffering off, set before the first body write (which starts the
+        // response). No ResponseCompression middleware is registered, so disabling
+        // buffering alone suffices for incremental delivery.
+        Response.ContentType = "text/event-stream";
+        Response.Headers.CacheControl = "no-cache";
+        HttpContext.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
+
+        var writer = new SseWriter(Response.Body, jsonOptions.Value.JsonSerializerOptions);
+
+        try
+        {
+            // Open with a heartbeat so the connection is alive across the classify +
+            // time-to-first-token gap — the only meaningful idle window, since answer
+            // tokens then flow continuously and keep the connection alive themselves.
+            await writer.WriteHeartbeatAsync(ct);
+            await foreach (var frame in streamService
+                .StreamReplyAsync(userId, request.Message, request.ClientMessageId, ct)
+                .WithCancellation(ct))
+            {
+                await writer.WriteEventAsync(frame.EventName, frame, ct);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Client disconnected — nothing more to write, and not a server fault.
+        }
+        catch (Exception ex)
+        {
+            // The 200 + heartbeat already committed the response, so the exception
+            // middleware can no longer emit a 500. Infrastructure failures (a bus,
+            // Marten, or EF error from the orchestrator) would otherwise drop the
+            // connection silently with no frame — surface a typed, retryable error
+            // frame best-effort instead, then log. CancellationToken.None: ct may
+            // already be cancelled, and this last write must still be attempted.
+            LogUnhandledStreamError(logger, userId, ex);
+            try
+            {
+                await writer.WriteEventAsync(
+                    "error",
+                    new ErrorFrame("Something went wrong on my end. Try again in a moment.", Retryable: true, RetryAfterSeconds: null),
+                    CancellationToken.None);
+            }
+            catch (Exception writeEx) when (writeEx is not OutOfMemoryException and not StackOverflowException)
+            {
+                // The stream may already be broken; nothing more can be done.
+                LogErrorFrameWriteFailed(logger, userId, writeEx);
+            }
+        }
+
+        // The response was written manually; tell MVC not to write a result over it.
+        return new EmptyResult();
+    }
+
     private static ConversationTurnDto MapTurn(ConversationTurnView turn) =>
         new(
             turn.TriggeringPlanEventId,
@@ -185,6 +271,18 @@ public sealed class ConversationController(
                 turn.CreatedAt,
                 Interactive: null,
                 MapTurn(turn)));
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Error,
+        Message = "Unhandled error streaming the conversation reply for user {UserId}; emitting a best-effort error frame")]
+    private static partial void LogUnhandledStreamError(ILogger logger, Guid userId, Exception ex);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Warning,
+        Message = "Failed to write the best-effort error frame for user {UserId}; the SSE stream was already broken")]
+    private static partial void LogErrorFrameWriteFailed(ILogger logger, Guid userId, Exception ex);
 
     private bool TryGetUserId(out Guid userId)
     {

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationMessageRequestDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationMessageRequestDto.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Request body for <c>POST /api/v1/conversation/messages</c> (Slice 4B PR4) — the
+/// streaming Q&amp;A endpoint. Carries the runner's free-text message and a
+/// client-generated message id that keys the durable-first user-turn idempotency marker
+/// (and, derived server-side, the coach reply's). A re-send after a mid-stream failure
+/// uses a <b>fresh</b> <see cref="ClientMessageId"/> (D5), which derives a fresh coach id
+/// so the original errored turn is left intact.
+/// </summary>
+/// <param name="Message">The runner's free-text message. Sanitized server-side before it reaches the safety gate, the classifier, or the answer assembly.</param>
+/// <param name="ClientMessageId">
+/// Client-generated message id (typically <c>crypto.randomUUID()</c>). Marked
+/// <see cref="JsonRequiredAttribute"/> so System.Text.Json refuses to under-post a
+/// default <see cref="Guid"/> when the field is omitted.
+/// </param>
+public sealed record ConversationMessageRequestDto(
+    [property: JsonRequired] string Message,
+    [property: JsonRequired] Guid ClientMessageId);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTurnId.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/ConversationTurnId.cs
@@ -25,13 +25,36 @@ public static class ConversationTurnId
     // idempotency keys would shift.
     private static readonly Guid CoachTurnNamespace = new("7d3f1b2a-9c84-4f6e-b1a2-2c5d6e7f8a90");
 
+    // A second fixed namespace for the scripted safety-referral turn. A distinct
+    // namespace (not the coach namespace) is load-bearing: an Amber chat message
+    // persists BOTH a scripted referral coach turn AND a streamed answer coach turn
+    // off the SAME client message id (Slice 4B PR4). Deriving both from the coach
+    // namespace would collide on the idempotency marker insert and drop one. As with
+    // the coach namespace — arbitrary but stable; never change it.
+    private static readonly Guid SafetyTurnNamespace = new("3a8c5e1d-6f29-4b7a-8d3c-9e1f2a4b6c8d");
+
     /// <summary>Derives the deterministic coach-turn id for a given user-turn client message id.</summary>
     /// <param name="clientMessageId">The user turn's client-generated message id.</param>
     /// <returns>A stable, well-formed GUID distinct from <paramref name="clientMessageId"/>.</returns>
-    public static Guid DeriveCoachTurnId(Guid clientMessageId)
+    public static Guid DeriveCoachTurnId(Guid clientMessageId) =>
+        DeriveTurnId(CoachTurnNamespace, clientMessageId);
+
+    /// <summary>
+    /// Derives the deterministic id for the scripted Amber safety-referral turn that
+    /// accompanies a chat answer (Slice 4B PR4). Idempotent on the user turn's client
+    /// message id and — by using a namespace distinct from
+    /// <see cref="DeriveCoachTurnId"/> — guaranteed not to collide with the answer
+    /// coach turn derived from the same client id, so a re-send appends neither twice.
+    /// </summary>
+    /// <param name="clientMessageId">The user turn's client-generated message id.</param>
+    /// <returns>A stable, well-formed GUID distinct from both <paramref name="clientMessageId"/> and <see cref="DeriveCoachTurnId"/>.</returns>
+    public static Guid DeriveSafetyTurnId(Guid clientMessageId) =>
+        DeriveTurnId(SafetyTurnNamespace, clientMessageId);
+
+    private static Guid DeriveTurnId(Guid turnNamespace, Guid clientMessageId)
     {
         Span<byte> buffer = stackalloc byte[32];
-        _ = CoachTurnNamespace.TryWriteBytes(buffer[..16]);
+        _ = turnNamespace.TryWriteBytes(buffer[..16]);
         _ = clientMessageId.TryWriteBytes(buffer[16..]);
 
         Span<byte> hash = stackalloc byte[32];

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostScriptedSafetyTurn.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostScriptedSafetyTurn.cs
@@ -1,0 +1,15 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Wolverine command (Slice 4B PR4) to persist a scripted safety referral as a coach
+/// turn on the user-scoped <c>Conversation</c> stream — the Amber injury / RED-S referral
+/// that accompanies a chat answer. Distinct from <see cref="PostCoachConversationTurn"/>
+/// because an Amber message persists BOTH this scripted referral and a streamed answer
+/// off the same client message id: the caller supplies a server-derived
+/// <see cref="TurnId"/> (<see cref="ConversationTurnId.DeriveSafetyTurnId"/>) so the two
+/// turns occupy distinct idempotency keys and a re-send appends neither twice.
+/// </summary>
+/// <param name="UserId">The runner whose conversation stream the turn appends to (also the tenant).</param>
+/// <param name="TurnId">The server-derived, deterministic referral turn id (the idempotency key).</param>
+/// <param name="Content">The scripted referral copy (system-authored; sanitizer-bypassed by the caller).</param>
+public sealed record PostScriptedSafetyTurn(Guid UserId, Guid TurnId, string Content);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostScriptedSafetyTurnHandler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostScriptedSafetyTurnHandler.cs
@@ -1,0 +1,75 @@
+using Marten;
+using Microsoft.Extensions.Logging;
+using RunCoach.Api.Infrastructure.Idempotency;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Wolverine command handler for <see cref="PostScriptedSafetyTurn"/> (Slice 4B PR4) —
+/// persists a scripted Amber referral as a <see cref="CoachMessagePosted"/> coach turn on
+/// the user-scoped <c>Conversation</c> stream. Idempotent on the caller-supplied,
+/// server-derived <see cref="PostScriptedSafetyTurn.TurnId"/>, so a re-send after a
+/// mid-stream answer failure re-derives the same id and never double-appends the
+/// referral. Appends to the stream the durable-first user turn already created.
+/// Wolverine's transactional middleware brackets a single Marten <c>SaveChangesAsync</c>;
+/// the handler never calls it.
+/// </summary>
+/// <remarks>
+/// Reuses the existing <see cref="CoachMessagePosted"/> event (no new event type, so the
+/// <c>MartenConfiguration.RegisteredEventTypes</c> registration guard is untouched): on
+/// the interactive stream a safety referral is a coach turn carrying scripted copy. It is
+/// never errored — the content is deterministic system copy, always complete.
+/// </remarks>
+public sealed partial class PostScriptedSafetyTurnHandler
+{
+    // See PostCoachConversationTurnHandler — Wolverine codegen needs a non-static logical
+    // handler type for ILogger<T>; the private constructor blocks instantiation.
+    private PostScriptedSafetyTurnHandler()
+    {
+    }
+
+    /// <summary>Persists the scripted safety coach turn, idempotent on the derived turn id.</summary>
+    /// <param name="cmd">The post-scripted-safety-turn command.</param>
+    /// <param name="session">Marten session bracketed by Wolverine's transactional middleware.</param>
+    /// <param name="idempotency">Idempotency store backed by the same <paramref name="session"/>.</param>
+    /// <param name="logger">Logger.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The persisted safety turn id (= the supplied derived id).</returns>
+    public static async Task<ConversationTurnPostedResponse> Handle(
+        PostScriptedSafetyTurn cmd,
+        IDocumentSession session,
+        IIdempotencyStore idempotency,
+        ILogger<PostScriptedSafetyTurnHandler> logger,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(cmd);
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(idempotency);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var prior = await idempotency
+            .SeenAsync<ConversationTurnPostedResponse>(cmd.TurnId, ct)
+            .ConfigureAwait(false);
+        if (prior is not null)
+        {
+            LogIdempotentReplay(logger, cmd.TurnId, cmd.UserId);
+            return prior;
+        }
+
+        // The user turn is durable-first, so the stream already exists — append. A
+        // scripted referral is never an errored marker (the content is always complete).
+        session.Events.Append(
+            cmd.UserId,
+            new CoachMessagePosted(cmd.UserId, cmd.TurnId, cmd.Content, IsErrored: false));
+
+        var response = new ConversationTurnPostedResponse(cmd.TurnId);
+        idempotency.Record(cmd.TurnId, response);
+        return response;
+    }
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Information,
+        Message = "Scripted safety referral turn idempotent replay turnId={TurnId} user={UserId}")]
+    private static partial void LogIdempotentReplay(ILogger logger, Guid turnId, Guid userId);
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/CardFrame.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/CardFrame.cs
@@ -1,0 +1,16 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// A workout-log confirmation card (Slice 4B PR4) emitted as <c>event: card</c> when the
+/// classifier triages the message as <see cref="MessageIntent.WorkoutLog"/>. Carries the
+/// parsed draft (the runner's stated actuals) and the server-resolved candidate
+/// prescription it matched (or <c>null</c> for an off-plan run). No answer is streamed
+/// and <b>nothing is committed</b> — the plan-mutating commit waits for an explicit,
+/// button-driven Confirm (Unit 5 / PR5), preserving the determinism boundary.
+/// </summary>
+/// <param name="Draft">The classifier-extracted draft (actuals in the runner's stated units).</param>
+/// <param name="Prescription">The server-resolved candidate prescription, or <c>null</c> when the run matched no scheduled workout.</param>
+public sealed record CardFrame(StructuredLogDraft Draft, CandidatePrescriptionDto? Prescription) : IConversationFrame
+{
+    string IConversationFrame.EventName => "card";
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ConversationAnswerContext.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ConversationAnswerContext.cs
@@ -1,0 +1,18 @@
+using RunCoach.Api.Modules.Training.Models;
+using RunCoach.Api.Modules.Training.Plan.Models;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// The grounded Q&amp;A context for a streamed answer (Slice 4B PR4): the runner's active
+/// plan (or <c>null</c> when none), recent logged workouts, and recent interactive turns.
+/// Loaded by <see cref="IConversationContextLoader"/> and fed to
+/// <c>ContextAssembler.ComposeForConversationAsync</c>.
+/// </summary>
+/// <param name="Plan">The runner's active plan projection, or <c>null</c> when there is no active plan.</param>
+/// <param name="RecentLogs">Recent logged workouts (the assembler orders them newest-first).</param>
+/// <param name="RecentTurns">Recent non-errored interactive turns, oldest-first, excluding the current user turn.</param>
+public sealed record ConversationAnswerContext(
+    PlanProjectionDto? Plan,
+    IReadOnlyList<LoggedWorkoutDetail> RecentLogs,
+    IReadOnlyList<ConversationContextTurn> RecentTurns);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ConversationContextLoader.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ConversationContextLoader.cs
@@ -1,0 +1,73 @@
+using Marten;
+using Microsoft.EntityFrameworkCore;
+using RunCoach.Api.Infrastructure;
+using RunCoach.Api.Modules.Training.Models;
+using RunCoach.Api.Modules.Training.Plan;
+using RunCoach.Api.Modules.Training.Plan.Models;
+using RunCoach.Api.Modules.Training.Workouts;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// Default <see cref="IConversationContextLoader"/> (Slice 4B PR4). Groups the read-side
+/// data access the streaming orchestrator needs — the app-local date, the candidate
+/// prescription resolution (delegated to the unchanged <see cref="IWorkoutLogService"/>),
+/// and the composed answer context — behind one collaborator. Reads run on a per-request
+/// tenanted Marten session keyed by the authenticated user id.
+/// </summary>
+public sealed class ConversationContextLoader(
+    IWorkoutLogService workoutLogService,
+    IWorkoutLogRepository workoutLogs,
+    IDocumentStore documentStore,
+    RunCoachDbContext db,
+    ILocalDateProvider localDate) : IConversationContextLoader
+{
+    private const int RecentLogLimit = 5;
+    private const int RecentTurnLimit = 10;
+
+    /// <inheritdoc />
+    public DateOnly Today() => localDate.Today();
+
+    /// <inheritdoc />
+    public Task<WorkoutPrescriptionSnapshot?> ResolveCandidatePrescriptionAsync(
+        Guid userId, DateOnly occurredOn, CancellationToken ct) =>
+        workoutLogService.ResolveCandidatePrescriptionAsync(userId, occurredOn, ct);
+
+    /// <inheritdoc />
+    public async Task<ConversationAnswerContext> LoadAnswerContextAsync(
+        Guid userId, Guid clientMessageId, CancellationToken ct)
+    {
+        // SingleOrDefaultAsync fully qualified: both Marten's and EF Core's extension are
+        // in scope. This is the EF query against the RunnerOnboardingProfile projection.
+        var currentPlanId = await EntityFrameworkQueryableExtensions
+            .SingleOrDefaultAsync(
+                db.RunnerOnboardingProfiles
+                    .AsNoTracking()
+                    .Where(p => p.UserId == userId)
+                    .Select(p => p.CurrentPlanId),
+                ct)
+            .ConfigureAwait(false);
+
+        await using var session = documentStore.LightweightSession(userId.ToString());
+
+        PlanProjectionDto? plan = currentPlanId is { } planId
+            ? await session.LoadAsync<PlanProjectionDto>(planId, ct).ConfigureAwait(false)
+            : null;
+
+        var conversation = await session.LoadAsync<ConversationView>(userId, ct).ConfigureAwait(false);
+        IReadOnlyList<ConversationContextTurn> recentTurns = (conversation?.Turns ?? [])
+            .Where(t => !t.IsErrored && t.TurnId != clientMessageId)
+            .TakeLast(RecentTurnLimit)
+            .Select(t => new ConversationContextTurn(t.Participant, t.Content))
+            .ToArray();
+
+        var logEntities = await workoutLogs
+            .GetByUserAsync(userId, cursor: null, limit: RecentLogLimit, ct)
+            .ConfigureAwait(false);
+        IReadOnlyList<LoggedWorkoutDetail> recentLogs = logEntities
+            .Select(LoggedWorkoutDetailMapper.ToLoggedWorkoutDetail)
+            .ToArray();
+
+        return new ConversationAnswerContext(plan, recentLogs, recentTurns);
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ConversationScripts.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ConversationScripts.cs
@@ -1,0 +1,20 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// System-authored, non-LLM scripted copy for the streaming Q&amp;A endpoint (Slice 4B
+/// PR4) that is not safety content. Deterministic — it never passes through the LLM, so
+/// it carries no voice/trademark risk and needs no <c>VoiceProseGuard</c> gate, but it is
+/// written in the DEC-084 gruff-direct register for consistency with the coach's voice.
+/// </summary>
+public static class ConversationScripts
+{
+    /// <summary>
+    /// The clarification streamed when the intent classifier returns
+    /// <see cref="MessageIntent.Ambiguous"/> — the coach asks rather than guessing,
+    /// keeping a workout out of the plan until the runner says so (confirm-then-commit).
+    /// </summary>
+    public const string Clarification =
+        "I can't tell if that's a question or a workout you're logging. Which is it? Ask me "
+        + "what you want to know, or give me the run with its distance and time and I'll set "
+        + "it up for you to confirm.";
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ConversationStreamOptions.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ConversationStreamOptions.cs
@@ -1,0 +1,20 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// Tunables for the streaming Q&amp;A endpoint (Slice 4B PR4), bound from the
+/// <c>Conversation</c> configuration section (all defaults sensible, so the section is
+/// optional).
+/// </summary>
+public sealed record ConversationStreamOptions
+{
+    /// <summary>The configuration section name.</summary>
+    public const string SectionName = "Conversation";
+
+    /// <summary>
+    /// Gets the back-off (seconds) surfaced on a <b>mid-stream</b> transient failure. The
+    /// adapter cannot capture a <c>Retry-After</c> header once bytes have streamed (R-084),
+    /// so a mid-stream transient carries a null hint; the endpoint substitutes this
+    /// configured default when it surfaces the retry affordance to the client. Default 5s.
+    /// </summary>
+    public int DefaultMidStreamRetryAfterSeconds { get; init; } = 5;
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ConversationStreamService.Logging.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ConversationStreamService.Logging.cs
@@ -1,0 +1,41 @@
+using RunCoach.Api.Modules.Training.Safety;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// Source-generated <c>[LoggerMessage]</c> partials for <see cref="ConversationStreamService"/>
+/// (CA1848). Kept in a dedicated partial file so the orchestration body holds no static
+/// members interleaved with its instance methods (SA1204).
+/// </summary>
+public sealed partial class ConversationStreamService
+{
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Warning,
+        Message = "Conversation safety gate Red short-circuit user={UserId} category={Category}: scripted turn emitted, no LLM")]
+    private static partial void LogRedShortCircuit(ILogger logger, Guid userId, ReferralCategory category);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Information,
+        Message = "Conversation Amber referral surfaced user={UserId} category={Category}: scripted referral turn persisted alongside the answer")]
+    private static partial void LogAmberReferral(ILogger logger, Guid userId, ReferralCategory category);
+
+    [LoggerMessage(
+        EventId = 3,
+        Level = LogLevel.Warning,
+        Message = "Conversation intent classifier failed user={UserId}; surfacing an error frame, intent never guessed")]
+    private static partial void LogClassifierFailed(ILogger logger, Guid userId, Exception ex);
+
+    [LoggerMessage(
+        EventId = 4,
+        Level = LogLevel.Information,
+        Message = "Conversation workout-log card emitted user={UserId} prescriptionMatched={Matched}: nothing committed pending Confirm")]
+    private static partial void LogWorkoutCard(ILogger logger, Guid userId, bool matched);
+
+    [LoggerMessage(
+        EventId = 5,
+        Level = LogLevel.Warning,
+        Message = "Conversation answer stream failed user={UserId} retryable={Retryable}: errored marker persisted, partial discarded")]
+    private static partial void LogAnswerStreamFailed(ILogger logger, Guid userId, bool retryable);
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ConversationStreamService.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ConversationStreamService.cs
@@ -1,0 +1,288 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.Extensions.Options;
+using RunCoach.Api.Modules.Coaching.Sanitization;
+using RunCoach.Api.Modules.Training.Safety;
+using Wolverine;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// Default <see cref="IConversationStreamService"/> (Slice 4B PR4). Mirrors the
+/// <c>EvaluateAdaptationHandler</c> orchestration discipline for the streaming surface:
+/// deterministic safety gate before any LLM call, scripted safety turns routed by
+/// category (never LLM prose), the LLM proposing while the deterministic pipeline
+/// disposes. Reads run on a per-request tenanted Marten session; every write goes through
+/// a tenant-scoped Wolverine handler (<c>InvokeForTenantAsync</c>) so the idempotency
+/// markers commit co-transactionally with the events.
+/// </summary>
+public sealed partial class ConversationStreamService(
+    IMessageBus bus,
+    IPromptSanitizer sanitizer,
+    ISafetyGate safetyGate,
+    IMessageIntentClassifier classifier,
+    IContextAssembler contextAssembler,
+    ICoachingLlm llm,
+    IConversationContextLoader contextLoader,
+    IOptions<ConversationStreamOptions> options,
+    ILogger<ConversationStreamService> logger) : IConversationStreamService
+{
+    private const string ClassifierFailedMessage =
+        "I had trouble reading your message just now. Send it again and I'll pick it up.";
+
+    private const string AnswerTransientMessage =
+        "Something cut my reply short. Give it another go in a moment.";
+
+    private const string AnswerPermanentMessage =
+        "I couldn't finish that reply. Try rephrasing it and sending again.";
+
+    private const string AnswerIncompleteMessage =
+        "That answer got cut off before I finished. Send it again and I'll give you the whole thing.";
+
+    private readonly ConversationStreamOptions _options = options.Value;
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<IConversationFrame> StreamReplyAsync(
+        Guid userId,
+        string message,
+        Guid clientMessageId,
+        CancellationToken ct)
+    {
+        // Eager argument validation must fire on the call, not deferred to first
+        // enumeration — so it lives here and the iterator body is a separate method (S4456),
+        // mirroring ClaudeCoachingLlm.StreamAsync.
+        ArgumentNullException.ThrowIfNull(message);
+        return StreamReplyCore(userId, message, clientMessageId, ct);
+    }
+
+    private async IAsyncEnumerable<IConversationFrame> StreamReplyCore(
+        Guid userId,
+        string message,
+        Guid clientMessageId,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        // (1) Persist the user turn durably FIRST, before the gate or any stream, so a
+        //     crash after this point leaves a recoverable record. Idempotent on the client id.
+        await PersistUserTurnAsync(userId, clientMessageId, message, ct).ConfigureAwait(false);
+
+        // (2) Deterministic safety gate on a SEPARATELY-sanitized copy (the DEC-059
+        //     boundary). The classifier and answer assembly each sanitize their own copy
+        //     from the raw message; this gate copy is normalized (Unicode-stripped) so
+        //     keyword detection cannot be evaded by zero-width splitting. The spotlight
+        //     wrapper is benign for keyword matching.
+        var gateText = (await sanitizer
+            .SanitizeAsync(message, PromptSection.CurrentUserMessage, ct)
+            .ConfigureAwait(false)).Sanitized;
+        var safety = safetyGate.Classify(gateText, metrics: null);
+
+        // (3) Red short-circuits to scripted resources — no classifier, no LLM. Safety is
+        //     never left to LLM self-policing (DEC-019/DEC-030/DEC-079).
+        if (safety.Tier == SafetyTier.Red)
+        {
+            var crisis = safety.Category == ReferralCategory.Crisis
+                ? CrisisResponseContent.CrisisResponse
+                : EmergencyResponseContent.EmergencyResponse;
+            yield return new SafetyFrame(crisis, SafetyTier.Red, safety.Category);
+            LogRedShortCircuit(logger, userId, safety.Category);
+            var crisisTurnId = await PersistCoachTurnAsync(userId, clientMessageId, crisis, isErrored: false, ct)
+                .ConfigureAwait(false);
+            yield return new DoneFrame(crisisTurnId);
+            yield break;
+        }
+
+        // (4) Amber surfaces the scripted referral BEFORE the answer (lower event version
+        //     ⇒ the timeline renders it no later than the answer), then the coach still
+        //     answers — for Q&A "Amber" has no plan load to clamp. Persisted as a coach
+        //     turn with a distinct derived id so it never collides with the answer turn.
+        if (safety.Tier == SafetyTier.Amber)
+        {
+            var referral = safety.Category == ReferralCategory.Injury
+                ? AmberReferralContent.InjuryReferral
+                : AmberReferralContent.RedSReferral;
+            yield return new SafetyFrame(referral, SafetyTier.Amber, safety.Category);
+            await PersistSafetyReferralAsync(userId, clientMessageId, referral, ct).ConfigureAwait(false);
+            LogAmberReferral(logger, userId, safety.Category);
+        }
+
+        // (5) Classify intent. A classifier failure surfaces an error frame and never
+        //     guesses intent (D3 fail-closed); nothing beyond the durable user turn persists.
+        MessageIntentOutput? intent = null;
+        ErrorFrame? classifyError = null;
+        try
+        {
+            intent = await classifier.ClassifyAsync(contextLoader.Today(), message, ct).ConfigureAwait(false);
+        }
+        catch (CoachingLlmException ex)
+        {
+            LogClassifierFailed(logger, userId, ex);
+            classifyError = ToErrorFrame(ex, ClassifierFailedMessage);
+        }
+
+        if (classifyError is not null)
+        {
+            yield return classifyError;
+            yield break;
+        }
+
+        // (6) Route on intent.
+        switch (intent!.Intent)
+        {
+            case MessageIntent.WorkoutLog:
+                // Server-authoritative candidate prescription (never LLM-extracted); the
+                // card commits nothing — the plan-mutating write waits for an explicit
+                // Confirm (PR5). A null match renders the off-plan card; Confirm still commits.
+                var snapshot = await contextLoader
+                    .ResolveCandidatePrescriptionAsync(userId, intent.WorkoutLog!.OccurredOn, ct)
+                    .ConfigureAwait(false);
+                LogWorkoutCard(logger, userId, snapshot is not null);
+                yield return new CardFrame(intent.WorkoutLog!, CandidatePrescriptionDto.FromSnapshot(snapshot));
+                yield break;
+
+            case MessageIntent.Ambiguous:
+                // Ask rather than guess — never silently route to a log.
+                yield return new TokenFrame(ConversationScripts.Clarification);
+                var clarifyTurnId = await PersistCoachTurnAsync(
+                        userId, clientMessageId, ConversationScripts.Clarification, isErrored: false, ct)
+                    .ConfigureAwait(false);
+                yield return new DoneFrame(clarifyTurnId);
+                yield break;
+
+            default:
+                await foreach (var frame in StreamAnswerAsync(userId, message, clientMessageId, ct)
+                                   .ConfigureAwait(false))
+                {
+                    yield return frame;
+                }
+
+                yield break;
+        }
+    }
+
+    /// <summary>
+    /// The Green/Amber Question path: assemble grounded Q&amp;A context and stream the
+    /// answer through the adapter. The SDK enumerator is driven MANUALLY (MoveNextAsync
+    /// inside try/catch, yield outside) per the C# yield-in-try constraint and the R-084
+    /// taxonomy: a client abort persists nothing and emits no frame; a mid/post-stream
+    /// failure discards the partial, persists an errored marker (never a partial as
+    /// complete), and emits an error frame; a clean finish persists the full answer and
+    /// emits the terminal done frame carrying the reconcile id.
+    /// </summary>
+    private async IAsyncEnumerable<IConversationFrame> StreamAnswerAsync(
+        Guid userId,
+        string message,
+        Guid clientMessageId,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        var context = await contextLoader.LoadAnswerContextAsync(userId, clientMessageId, ct).ConfigureAwait(false);
+        var composition = await contextAssembler
+            .ComposeForConversationAsync(context.Plan, context.RecentLogs, context.RecentTurns, message, ct)
+            .ConfigureAwait(false);
+
+        var buffer = new StringBuilder();
+        ErrorFrame? streamError = null;
+        var aborted = false;
+
+        await using var enumerator = llm
+            .StreamAsync(composition.SystemPrompt, composition.UserMessage, ct)
+            .GetAsyncEnumerator(ct);
+
+        while (true)
+        {
+            string delta;
+            try
+            {
+                if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                {
+                    break;
+                }
+
+                delta = enumerator.Current;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // Client disconnected mid-stream: not a fault. Persist nothing beyond the
+                // durable user turn, emit no error frame, do not 500.
+                aborted = true;
+                break;
+            }
+            catch (IncompleteCoachingLlmException ex)
+            {
+                // A truncated free-text reply is incomplete, not a complete turn.
+                streamError = new ErrorFrame(AnswerIncompleteMessage, ex.Retryable, null);
+                break;
+            }
+            catch (TransientCoachingLlmException ex)
+            {
+                streamError = new ErrorFrame(
+                    AnswerTransientMessage, Retryable: true, ex.RetryAfterSeconds ?? _options.DefaultMidStreamRetryAfterSeconds);
+                break;
+            }
+            catch (PermanentCoachingLlmException)
+            {
+                streamError = new ErrorFrame(AnswerPermanentMessage, Retryable: false, RetryAfterSeconds: null);
+                break;
+            }
+            catch (CoachingLlmException)
+            {
+                // Totality backstop for any future subtype — treat as non-retryable.
+                streamError = new ErrorFrame(AnswerPermanentMessage, Retryable: false, RetryAfterSeconds: null);
+                break;
+            }
+
+            buffer.Append(delta);
+            yield return new TokenFrame(delta);
+        }
+
+        if (aborted)
+        {
+            yield break;
+        }
+
+        if (streamError is not null)
+        {
+            // Discard the partial; persist an explicit errored marker (never a partial as
+            // complete). The client re-sends with a fresh client message id (D5).
+            await PersistCoachTurnAsync(userId, clientMessageId, content: string.Empty, isErrored: true, ct)
+                .ConfigureAwait(false);
+            LogAnswerStreamFailed(logger, userId, streamError.Retryable);
+            yield return streamError;
+            yield break;
+        }
+
+        var answerTurnId = await PersistCoachTurnAsync(userId, clientMessageId, buffer.ToString(), isErrored: false, ct)
+            .ConfigureAwait(false);
+        yield return new DoneFrame(answerTurnId);
+    }
+
+    private async Task PersistUserTurnAsync(Guid userId, Guid clientMessageId, string message, CancellationToken ct) =>
+        await bus.InvokeForTenantAsync<ConversationTurnPostedResponse>(
+                userId.ToString(),
+                new PostUserConversationTurn(userId, clientMessageId, message),
+                ct)
+            .ConfigureAwait(false);
+
+    private async Task<Guid> PersistCoachTurnAsync(
+        Guid userId, Guid clientMessageId, string content, bool isErrored, CancellationToken ct)
+    {
+        var response = await bus.InvokeForTenantAsync<ConversationTurnPostedResponse>(
+                userId.ToString(),
+                new PostCoachConversationTurn(userId, clientMessageId, content, isErrored),
+                ct)
+            .ConfigureAwait(false);
+        return response.TurnId;
+    }
+
+    private async Task PersistSafetyReferralAsync(Guid userId, Guid clientMessageId, string referral, CancellationToken ct) =>
+        await bus.InvokeForTenantAsync<ConversationTurnPostedResponse>(
+                userId.ToString(),
+                new PostScriptedSafetyTurn(userId, ConversationTurnId.DeriveSafetyTurnId(clientMessageId), referral),
+                ct)
+            .ConfigureAwait(false);
+
+    private ErrorFrame ToErrorFrame(CoachingLlmException ex, string userMessage) => ex switch
+    {
+        TransientCoachingLlmException t => new ErrorFrame(
+            userMessage, Retryable: true, t.RetryAfterSeconds ?? _options.DefaultMidStreamRetryAfterSeconds),
+        _ => new ErrorFrame(userMessage, Retryable: false, RetryAfterSeconds: null),
+    };
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/DoneFrame.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/DoneFrame.cs
@@ -2,11 +2,13 @@ namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
 
 /// <summary>
 /// The terminal success frame (Slice 4B PR4) emitted as <c>event: done</c> after a coach
-/// turn (answer, scripted safety turn, clarification, or confirmation card) completes.
-/// Carries the persisted <see cref="TurnId"/> — load-bearing for the client's
+/// turn (answer, scripted safety turn, or clarification) completes. The workout-log
+/// confirmation card is NOT terminated by a done frame: that branch emits a <c>card</c>
+/// frame and commits nothing (no coach turn, so no persisted turn id), pending an explicit
+/// Confirm (PR5). Carries the persisted <see cref="TurnId"/> — load-bearing for the client's
 /// reconcile-once: the live bubble is folded into the timeline cache keyed on this id.
 /// </summary>
-/// <param name="TurnId">The persisted coach/safety/card turn id (server-derived for the coach reply).</param>
+/// <param name="TurnId">The persisted coach/safety turn id (server-derived for the coach reply).</param>
 public sealed record DoneFrame(Guid TurnId) : IConversationFrame
 {
     string IConversationFrame.EventName => "done";

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/DoneFrame.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/DoneFrame.cs
@@ -1,0 +1,13 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// The terminal success frame (Slice 4B PR4) emitted as <c>event: done</c> after a coach
+/// turn (answer, scripted safety turn, clarification, or confirmation card) completes.
+/// Carries the persisted <see cref="TurnId"/> — load-bearing for the client's
+/// reconcile-once: the live bubble is folded into the timeline cache keyed on this id.
+/// </summary>
+/// <param name="TurnId">The persisted coach/safety/card turn id (server-derived for the coach reply).</param>
+public sealed record DoneFrame(Guid TurnId) : IConversationFrame
+{
+    string IConversationFrame.EventName => "done";
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ErrorFrame.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/ErrorFrame.cs
@@ -1,0 +1,16 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// A terminal error frame (Slice 4B PR4) emitted as <c>event: error</c> when the
+/// classifier or the answer stream fails (a DEC-073 Transient/Permanent escape, or a
+/// free-text-incomplete finish). The partial answer, if any, is discarded — never
+/// reconciled into the timeline — and the client is expected to re-send with a
+/// <b>fresh</b> client message id (D5).
+/// </summary>
+/// <param name="Message">A user-facing, non-leaking failure message.</param>
+/// <param name="Retryable">Whether re-sending the request is likely to help (Transient / max-tokens) or not (Permanent).</param>
+/// <param name="RetryAfterSeconds">The server-advised back-off in seconds when known (a pre-stream 429 hint); <c>null</c> otherwise.</param>
+public sealed record ErrorFrame(string Message, bool Retryable, int? RetryAfterSeconds) : IConversationFrame
+{
+    string IConversationFrame.EventName => "error";
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/IConversationContextLoader.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/IConversationContextLoader.cs
@@ -1,0 +1,31 @@
+using RunCoach.Api.Modules.Training.Workouts;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// Owns the read-side grounding for the streaming Q&amp;A endpoint (Slice 4B PR4): the
+/// app-local date, the server-authoritative candidate-prescription resolution, and the
+/// composed answer context (plan + recent logs + recent interactive turns). Extracted
+/// from <see cref="ConversationStreamService"/> so the orchestrator depends on one
+/// read-side collaborator rather than five raw data-access services (REVIEW.md DI rule).
+/// </summary>
+public interface IConversationContextLoader
+{
+    /// <summary>Gets the app-local "today" (the classifier resolves relative dates against it).</summary>
+    DateOnly Today();
+
+    /// <summary>
+    /// Resolves the server-authoritative candidate prescription a run on
+    /// <paramref name="occurredOn"/> would match (the confirmation card's candidate);
+    /// <c>null</c> for an off-plan / unscheduled run.
+    /// </summary>
+    Task<WorkoutPrescriptionSnapshot?> ResolveCandidatePrescriptionAsync(
+        Guid userId, DateOnly occurredOn, CancellationToken ct);
+
+    /// <summary>
+    /// Loads the grounded Q&amp;A context: the active plan, recent logged workouts, and
+    /// recent interactive turns (excluding the just-persisted current user turn and any
+    /// errored markers), on one per-request tenanted Marten session.
+    /// </summary>
+    Task<ConversationAnswerContext> LoadAnswerContextAsync(Guid userId, Guid clientMessageId, CancellationToken ct);
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/IConversationFrame.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/IConversationFrame.cs
@@ -1,0 +1,16 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// A single frame in the streaming Q&amp;A response (Slice 4B PR4). The
+/// <see cref="IConversationStreamService"/> yields these in order; the controller
+/// serializes each as an SSE frame (<c>event: {EventName}\ndata: {json}\n\n</c>) via
+/// <see cref="SseWriter"/>. <see cref="EventName"/> is an <b>explicit</b> interface
+/// implementation on every frame so it carries the SSE event name without becoming a
+/// serialized JSON property (System.Text.Json ignores explicit interface members), and
+/// so a new frame type cannot be added without supplying its event name.
+/// </summary>
+public interface IConversationFrame
+{
+    /// <summary>Gets the SSE event name for this frame (e.g. <c>token</c>, <c>done</c>).</summary>
+    string EventName { get; }
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/IConversationStreamService.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/IConversationStreamService.cs
@@ -1,0 +1,22 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// Orchestrates a single streaming Q&amp;A turn for <c>POST /api/v1/conversation/messages</c>
+/// (Slice 4B PR4, the integration gate). Persists the user turn durable-first, runs the
+/// deterministic safety gate, classifies intent, and routes to a streamed answer, a
+/// confirmation card, a clarification, or a scripted safety turn — yielding the response
+/// as an ordered sequence of <see cref="IConversationFrame"/>. The controller is a thin
+/// transport that serializes each frame as an SSE event; all coaching/persistence logic
+/// lives here so the controller stays an entry point only.
+/// </summary>
+public interface IConversationStreamService
+{
+    /// <summary>Streams the coach's response to one runner message as ordered frames.</summary>
+    /// <param name="userId">The authenticated runner (also the Marten tenant + conversation stream id).</param>
+    /// <param name="message">The runner's raw free-text message (sanitized internally; never pre-sanitized by the caller).</param>
+    /// <param name="clientMessageId">The client-generated message id keying the durable-first user turn.</param>
+    /// <param name="ct">The request-aborted token; a client disconnect is surfaced as a clean abort, never a fault.</param>
+    /// <returns>The ordered response frames (token / safety / card / error / done).</returns>
+    IAsyncEnumerable<IConversationFrame> StreamReplyAsync(
+        Guid userId, string message, Guid clientMessageId, CancellationToken ct);
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/SafetyFrame.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/SafetyFrame.cs
@@ -1,0 +1,19 @@
+using RunCoach.Api.Modules.Training.Safety;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// A scripted, deterministic safety turn (Slice 4B PR4) emitted as <c>event: safety</c>:
+/// the Red crisis / emergency response that short-circuits the LLM, or the Amber
+/// referral that accompanies an answer. The content is system-authored (never LLM prose)
+/// and bypasses the prompt sanitizer, so resource strings like
+/// <c>988 Suicide &amp; Crisis Lifeline</c> reach the client verbatim
+/// (DEC-019/DEC-030/DEC-079 — safety is never left to LLM self-policing).
+/// </summary>
+/// <param name="Content">The scripted safety copy.</param>
+/// <param name="Tier">The safety tier that drove it (<see cref="SafetyTier.Red"/> or <see cref="SafetyTier.Amber"/>).</param>
+/// <param name="Category">The referral category driving the content (Crisis / EmergencyReferral / Injury / RedS).</param>
+public sealed record SafetyFrame(string Content, SafetyTier Tier, ReferralCategory Category) : IConversationFrame
+{
+    string IConversationFrame.EventName => "safety";
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/SseWriter.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/SseWriter.cs
@@ -1,0 +1,52 @@
+using System.Text;
+using System.Text.Json;
+
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// Hand-rolled Server-Sent-Events frame writer for the streaming Q&amp;A endpoint
+/// (Slice 4B PR4, <c>POST /api/v1/conversation/messages</c>). Serializes each frame as
+/// <c>event: {name}\ndata: {json}\n\n</c> and flushes immediately, so a token reaches
+/// the client the moment it is produced (response buffering is disabled on the SSE
+/// path). Heartbeats are SSE comment lines (<c>: …\n\n</c>) that keep an idle connection
+/// alive without the client parsing them as a message. No SSE dependency — the framing
+/// is ~15 lines per the spec.
+/// </summary>
+/// <remarks>
+/// Payloads serialize with the API's configured <see cref="JsonSerializerOptions"/>
+/// (camelCase web defaults) so frames match every other API response — NOT the
+/// snake_case structured-output options used for LLM constrained decoding.
+/// </remarks>
+public sealed class SseWriter(Stream output, JsonSerializerOptions jsonOptions)
+{
+    private static readonly byte[] HeartbeatBytes = ": hb\n\n"u8.ToArray();
+
+    private readonly Stream _output = output;
+    private readonly JsonSerializerOptions _jsonOptions = jsonOptions;
+
+    /// <summary>Writes one typed SSE frame and flushes it.</summary>
+    /// <param name="eventName">The SSE event name (e.g. <c>token</c>, <c>done</c>, <c>error</c>).</param>
+    /// <param name="data">The frame payload; serialized to a single compact JSON data line.</param>
+    /// <param name="ct">Cancellation token (the request-aborted token on the live path).</param>
+    public async Task WriteEventAsync(string eventName, object data, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(eventName);
+        ArgumentNullException.ThrowIfNull(data);
+
+        // Compact (no indentation) so the JSON occupies a single `data:` line — a frame
+        // is terminated by the blank line, so an embedded newline would split the frame.
+        var json = JsonSerializer.Serialize(data, _jsonOptions);
+        var frame = Encoding.UTF8.GetBytes($"event: {eventName}\ndata: {json}\n\n");
+
+        await _output.WriteAsync(frame, ct).ConfigureAwait(false);
+        await _output.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Writes an SSE heartbeat comment line and flushes it.</summary>
+    /// <param name="ct">Cancellation token (the request-aborted token on the live path).</param>
+    public async Task WriteHeartbeatAsync(CancellationToken ct)
+    {
+        await _output.WriteAsync(HeartbeatBytes, ct).ConfigureAwait(false);
+        await _output.FlushAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/TokenFrame.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/Streaming/TokenFrame.cs
@@ -1,0 +1,12 @@
+namespace RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// An incremental text delta of a streamed coach answer or clarification (Slice 4B PR4).
+/// Emitted as <c>event: token</c>. The client appends deltas into a live bubble and
+/// reconciles into the timeline cache once on the terminal <see cref="DoneFrame"/>.
+/// </summary>
+/// <param name="Delta">The next chunk of answer text (already trademark-scrubbed by the adapter).</param>
+public sealed record TokenFrame(string Delta) : IConversationFrame
+{
+    string IConversationFrame.EventName => "token";
+}

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/IWorkoutLogService.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/IWorkoutLogService.cs
@@ -29,4 +29,16 @@ public interface IWorkoutLogService
     /// </summary>
     Task<QueryWorkoutLogsResponseDto> QueryAsync(
         Guid userId, WorkoutLogCursor? cursor, int? requestedLimit, CancellationToken ct);
+
+    /// <summary>
+    /// Resolves the server-authoritative candidate prescription a run on
+    /// <paramref name="occurredOn"/> would match for <paramref name="userId"/> — the
+    /// same plan-slot resolution <see cref="CreateAsync"/> performs (DEC-076), exposed so
+    /// the conversational-logging confirmation card (Slice 4B) can surface the candidate
+    /// before any commit. Returns <c>null</c> for an off-plan / unscheduled run (no active
+    /// plan, no matching slot, or a malformed stored prescription) — Confirm still commits
+    /// an off-plan log. Read-only: writes nothing to the database.
+    /// </summary>
+    Task<WorkoutPrescriptionSnapshot?> ResolveCandidatePrescriptionAsync(
+        Guid userId, DateOnly occurredOn, CancellationToken ct);
 }

--- a/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogService.cs
+++ b/backend/src/RunCoach.Api/Modules/Training/Workouts/WorkoutLogService.cs
@@ -91,6 +91,11 @@ public sealed partial class WorkoutLogService(
         return new QueryWorkoutLogsResponseDto(dtos, nextCursor);
     }
 
+    /// <inheritdoc />
+    public Task<WorkoutPrescriptionSnapshot?> ResolveCandidatePrescriptionAsync(
+        Guid userId, DateOnly occurredOn, CancellationToken ct) =>
+        ResolvePrescriptionAsync(userId, occurredOn, ct);
+
     private static string? SerializeMetrics(IReadOnlyDictionary<string, JsonElement>? metrics) =>
         metrics is { Count: > 0 } ? JsonSerializer.Serialize(metrics) : null;
 

--- a/backend/tests/RunCoach.Api.Tests/Infrastructure/StubCoachingLlm.cs
+++ b/backend/tests/RunCoach.Api.Tests/Infrastructure/StubCoachingLlm.cs
@@ -42,6 +42,8 @@ public sealed class StubCoachingLlm : ICoachingLlm
 {
     private static Func<object>? _structuredBehavior;
     private static int _structuredCallCount;
+    private static Func<CancellationToken, IAsyncEnumerable<string>>? _streamBehavior;
+    private static int _streamCallCount;
 
     /// <summary>
     /// Gets the number of structured-output calls made since the last
@@ -51,6 +53,13 @@ public sealed class StubCoachingLlm : ICoachingLlm
     public static int StructuredCallCount => Volatile.Read(ref _structuredCallCount);
 
     /// <summary>
+    /// Gets the number of streaming calls made since the last <see cref="Reset"/>.
+    /// The Slice 4B SSE tests assert <c>0</c> on the non-streaming paths (Red
+    /// short-circuit, WorkoutLog card) and <c>1</c> on the Question answer path.
+    /// </summary>
+    public static int StreamCallCount => Volatile.Read(ref _streamCallCount);
+
+    /// <summary>
     /// Clears the scripted behavior and zeroes the call counter. Call from test
     /// setup/dispose so one test's script never leaks into the next.
     /// </summary>
@@ -58,6 +67,23 @@ public sealed class StubCoachingLlm : ICoachingLlm
     {
         Volatile.Write(ref _structuredBehavior, null);
         Interlocked.Exchange(ref _structuredCallCount, 0);
+        Volatile.Write(ref _streamBehavior, null);
+        Interlocked.Exchange(ref _streamCallCount, 0);
+    }
+
+    /// <summary>
+    /// Scripts the next streaming call (Slice 4B SSE endpoint): the delegate is invoked
+    /// once per <see cref="StreamAsync"/> with the request-cancellation token and returns
+    /// the token sequence to yield. A scripted iterator may yield then throw a
+    /// <see cref="CoachingLlmException"/> (mid-stream failure) or an
+    /// <see cref="IncompleteCoachingLlmException"/> (free-text-incomplete finish), or
+    /// await on the supplied token to simulate a client abort.
+    /// </summary>
+    /// <param name="behavior">The per-call streaming behavior delegate.</param>
+    public static void UseStreamBehavior(Func<CancellationToken, IAsyncEnumerable<string>> behavior)
+    {
+        ArgumentNullException.ThrowIfNull(behavior);
+        Volatile.Write(ref _streamBehavior, behavior);
     }
 
     /// <summary>
@@ -81,11 +107,18 @@ public sealed class StubCoachingLlm : ICoachingLlm
             + "generation. Script the structured surface instead, or move the coverage to the eval tier.");
 
     /// <inheritdoc />
-    public IAsyncEnumerable<string> StreamAsync(string systemPrompt, string userMessage, CancellationToken ct) =>
-        throw new InvalidOperationException(
-            "StubCoachingLlm.StreamAsync was called: no integration-tier flow scripts streaming "
-            + "generation. Streaming coverage lives in the ClaudeCoachingLlm streaming tests; add a "
-            + "dedicated streaming test seam if an integration flow needs it.");
+    public IAsyncEnumerable<string> StreamAsync(string systemPrompt, string userMessage, CancellationToken ct)
+    {
+        Interlocked.Increment(ref _streamCallCount);
+
+        var behavior = Volatile.Read(ref _streamBehavior)
+            ?? throw new InvalidOperationException(
+                "StubCoachingLlm received an unscripted streaming call. Script the token sequence "
+                + "via StubCoachingLlm.UseStreamBehavior(...) in the test arrange, or fix the flow "
+                + "under test if no streaming call was expected.");
+
+        return behavior(ct);
+    }
 
     /// <inheritdoc />
     public Task<(T Result, AnthropicUsage Usage)> GenerateStructuredAsync<T>(

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/CandidatePrescriptionDtoTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/CandidatePrescriptionDtoTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching.Conversation;
+using RunCoach.Api.Modules.Coaching.Models.Structured;
+using RunCoach.Api.Modules.Training.Models;
+using RunCoach.Api.Modules.Training.Workouts;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Conversation;
+
+/// <summary>
+/// Unit coverage for <see cref="CandidatePrescriptionDto.FromSnapshot"/> (Slice 4B PR4) — the
+/// server-authoritative projection of a resolved <see cref="WorkoutPrescriptionSnapshot"/> onto
+/// the confirmation-card wire summary. Guards the field mapping (notably that the fast/easy pace
+/// bounds are not swapped) and the off-plan <c>null</c> branch. The canonical-plan integration
+/// fixture cannot catch a pace-band swap because its week-1 micro workout prescribes equal
+/// fast/easy paces, so the swap guard lives here with distinct bounds.
+/// </summary>
+public class CandidatePrescriptionDtoTests
+{
+    [Fact]
+    public void FromSnapshot_MapsEveryField_AndKeepsTheFastBoundFasterThanEasy()
+    {
+        // Arrange — distinct fast/easy bounds (fast = fewer sec/km) so a swapped
+        // PrescribedPaceFast/PrescribedPaceSlow mapping would flip the asserted values.
+        var snapshot = WorkoutPrescriptionSnapshot.Create(
+            sourcePlanId: Guid.NewGuid(),
+            weekNumber: 3,
+            dayOfWeek: 2,
+            workoutType: WorkoutType.Tempo,
+            prescribedDistance: Distance.FromKilometers(10),
+            prescribedDuration: Duration.FromMinutes(45),
+            prescribedPaceFast: Pace.FromSecondsPerKm(240),
+            prescribedPaceSlow: Pace.FromSecondsPerKm(330));
+
+        // Act
+        var actual = CandidatePrescriptionDto.FromSnapshot(snapshot);
+
+        // Assert
+        actual.Should().NotBeNull();
+        actual!.WorkoutType.Should().Be("Tempo");
+        actual.DistanceMeters.Should().Be(10_000);
+        actual.DurationSeconds.Should().Be(2_700);
+        actual.PaceFastSecPerKm.Should().Be(240, because: "the fast bound maps from PrescribedPaceFast");
+        actual.PaceEasySecPerKm.Should().Be(330, because: "the easy bound maps from PrescribedPaceSlow");
+        actual.PaceFastSecPerKm.Should().BeLessThan(
+            actual.PaceEasySecPerKm,
+            because: "fast is the harder, lower-sec/km bound — a swapped mapping would invert this");
+    }
+
+    [Fact]
+    public void FromSnapshot_Null_ReturnsNull()
+    {
+        // Arrange / Act — an off-plan run resolves no prescription snapshot.
+        var actual = CandidatePrescriptionDto.FromSnapshot(null);
+
+        // Assert
+        actual.Should().BeNull(because: "an off-plan run carries no candidate prescription on the card");
+    }
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/ConversationTurnIdTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/ConversationTurnIdTests.cs
@@ -55,4 +55,59 @@ public sealed class ConversationTurnIdTests
             first,
             because: "a re-send with a fresh client id must derive a separate coach turn, not collide with the original");
     }
+
+    [Fact]
+    public void DeriveSafetyTurnId_IsDeterministic_SameInputSameOutput()
+    {
+        // Act
+        var first = ConversationTurnId.DeriveSafetyTurnId(ClientMessageId);
+        var second = ConversationTurnId.DeriveSafetyTurnId(ClientMessageId);
+
+        // Assert
+        second.Should().Be(
+            first,
+            because: "a re-send after mid-stream death must re-derive the same scripted-referral idempotency key so the Amber referral is never double-appended");
+    }
+
+    [Fact]
+    public void DeriveSafetyTurnId_DiffersFromCoachTurnId_ForTheSameClientId()
+    {
+        // Act
+        var safetyTurnId = ConversationTurnId.DeriveSafetyTurnId(ClientMessageId);
+        var coachTurnId = ConversationTurnId.DeriveCoachTurnId(ClientMessageId);
+
+        // Assert
+        safetyTurnId.Should().NotBe(
+            coachTurnId,
+            because: "an Amber message persists BOTH a scripted referral turn and a streamed answer turn off the same client id; they must occupy distinct idempotency keys or one would overwrite the other");
+    }
+
+    [Fact]
+    public void DeriveSafetyTurnId_DiffersFromClientMessageId()
+    {
+        // Act
+        var actual = ConversationTurnId.DeriveSafetyTurnId(ClientMessageId);
+
+        // Assert
+        actual.Should().NotBe(
+            ClientMessageId,
+            because: "the user turn already keyed its idempotency marker on the client id; the scripted referral turn needs a distinct key");
+        actual.Should().NotBe(Guid.Empty, because: "the derived id must be a usable, non-empty GUID");
+    }
+
+    [Fact]
+    public void DeriveSafetyTurnId_DistinctClientIds_ProduceDistinctSafetyIds()
+    {
+        // Arrange
+        var otherClientId = new Guid("22222222-2222-2222-2222-222222222222");
+
+        // Act
+        var first = ConversationTurnId.DeriveSafetyTurnId(ClientMessageId);
+        var second = ConversationTurnId.DeriveSafetyTurnId(otherClientId);
+
+        // Assert
+        second.Should().NotBe(
+            first,
+            because: "two different messages each carrying an Amber signal must derive separate referral turns");
+    }
 }

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/ConversationMessagesEndpointIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/ConversationMessagesEndpointIntegrationTests.cs
@@ -196,6 +196,12 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
 
         StubCoachingLlm.StreamCallCount.Should().Be(0, because: "the card path never streams");
         (await CountWorkoutLogsAsync(userId)).Should().Be(0, because: "the card commits nothing until Confirm (PR5)");
+
+        // The card branch commits NOTHING beyond the durable user turn: no coach turn, no
+        // log row — a regression that appended a coach turn for the card would be caught here.
+        var view = await LoadConversationViewAsync(userId);
+        view!.Turns.Should().ContainSingle(because: "only the durable-first user turn persists for a card")
+            .Which.Participant.Should().Be(ConversationParticipant.User);
     }
 
     [Fact]
@@ -342,6 +348,39 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
         // Assert
         response.StatusCode.Should().Be(
             HttpStatusCode.BadRequest, because: "a mutation without the antiforgery token is rejected before streaming");
+        response.Content.Headers.ContentType?.MediaType.Should().Be(
+            "application/problem+json", because: "the antiforgery rejection returns structured ProblemDetails, not a bare 400");
+    }
+
+    [Fact]
+    public async Task BlankMessage_IsRejectedWith400_BeforeAnyLlmCall()
+    {
+        // Arrange — a valid antiforgery token so the request reaches the boundary validation.
+        StubCoachingLlm.Reset();
+        var (client, _, token) = await RegisterLoginAndPrimeAsync();
+
+        // Act
+        using var response = await PostMessageAsync(client, token, "   ", Guid.NewGuid());
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        StubCoachingLlm.StructuredCallCount.Should().Be(0, because: "a blank message never reaches the classifier");
+    }
+
+    [Fact]
+    public async Task EmptyClientMessageId_IsRejectedWith400()
+    {
+        // Arrange — an empty client id would collide every empty-id post on the derived keys.
+        StubCoachingLlm.Reset();
+        var (client, _, token) = await RegisterLoginAndPrimeAsync();
+
+        // Act
+        using var response = await PostMessageAsync(client, token, "How's my plan?", Guid.Empty);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        StubCoachingLlm.StructuredCallCount.Should().Be(0);
     }
 
     [Fact]

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/ConversationMessagesEndpointIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/ConversationMessagesEndpointIntegrationTests.cs
@@ -1,0 +1,788 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Marten;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using RunCoach.Api.Infrastructure;
+using RunCoach.Api.Modules.Coaching;
+using RunCoach.Api.Modules.Coaching.Conversation;
+using RunCoach.Api.Modules.Coaching.Onboarding.Entities;
+using RunCoach.Api.Modules.Identity.Contracts;
+using RunCoach.Api.Modules.Training.Plan.Models;
+using RunCoach.Api.Modules.Training.Safety;
+using RunCoach.Api.Modules.Training.Workouts;
+using RunCoach.Api.Tests.Infrastructure;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// Integration coverage for the streaming Q&amp;A endpoint
+/// <c>POST /api/v1/conversation/messages</c> (Slice 4B PR4, the integration gate). Drives
+/// the real <see cref="RunCoachAppFactory"/> SUT end-to-end: the CookieOrBearer gate,
+/// antiforgery, the real deterministic <c>SafetyGate</c>, the stubbed classifier + answer
+/// stream (<see cref="StubCoachingLlm"/>), the two-write user-scoped persistence, and the
+/// hand-rolled SSE framing. Asserts each acceptance scenario from
+/// <c>sse-conversation-endpoint.feature</c>.
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory factory)
+    : DbBackedIntegrationTestBase(factory)
+{
+    private const string MessagesPath = "/api/v1/conversation/messages";
+    private const string StrongPassword = "Str0ngTestPassw0rd!";
+
+    private static readonly Uri BaseUri = new("https://localhost");
+    private static readonly DateTimeOffset PlanGeneratedAt = new(2026, 4, 25, 12, 0, 0, TimeSpan.Zero);
+    private static readonly JsonSerializerOptions WebOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public async Task GreenQuestion_StreamsTokens_ThenDoneCarryingThePersistedTurnId()
+    {
+        // Arrange
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(() => Question());
+        StubCoachingLlm.UseStreamBehavior(_ => YieldTokensAsync("Run it easy.", " Keep the effort relaxed."));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        await SeedActivePlanAsync(userId);
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(
+            client, token, "How should I pace my long run this weekend?", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("text/event-stream");
+
+        var tokens = frames.Where(f => f.Event == "token").ToArray();
+        tokens.Should().NotBeEmpty(because: "a green answer streams as token frames");
+        string.Concat(tokens.Select(f => Payload<TokenPayload>(f).Delta))
+            .Should().Be("Run it easy. Keep the effort relaxed.");
+
+        var done = frames.Should().ContainSingle(f => f.Event == "done").Subject;
+        Payload<DonePayload>(done).TurnId.Should().Be(
+            ConversationTurnId.DeriveCoachTurnId(clientMessageId),
+            because: "the done frame carries the server-derived coach turn id the client reconciles on");
+        frames.Should().NotContain(f => f.Event == "error");
+
+        var view = await LoadConversationViewAsync(userId);
+        view!.Turns.Should().HaveCount(2);
+        view.Turns.Should().ContainSingle(t => t.Participant == ConversationParticipant.User)
+            .Which.TurnId.Should().Be(clientMessageId);
+        view.Turns.Should().ContainSingle(t => t.Participant == ConversationParticipant.Coach)
+            .Which.Content.Should().Be("Run it easy. Keep the effort relaxed.");
+    }
+
+    [Fact]
+    public async Task GreenQuestion_WithNoActivePlan_StillStreamsAnAnswer()
+    {
+        // Arrange — a registered runner with no onboarding profile / plan at all: the
+        // answer context composes a "No active plan." grounding rather than NRE-ing.
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(() => Question());
+        StubCoachingLlm.UseStreamBehavior(_ => YieldTokensAsync("Let's get you started."));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(client, token, "What should I do first?", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert
+        frames.Should().Contain(f => f.Event == "token");
+        frames.Should().ContainSingle(f => f.Event == "done");
+        frames.Should().NotContain(f => f.Event == "error");
+        var view = await LoadConversationViewAsync(userId);
+        view!.Turns.Should().Contain(t => t.Participant == ConversationParticipant.Coach
+            && t.Content == "Let's get you started.");
+    }
+
+    [Fact]
+    public async Task RedCrisis_EmitsScriptedResources_AndNeverCallsTheLlm()
+    {
+        // Arrange — no classifier/stream scripted: a Red short-circuit must never reach them.
+        StubCoachingLlm.Reset();
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(
+            client, token, "Honestly lately I just want to end it all.", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert
+        var safety = frames.Should().ContainSingle(f => f.Event == "safety").Subject;
+        var payload = Payload<SafetyPayload>(safety);
+        payload.Tier.Should().Be(SafetyTier.Red);
+        payload.Content.Should().Contain("988 Suicide & Crisis Lifeline");
+        payload.Content.Should().Contain("Crisis Text Line: text 741741");
+        frames.Should().Contain(f => f.Event == "done");
+        frames.Should().NotContain(f => f.Event == "token", because: "the crisis short-circuit streams no LLM answer");
+
+        StubCoachingLlm.StructuredCallCount.Should().Be(0, because: "Red never reaches the classifier");
+        StubCoachingLlm.StreamCallCount.Should().Be(0, because: "Red never reaches the answer stream");
+
+        var view = await LoadConversationViewAsync(userId);
+        view!.Turns.Should().ContainSingle(t => t.Participant == ConversationParticipant.Coach)
+            .Which.Content.Should().Contain("988");
+    }
+
+    [Fact]
+    public async Task AmberInjury_SurfacesReferralTurn_AlongsideTheStreamedAnswer()
+    {
+        // Arrange
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(() => Question());
+        StubCoachingLlm.UseStreamBehavior(_ => YieldTokensAsync("Let's ease off."));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        await SeedActivePlanAsync(userId);
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(
+            client, token, "I had sharp pain in my knee on today's run.", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert
+        var safety = frames.Should().ContainSingle(f => f.Event == "safety").Subject;
+        var payload = Payload<SafetyPayload>(safety);
+        payload.Tier.Should().Be(SafetyTier.Amber);
+        payload.Category.Should().Be(ReferralCategory.Injury);
+        payload.Content.Should().Be(AmberReferralContent.InjuryReferral);
+        frames.Should().Contain(f => f.Event == "token", because: "the coach still answers an Amber Q&A");
+
+        // The Amber path persists TWO coach turns off the same client id (the referral on
+        // DeriveSafetyTurnId, the answer on DeriveCoachTurnId); the done frame must carry the
+        // ANSWER id so the client reconciles the live bubble onto the answer, not the referral.
+        var amberDone = frames.Should().ContainSingle(f => f.Event == "done").Subject;
+        Payload<DonePayload>(amberDone).TurnId.Should().Be(
+            ConversationTurnId.DeriveCoachTurnId(clientMessageId),
+            because: "the done frame carries the answer coach turn id, not the safety referral turn id");
+
+        var view = await LoadConversationViewAsync(userId);
+        view!.Turns.Should().HaveCount(3, because: "user turn + scripted referral coach turn + answer coach turn");
+        view.Turns.Should().Contain(t => t.Content == AmberReferralContent.InjuryReferral);
+        view.Turns.Should().Contain(t => t.Content == "Let's ease off.");
+    }
+
+    [Fact]
+    public async Task WorkoutLog_ReturnsConfirmationCard_AndCommitsNothing()
+    {
+        // Arrange
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(() => WorkoutLog(LocalToday()));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        await SeedActivePlanAsync(userId);
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(
+            client, token, "Did my easy 5k this morning, felt good.", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert
+        var card = frames.Should().ContainSingle(f => f.Event == "card").Subject;
+        var payload = Payload<CardPayload>(card);
+        payload.Draft.DistanceValue.Should().Be(5);
+        payload.Draft.DistanceUnit.Should().Be(RunnerDistanceUnit.Kilometers);
+        frames.Should().NotContain(f => f.Event == "token", because: "a workout-log card streams no answer");
+
+        StubCoachingLlm.StreamCallCount.Should().Be(0, because: "the card path never streams");
+        (await CountWorkoutLogsAsync(userId)).Should().Be(0, because: "the card commits nothing until Confirm (PR5)");
+    }
+
+    [Fact]
+    public async Task Ambiguous_StreamsAClarification_AndDoesNotRouteToALog()
+    {
+        // Arrange
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(() => Ambiguous());
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(client, token, "knee thing, dunno", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert
+        var tokens = frames.Where(f => f.Event == "token").ToArray();
+        tokens.Should().NotBeEmpty();
+        string.Concat(tokens.Select(f => Payload<TokenPayload>(f).Delta))
+            .Should().Contain("question or a workout", because: "the coach asks rather than guessing");
+        frames.Should().Contain(f => f.Event == "done");
+        frames.Should().NotContain(f => f.Event == "card", because: "an ambiguous message is never silently logged");
+        StubCoachingLlm.StreamCallCount.Should().Be(0, because: "the clarification is scripted, not LLM-streamed");
+        (await CountWorkoutLogsAsync(userId)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MidStreamFailure_EmitsErrorFrame_AndPersistsAnErroredMarker_NotAPartial()
+    {
+        // Arrange — the stream yields one token then throws a transient failure.
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(() => Question());
+        StubCoachingLlm.UseStreamBehavior(_ => FailingStreamAsync("partial answer"));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        await SeedActivePlanAsync(userId);
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(client, token, "What's my week look like?", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert
+        var error = frames.Should().ContainSingle(f => f.Event == "error").Subject;
+        var errorPayload = Payload<ErrorPayload>(error);
+        errorPayload.Retryable.Should().BeTrue(because: "a transient failure is retryable");
+        errorPayload.RetryAfterSeconds.Should().Be(
+            5,
+            because: "a mid-stream transient carries no Retry-After hint, so the configured DefaultMidStreamRetryAfterSeconds is surfaced");
+        frames.Should().NotContain(f => f.Event == "done", because: "a failed turn has no terminal done");
+
+        var view = await LoadConversationViewAsync(userId);
+        var coach = view!.Turns.Should().ContainSingle(t => t.Participant == ConversationParticipant.Coach).Subject;
+        coach.IsErrored.Should().BeTrue(because: "the truncated reply is marked errored, never stored as complete");
+        coach.Content.Should().BeEmpty(because: "an errored marker carries no partial text");
+        view.Turns.Should().Contain(t => t.Participant == ConversationParticipant.User && t.TurnId == clientMessageId);
+    }
+
+    [Fact]
+    public async Task ClassifierFailure_EmitsErrorFrame_AndNeverGuessesIntent()
+    {
+        // Arrange — the classifier call throws; no stream is scripted (it must not be reached).
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(
+            () => throw new PermanentCoachingLlmException("classifier exploded", null));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(client, token, "How's my training going?", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert
+        frames.Should().ContainSingle(f => f.Event == "error");
+        frames.Should().NotContain(f => f.Event == "token", because: "intent is never guessed into an answer");
+        frames.Should().NotContain(f => f.Event == "card", because: "intent is never guessed into a log");
+        StubCoachingLlm.StreamCallCount.Should().Be(0);
+
+        var view = await LoadConversationViewAsync(userId);
+        view!.Turns.Should().ContainSingle()
+            .Which.Participant.Should().Be(
+                ConversationParticipant.User,
+                because: "nothing beyond the durable user turn is persisted on a classifier failure");
+    }
+
+    [Fact]
+    public async Task ClientAbort_PersistsNoCoachTurn_AndDoesNotServerError()
+    {
+        // Arrange — the stream yields one token then blocks until the request is aborted.
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(() => Question());
+        StubCoachingLlm.UseStreamBehavior((ct) => AbortableStreamAsync("first", ct));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        await SeedActivePlanAsync(userId);
+        var clientMessageId = Guid.NewGuid();
+        using var abort = new CancellationTokenSource();
+
+        // Act — read the first token, then abort the request mid-stream.
+        using var request = BuildPost(token, "Tell me about my plan.", clientMessageId);
+        var aborted = false;
+        try
+        {
+            using var response = await client.SendAsync(
+                request, HttpCompletionOption.ResponseHeadersRead, abort.Token);
+            await using var stream = await response.Content.ReadAsStreamAsync(abort.Token);
+            using var reader = new StreamReader(stream);
+            string? line;
+            while ((line = await reader.ReadLineAsync(abort.Token)) is not null)
+            {
+                if (line.StartsWith("data:", StringComparison.Ordinal) && line.Contains("first", StringComparison.Ordinal))
+                {
+                    await abort.CancelAsync();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            aborted = true;
+        }
+
+        // Assert — the user turn is durable (written before the stream), but no coach turn is
+        // ever persisted on abort (not even an errored marker). The server logs no 5xx.
+        aborted.Should().BeTrue(because: "cancelling the in-flight read surfaces a client cancellation");
+        var view = await LoadConversationViewAsync(userId);
+        view!.Turns.Should().Contain(t => t.Participant == ConversationParticipant.User && t.TurnId == clientMessageId);
+        view.Turns.Should().NotContain(
+            t => t.Participant == ConversationParticipant.Coach,
+            because: "an aborted stream persists nothing for the coach reply");
+    }
+
+    [Fact]
+    public async Task MissingAntiforgeryToken_IsRejected()
+    {
+        // Arrange — a logged-in cookie client, but the request omits the X-XSRF-TOKEN header.
+        StubCoachingLlm.Reset();
+        var (client, _, _) = await RegisterLoginAndPrimeAsync();
+        var request = new HttpRequestMessage(HttpMethod.Post, MessagesPath)
+        {
+            Content = JsonContent.Create(new ConversationMessageRequestDto("hi", Guid.NewGuid())),
+        };
+
+        // Act
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(
+            HttpStatusCode.BadRequest, because: "a mutation without the antiforgery token is rejected before streaming");
+    }
+
+    [Fact]
+    public async Task RedEmergency_EmitsStopAndReferContent_AndNeverCallsTheLlm()
+    {
+        // Arrange — a cardiac signal classifies Red/EmergencyReferral, a distinct branch from
+        // the crisis branch: it must route to the stop-and-call-911 copy, never the 988 lines.
+        StubCoachingLlm.Reset();
+        var (client, _, token) = await RegisterLoginAndPrimeAsync();
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(
+            client, token, "I had chest pain partway through the run and felt dizzy.", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert
+        var safety = frames.Should().ContainSingle(f => f.Event == "safety").Subject;
+        var payload = Payload<SafetyPayload>(safety);
+        payload.Tier.Should().Be(SafetyTier.Red);
+        payload.Category.Should().Be(ReferralCategory.EmergencyReferral);
+        payload.Content.Should().Contain("911", because: "an urgent medical signal routes to emergency care, not the crisis lines");
+        payload.Content.Should().NotContain("988", because: "the mental-health crisis copy must not be sent for a cardiac symptom");
+        StubCoachingLlm.StructuredCallCount.Should().Be(0);
+        StubCoachingLlm.StreamCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AmberRedS_SurfacesEnergyBalanceReferral_AlongsideTheStreamedAnswer()
+    {
+        // Arrange — a RED-S signal classifies Amber/RedS, the other Amber branch: it must route
+        // to the sports-dietitian / energy-balance copy, not the injury physiotherapy referral.
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(() => Question());
+        StubCoachingLlm.UseStreamBehavior(_ => YieldTokensAsync("Fuel comes first."));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        await SeedActivePlanAsync(userId);
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(
+            client, token, "I'm not eating enough but I keep training hard.", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert
+        var safety = frames.Should().ContainSingle(f => f.Event == "safety").Subject;
+        var payload = Payload<SafetyPayload>(safety);
+        payload.Tier.Should().Be(SafetyTier.Amber);
+        payload.Category.Should().Be(ReferralCategory.RedS);
+        payload.Content.Should().Be(AmberReferralContent.RedSReferral);
+        payload.Content.Should().Contain("dietitian");
+        frames.Should().Contain(f => f.Event == "token", because: "the coach still answers on an Amber RED-S message");
+    }
+
+    [Fact]
+    public async Task GreenQuestion_RePostedWithSameClientMessageId_IsIdempotent()
+    {
+        // Arrange
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(() => Question());
+        StubCoachingLlm.UseStreamBehavior(_ => YieldTokensAsync("Same answer."));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        await SeedActivePlanAsync(userId);
+        var clientMessageId = Guid.NewGuid();
+
+        // Act — submit the identical message twice (a client retry / double-post).
+        using (var first = await PostMessageAsync(client, token, "How's it going?", clientMessageId))
+        {
+            await ReadFramesAsync(first);
+        }
+
+        using (var second = await PostMessageAsync(client, token, "How's it going?", clientMessageId))
+        {
+            await ReadFramesAsync(second);
+        }
+
+        // Assert — the durable-first user turn and the server-derived coach turn are both
+        // idempotent, so the append-only stream holds exactly one of each, not duplicates.
+        var view = await LoadConversationViewAsync(userId);
+        view!.Turns.Should().HaveCount(2, because: "a re-POST with the same client id double-appends nothing");
+    }
+
+    [Fact]
+    public async Task AmberReferral_RePostedWithSameClientMessageId_DoesNotDoubleAppend()
+    {
+        // Arrange — exercises PostScriptedSafetyTurnHandler's idempotency on the derived
+        // safety turn id (the scripted referral must never double-append on a retry).
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(() => Question());
+        StubCoachingLlm.UseStreamBehavior(_ => YieldTokensAsync("Ease back."));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        await SeedActivePlanAsync(userId);
+        var clientMessageId = Guid.NewGuid();
+        const string message = "I had sharp pain in my knee on today's run.";
+
+        // Act
+        using (var first = await PostMessageAsync(client, token, message, clientMessageId))
+        {
+            await ReadFramesAsync(first);
+        }
+
+        using (var second = await PostMessageAsync(client, token, message, clientMessageId))
+        {
+            await ReadFramesAsync(second);
+        }
+
+        // Assert
+        var view = await LoadConversationViewAsync(userId);
+        view!.Turns.Should().HaveCount(
+            3, because: "the user turn, the scripted referral turn, and the answer turn are each idempotent on a retry");
+        view.Turns.Count(t => t.Content == AmberReferralContent.InjuryReferral).Should().Be(
+            1, because: "the scripted Amber referral is appended exactly once across both posts");
+    }
+
+    [Theory]
+    [InlineData(IncompleteReason.MaxTokens, true)]
+    [InlineData(IncompleteReason.ContextWindowExceeded, false)]
+    public async Task MidStreamIncompleteFinish_EmitsErrorFrame_WithRetryabilityFromTheReason(
+        IncompleteReason reason, bool expectedRetryable)
+    {
+        // Arrange — a free-text-incomplete finish (max_tokens / context overflow): retryability
+        // is instance-specific (a shorter retry can fit a max_tokens truncation, but not an
+        // oversized context), distinct from the hardcoded Transient/Permanent retryability.
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(() => Question());
+        StubCoachingLlm.UseStreamBehavior(_ => IncompleteStreamAsync("partial", reason));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        await SeedActivePlanAsync(userId);
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(client, token, "Give me my week.", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert
+        var error = frames.Should().ContainSingle(f => f.Event == "error").Subject;
+        Payload<ErrorPayload>(error).Retryable.Should().Be(
+            expectedRetryable, because: "an incomplete finish derives retryability from its reason, not a fixed value");
+        frames.Should().NotContain(f => f.Event == "done");
+
+        var view = await LoadConversationViewAsync(userId);
+        var coach = view!.Turns.Should().ContainSingle(t => t.Participant == ConversationParticipant.Coach).Subject;
+        coach.IsErrored.Should().BeTrue(because: "a truncated reply is an errored marker, never a complete turn");
+        coach.Content.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MidStreamPermanentFailure_EmitsNonRetryableError_AndErroredMarker()
+    {
+        // Arrange
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(() => Question());
+        StubCoachingLlm.UseStreamBehavior(_ => PermanentFailingStreamAsync("partial"));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        await SeedActivePlanAsync(userId);
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(client, token, "Why is my pace off?", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert
+        var error = frames.Should().ContainSingle(f => f.Event == "error").Subject;
+        var payload = Payload<ErrorPayload>(error);
+        payload.Retryable.Should().BeFalse(because: "a permanent mid-stream failure is not worth retrying");
+        payload.RetryAfterSeconds.Should().BeNull();
+        frames.Should().NotContain(f => f.Event == "done");
+
+        var view = await LoadConversationViewAsync(userId);
+        view!.Turns.Should().ContainSingle(t => t.Participant == ConversationParticipant.Coach)
+            .Which.IsErrored.Should().BeTrue();
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        StubCoachingLlm.Reset();
+        await Factory.Services.ResetAllMartenDataAsync();
+        await base.DisposeAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    private static MessageIntentOutput Question() =>
+        new() { Intent = MessageIntent.Question, WorkoutLog = null };
+
+    private static MessageIntentOutput Ambiguous() =>
+        new() { Intent = MessageIntent.Ambiguous, WorkoutLog = null };
+
+    private static MessageIntentOutput WorkoutLog(DateOnly today) =>
+        new()
+        {
+            Intent = MessageIntent.WorkoutLog,
+            WorkoutLog = new StructuredLogDraft
+            {
+                OccurredOn = today,
+                DistanceValue = 5,
+                DistanceUnit = RunnerDistanceUnit.Kilometers,
+                DurationHours = 0,
+                DurationMinutes = 25,
+                DurationSeconds = 0,
+                CompletionStatus = CompletionStatus.Complete,
+                Notes = "felt good",
+            },
+        };
+
+    private static async IAsyncEnumerable<string> YieldTokensAsync(params string[] tokens)
+    {
+        foreach (var t in tokens)
+        {
+            await Task.Yield();
+            yield return t;
+        }
+    }
+
+    private static async IAsyncEnumerable<string> FailingStreamAsync(string firstToken)
+    {
+        yield return firstToken;
+        await Task.Yield();
+        throw new TransientCoachingLlmException("mid-stream boom", retryAfterSeconds: null, innerException: null);
+    }
+
+    private static async IAsyncEnumerable<string> PermanentFailingStreamAsync(string firstToken)
+    {
+        yield return firstToken;
+        await Task.Yield();
+        throw new PermanentCoachingLlmException("mid-stream permanent", innerException: null);
+    }
+
+    private static async IAsyncEnumerable<string> IncompleteStreamAsync(string firstToken, IncompleteReason reason)
+    {
+        // A free-text-incomplete finish: the adapter yields its partial deltas, then throws
+        // IncompleteCoachingLlmException at the END of a clean enumeration (max_tokens etc.).
+        yield return firstToken;
+        await Task.Yield();
+        throw new IncompleteCoachingLlmException("truncated", reason);
+    }
+
+    private static async IAsyncEnumerable<string> AbortableStreamAsync(
+        string firstToken, [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return firstToken;
+        await Task.Delay(Timeout.Infinite, ct);
+        yield return "unreachable";
+    }
+
+    private static T Payload<T>(SseFrame frame) =>
+        JsonSerializer.Deserialize<T>(frame.Data, WebOptions)
+        ?? throw new InvalidOperationException($"frame '{frame.Event}' had no JSON payload");
+
+    private static async Task<List<SseFrame>> ReadFramesAsync(HttpResponseMessage response)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        using var reader = new StreamReader(stream);
+
+        var frames = new List<SseFrame>();
+        string? currentEvent = null;
+        var data = new StringBuilder();
+
+        string? line;
+        while ((line = await reader.ReadLineAsync(ct)) is not null)
+        {
+            if (line.Length == 0)
+            {
+                if (currentEvent is not null)
+                {
+                    frames.Add(new SseFrame(currentEvent, data.ToString()));
+                }
+
+                currentEvent = null;
+                data.Clear();
+                continue;
+            }
+
+            // An SSE comment line (heartbeat) starts with ':' and is not a frame.
+            if (line.StartsWith(':'))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("event:", StringComparison.Ordinal))
+            {
+                currentEvent = line["event:".Length..].Trim();
+            }
+            else if (line.StartsWith("data:", StringComparison.Ordinal))
+            {
+                data.Append(line["data:".Length..].Trim());
+            }
+        }
+
+        return frames;
+    }
+
+    private static HttpRequestMessage BuildPost(string antiforgeryToken, string message, Guid clientMessageId)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, MessagesPath);
+        request.Headers.Add(AuthCookieNames.AntiforgeryHeader, antiforgeryToken);
+        request.Content = JsonContent.Create(new ConversationMessageRequestDto(message, clientMessageId));
+        return request;
+    }
+
+    private static async Task<HttpResponseMessage> PostMessageAsync(
+        HttpClient client, string antiforgeryToken, string message, Guid clientMessageId)
+    {
+        var request = BuildPost(antiforgeryToken, message, clientMessageId);
+        return await client.SendAsync(
+            request, HttpCompletionOption.ResponseHeadersRead, TestContext.Current.CancellationToken);
+    }
+
+    private static DateOnly LocalToday() => DateOnly.FromDateTime(DateTime.UtcNow);
+
+    private static (HttpClient Client, System.Net.CookieContainer Container) CreateCookieClient(RunCoachAppFactory factory)
+    {
+        var container = new System.Net.CookieContainer();
+        var client = factory.CreateDefaultClient(new CookieContainerHandler(container));
+        client.BaseAddress = BaseUri;
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        return (client, container);
+    }
+
+    private static async Task<string> PrimeAntiforgeryAsync(HttpClient client, System.Net.CookieContainer container)
+    {
+        using var response = await client.GetAsync("/api/v1/auth/xsrf", TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        var requestCookie = GetCookie(container, AuthCookieNames.AntiforgeryRequest);
+        requestCookie.Should().NotBeNull("/xsrf must issue the SPA-readable request token cookie");
+        return requestCookie!.Value;
+    }
+
+    private static async Task<Guid> RegisterAsync(
+        HttpClient client, System.Net.CookieContainer container, string email, string password)
+    {
+        var token = await PrimeAntiforgeryAsync(client, container);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/auth/register");
+        request.Headers.Add(AuthCookieNames.AntiforgeryHeader, token);
+        request.Content = JsonContent.Create(new RegisterRequestDto(email, password));
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Created, because: "register helper must succeed");
+        var body = await response.Content.ReadFromJsonAsync<AuthResponseDto>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        return body!.UserId;
+    }
+
+    private static async Task LoginAsync(
+        HttpClient client, System.Net.CookieContainer container, string email, string password)
+    {
+        var token = await PrimeAntiforgeryAsync(client, container);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/auth/login");
+        request.Headers.Add(AuthCookieNames.AntiforgeryHeader, token);
+        request.Content = JsonContent.Create(new LoginRequestDto(email, password));
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK, because: "login helper must succeed");
+    }
+
+    private static System.Net.Cookie? GetCookie(System.Net.CookieContainer container, string name)
+    {
+        foreach (System.Net.Cookie c in container.GetCookies(BaseUri))
+        {
+            if (string.Equals(c.Name, name, StringComparison.Ordinal))
+            {
+                return c;
+            }
+        }
+
+        return null;
+    }
+
+    private async Task<(HttpClient Client, Guid UserId, string Token)> RegisterLoginAndPrimeAsync()
+    {
+        var (client, container) = CreateCookieClient(Factory);
+        var email = $"sse-{Guid.NewGuid():N}@example.test";
+        var userId = await RegisterAsync(client, container, email, StrongPassword);
+        await LoginAsync(client, container, email, StrongPassword);
+        var token = await PrimeAntiforgeryAsync(client, container);
+        return (client, userId, token);
+    }
+
+    private async Task<ConversationView?> LoadConversationViewAsync(Guid userId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        return await session.LoadAsync<ConversationView>(userId, TestContext.Current.CancellationToken);
+    }
+
+    private async Task<int> CountWorkoutLogsAsync(Guid userId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<RunCoachDbContext>();
+        return await EntityFrameworkQueryableExtensions.CountAsync(
+            db.WorkoutLogs.Where(w => w.UserId == userId), TestContext.Current.CancellationToken);
+    }
+
+    private async Task SeedActivePlanAsync(Guid userId)
+    {
+        var planId = Guid.NewGuid();
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+            await using var session = store.LightweightSession(userId.ToString());
+            var sequence = StubPlanGenerationService.BuildCanonicalSequence(
+                planId, userId, goal: "Half Marathon", PlanGeneratedAt, previousPlanId: null);
+            session.Events.StartStream<PlanProjectionDto>(planId, [.. sequence.ToEvents()]);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<RunCoachDbContext>();
+            var profile = await EntityFrameworkQueryableExtensions.SingleOrDefaultAsync(
+                db.RunnerOnboardingProfiles.Where(p => p.UserId == userId), TestContext.Current.CancellationToken);
+            if (profile is null)
+            {
+                var now = DateTimeOffset.UtcNow;
+                db.RunnerOnboardingProfiles.Add(new RunnerOnboardingProfile
+                {
+                    UserId = userId,
+                    TenantId = userId.ToString(),
+                    CurrentPlanId = planId,
+                    CreatedOn = now,
+                    ModifiedOn = now,
+                });
+            }
+            else
+            {
+                profile.CurrentPlanId = planId;
+            }
+
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    private sealed record SseFrame(string Event, string Data);
+
+    private sealed record TokenPayload(string Delta);
+
+    private sealed record SafetyPayload(string Content, SafetyTier Tier, ReferralCategory Category);
+
+    private sealed record CardPayload(StructuredLogDraft Draft, CandidatePrescriptionDto? Prescription);
+
+    private sealed record ErrorPayload(string Message, bool Retryable, int? RetryAfterSeconds);
+
+    private sealed record DonePayload(Guid TurnId);
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/ConversationMessagesEndpointIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/ConversationMessagesEndpointIntegrationTests.cs
@@ -367,6 +367,11 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        var problem = await ReadProblemAsync(response);
+        problem.Status.Should().Be(400);
+        problem.Type.Should().Be("https://runcoach.app/problems/invalid-conversation-message");
+        problem.Title.Should().Be("The message must be non-empty and carry a non-empty client message id.");
+        problem.TraceId.Should().NotBeNullOrEmpty(because: "the ProblemDetails carries a traceId for correlation");
         StubCoachingLlm.StructuredCallCount.Should().Be(0, because: "a blank message never reaches the classifier");
     }
 
@@ -382,6 +387,12 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        var problem = await ReadProblemAsync(response);
+        problem.Status.Should().Be(400);
+        problem.Type.Should().Be("https://runcoach.app/problems/invalid-conversation-message");
+        problem.Title.Should().Be("The message must be non-empty and carry a non-empty client message id.");
+        problem.TraceId.Should().NotBeNullOrEmpty(because: "the ProblemDetails carries a traceId for correlation");
         StubCoachingLlm.StructuredCallCount.Should().Be(0);
     }
 
@@ -559,12 +570,9 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
     [Fact]
     public async Task PostHeartbeatUnhandledError_EmitsBestEffortRetryableErrorFrame_FromTheControllerCatch()
     {
-        // Arrange — the classifier throws an InvalidOperationException, standing in for an infra
-        // failure (bus / Marten / EF) that escapes the orchestrator. It is not one of the coaching-LLM
-        // exception types the orchestrator handles in-service, so it propagates all the way into the
-        // controller's unconditional post-heartbeat error handler — the best-effort error-frame path
-        // every in-stream failure test bypasses by scripting a coaching-LLM exception the orchestrator
-        // owns. A benign Green message keeps the safety gate quiet so the sole frame is the controller's.
+        // The classifier throws a non-coaching-LLM exception, which the orchestrator does not catch
+        // in-service, so it escapes into the controller's post-heartbeat error path. A benign Green
+        // message keeps the safety gate quiet, so the only frame is the controller's error frame.
         StubCoachingLlm.Reset();
         StubCoachingLlm.UseStructuredBehavior(
             () => throw new InvalidOperationException("infra failure escaping the orchestrator"));
@@ -606,12 +614,9 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
     [Fact]
     public async Task LoadAnswerContext_ExcludesErroredAndCurrentTurns_AndCapsAtTheRecentLimit()
     {
-        // Arrange — seed a realistic interactive conversation through the SAME two-write bus commands
-        // the production endpoint uses (so the real InteractiveConversationProjection materializes the
-        // ConversationView): 12 ordinary turns, then one errored coach marker, then the "current" user
-        // turn keyed by the clientMessageId under test. The context loader must drop the errored marker
-        // (!IsErrored) and the current turn (TurnId != clientMessageId) from the LLM grounding, then
-        // keep only the most-recent RecentTurnLimit (10) of what remains.
+        // Seed, through the production bus commands, twelve ordinary turns, one errored coach marker,
+        // and the current user turn keyed by the id under test. The loader must drop the errored marker
+        // and the current turn from the grounding, then keep only the most-recent ten of the rest.
         StubCoachingLlm.Reset();
         var userId = Guid.NewGuid();
         var currentTurnId = Guid.NewGuid();
@@ -746,6 +751,13 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
     private static T Payload<T>(SseFrame frame) =>
         JsonSerializer.Deserialize<T>(frame.Data, WebOptions)
         ?? throw new InvalidOperationException($"frame '{frame.Event}' had no JSON payload");
+
+    private static async Task<ProblemPayload> ReadProblemAsync(HttpResponseMessage response)
+    {
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        return JsonSerializer.Deserialize<ProblemPayload>(body, WebOptions)
+            ?? throw new InvalidOperationException("expected a ProblemDetails body");
+    }
 
     private static async Task<List<SseFrame>> ReadFramesAsync(HttpResponseMessage response)
     {
@@ -941,4 +953,6 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
     private sealed record ErrorPayload(string Message, bool Retryable, int? RetryAfterSeconds);
 
     private sealed record DonePayload(Guid TurnId);
+
+    private sealed record ProblemPayload(string? Type, string? Title, int? Status, string? TraceId);
 }

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/ConversationMessagesEndpointIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/ConversationMessagesEndpointIntegrationTests.cs
@@ -11,12 +11,14 @@ using Microsoft.Extensions.DependencyInjection;
 using RunCoach.Api.Infrastructure;
 using RunCoach.Api.Modules.Coaching;
 using RunCoach.Api.Modules.Coaching.Conversation;
+using RunCoach.Api.Modules.Coaching.Conversation.Streaming;
 using RunCoach.Api.Modules.Coaching.Onboarding.Entities;
 using RunCoach.Api.Modules.Identity.Contracts;
 using RunCoach.Api.Modules.Training.Plan.Models;
 using RunCoach.Api.Modules.Training.Safety;
 using RunCoach.Api.Modules.Training.Workouts;
 using RunCoach.Api.Tests.Infrastructure;
+using Wolverine;
 
 namespace RunCoach.Api.Tests.Modules.Coaching.Conversation.Streaming;
 
@@ -552,6 +554,121 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
         var view = await LoadConversationViewAsync(userId);
         view!.Turns.Should().ContainSingle(t => t.Participant == ConversationParticipant.Coach)
             .Which.IsErrored.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task PostHeartbeatUnhandledError_EmitsBestEffortRetryableErrorFrame_FromTheControllerCatch()
+    {
+        // Arrange — the classifier throws an InvalidOperationException, standing in for an infra
+        // failure (bus / Marten / EF) that escapes the orchestrator. It is not one of the coaching-LLM
+        // exception types the orchestrator handles in-service, so it propagates all the way into the
+        // controller's unconditional post-heartbeat error handler — the best-effort error-frame path
+        // every in-stream failure test bypasses by scripting a coaching-LLM exception the orchestrator
+        // owns. A benign Green message keeps the safety gate quiet so the sole frame is the controller's.
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(
+            () => throw new InvalidOperationException("infra failure escaping the orchestrator"));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(client, token, "How's my training going?", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert — the heartbeat already committed the 200 + text/event-stream before the throw, so
+        // the failure is NOT a 500 and the stream is NOT torn: the client reads it cleanly to
+        // completion (ReadFramesAsync returns without throwing) and gets exactly one error frame.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("text/event-stream");
+
+        var error = frames.Should().ContainSingle(f => f.Event == "error").Subject;
+        var errorPayload = Payload<ErrorPayload>(error);
+        errorPayload.Message.Should().Be(
+            "Something went wrong on my end. Try again in a moment.",
+            because: "the frame is the controller's hardcoded best-effort copy, proving the controller-level catch handled the escape rather than the orchestrator's in-service ClassifierFailedMessage path");
+        errorPayload.Retryable.Should().BeTrue(because: "the controller's best-effort error frame is always retryable");
+        errorPayload.RetryAfterSeconds.Should().BeNull(
+            because: "the controller emits no back-off hint on an unhandled escape");
+
+        frames.Should().NotContain(f => f.Event == "done", because: "an unhandled failure has no terminal done frame");
+        frames.Should().NotContain(f => f.Event == "token", because: "the throw escapes before any answer streams");
+
+        // The durable-first user turn still persisted (PersistUserTurnAsync committed before the
+        // classifier ran), proving the failure is strictly post-heartbeat and nothing beyond the
+        // user turn was written on the escape.
+        var view = await LoadConversationViewAsync(userId);
+        view!.Turns.Should().ContainSingle()
+            .Which.Participant.Should().Be(
+                ConversationParticipant.User,
+                because: "only the durable user turn persists; the unhandled escape writes no coach turn");
+    }
+
+    [Fact]
+    public async Task LoadAnswerContext_ExcludesErroredAndCurrentTurns_AndCapsAtTheRecentLimit()
+    {
+        // Arrange — seed a realistic interactive conversation through the SAME two-write bus commands
+        // the production endpoint uses (so the real InteractiveConversationProjection materializes the
+        // ConversationView): 12 ordinary turns, then one errored coach marker, then the "current" user
+        // turn keyed by the clientMessageId under test. The context loader must drop the errored marker
+        // (!IsErrored) and the current turn (TurnId != clientMessageId) from the LLM grounding, then
+        // keep only the most-recent RecentTurnLimit (10) of what remains.
+        StubCoachingLlm.Reset();
+        var userId = Guid.NewGuid();
+        var currentTurnId = Guid.NewGuid();
+        const string erroredContent = "errored marker should never ground the prompt";
+        const string currentContent = "current turn should be excluded from its own grounding";
+        var ct = TestContext.Current.CancellationToken;
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+
+            // 12 ordinary turns, oldest-first, alternating runner/coach (the first MUST be a user
+            // turn — the Conversation stream is created by a UserMessagePosted).
+            for (var i = 0; i < 12; i++)
+            {
+                if (i % 2 == 0)
+                {
+                    await bus.InvokeForTenantAsync<ConversationTurnPostedResponse>(
+                        userId.ToString(), new PostUserConversationTurn(userId, Guid.NewGuid(), $"turn-{i:D2}"), ct);
+                }
+                else
+                {
+                    await bus.InvokeForTenantAsync<ConversationTurnPostedResponse>(
+                        userId.ToString(),
+                        new PostCoachConversationTurn(userId, Guid.NewGuid(), $"turn-{i:D2}", IsErrored: false),
+                        ct);
+                }
+            }
+
+            // An errored coach marker (the projection forces its content empty) ...
+            await bus.InvokeForTenantAsync<ConversationTurnPostedResponse>(
+                userId.ToString(),
+                new PostCoachConversationTurn(userId, Guid.NewGuid(), erroredContent, IsErrored: true),
+                ct);
+
+            // ... and the current user turn, keyed by the clientMessageId the loader is asked about.
+            await bus.InvokeForTenantAsync<ConversationTurnPostedResponse>(
+                userId.ToString(), new PostUserConversationTurn(userId, currentTurnId, currentContent), ct);
+        }
+
+        // Act
+        ConversationAnswerContext context;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var loader = scope.ServiceProvider.GetRequiredService<IConversationContextLoader>();
+            context = await loader.LoadAnswerContextAsync(userId, currentTurnId, ct);
+        }
+
+        // Assert — the errored marker and the current turn are gone, and only the 10 most-recent of
+        // the 12 ordinary turns survive the cap (turn-00 and turn-01 are dropped), in append order.
+        context.RecentTurns.Should().NotContain(
+            t => t.Content == currentContent,
+            because: "the just-persisted current turn (TurnId == clientMessageId) is excluded from its own grounding");
+        context.RecentTurns.Should().NotContain(
+            t => t.Content.Length == 0, because: "errored coach markers carry empty content and never ground the prompt");
+        context.RecentTurns.Select(t => t.Content).Should()
+            .Equal("turn-02", "turn-03", "turn-04", "turn-05", "turn-06", "turn-07", "turn-08", "turn-09", "turn-10", "turn-11");
     }
 
     /// <inheritdoc />

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/SseWriterTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/SseWriterTests.cs
@@ -1,0 +1,126 @@
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching.Conversation.Streaming;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Conversation.Streaming;
+
+/// <summary>
+/// Unit tests over <see cref="SseWriter"/> — the hand-rolled Server-Sent-Events frame
+/// serializer for the streaming Q&amp;A endpoint (Slice 4B PR4). Asserts the exact wire
+/// framing (<c>event: …\ndata: …\n\n</c>), the heartbeat comment shape, camelCase JSON
+/// payloads, and that every frame is flushed individually (SSE buffering off).
+/// </summary>
+public sealed class SseWriterTests
+{
+    private static readonly JsonSerializerOptions WebOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public async Task WriteEventAsync_EmitsEventThenDataThenBlankLine()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        var writer = new SseWriter(stream, WebOptions);
+
+        // Act
+        await writer.WriteEventAsync("token", new { delta = "hi" }, TestContext.Current.CancellationToken);
+
+        // Assert
+        var actual = Encoding.UTF8.GetString(stream.ToArray());
+        actual.Should().Be(
+            "event: token\ndata: {\"delta\":\"hi\"}\n\n",
+            because: "an SSE frame is the event name, a single compact JSON data line, then a blank line terminator");
+    }
+
+    [Fact]
+    public async Task WriteEventAsync_SerializesPayloadCamelCase()
+    {
+        // Arrange — a PascalCase property must surface camelCase on the wire (JsonSerializerDefaults.Web),
+        // matching every other API response and NOT the snake_case structured-output options.
+        using var stream = new MemoryStream();
+        var writer = new SseWriter(stream, WebOptions);
+
+        // Act
+        await writer.WriteEventAsync(
+            "error",
+            new ErrorPayload("boom", Retryable: true, RetryAfterSeconds: 5),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var actual = Encoding.UTF8.GetString(stream.ToArray());
+        actual.Should().Be("event: error\ndata: {\"message\":\"boom\",\"retryable\":true,\"retryAfterSeconds\":5}\n\n");
+    }
+
+    [Fact]
+    public async Task WriteHeartbeatAsync_EmitsACommentLine()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        var writer = new SseWriter(stream, WebOptions);
+
+        // Act
+        await writer.WriteHeartbeatAsync(TestContext.Current.CancellationToken);
+
+        // Assert — an SSE comment line starts with ':' and carries no event/data, so it
+        // keeps the connection alive without the client treating it as a message.
+        var actual = Encoding.UTF8.GetString(stream.ToArray());
+        actual.Should().StartWith(":", because: "a heartbeat is an SSE comment, not an event");
+        actual.Should().EndWith("\n\n");
+        actual.Should().NotContain("event:", because: "a heartbeat must not parse as a typed frame");
+    }
+
+    [Fact]
+    public async Task EachWrite_FlushesIndividually()
+    {
+        // Arrange — SSE requires buffering off so each token reaches the client as it is
+        // produced; assert FlushAsync fires once per frame (and once per heartbeat).
+        var inner = new MemoryStream();
+        await using var flushTracker = new FlushCountingStream(inner);
+        var writer = new SseWriter(flushTracker, WebOptions);
+
+        // Act
+        await writer.WriteEventAsync("token", new { delta = "a" }, TestContext.Current.CancellationToken);
+        await writer.WriteEventAsync("token", new { delta = "b" }, TestContext.Current.CancellationToken);
+        await writer.WriteHeartbeatAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        flushTracker.FlushCount.Should().Be(3, because: "every frame and heartbeat is flushed the moment it is written");
+    }
+
+    private sealed record ErrorPayload(string Message, bool Retryable, int? RetryAfterSeconds);
+
+    /// <summary>A pass-through stream that counts <see cref="FlushAsync(CancellationToken)"/> calls.</summary>
+    private sealed class FlushCountingStream(Stream inner) : Stream
+    {
+        public int FlushCount { get; private set; }
+
+        public override bool CanRead => inner.CanRead;
+
+        public override bool CanSeek => inner.CanSeek;
+
+        public override bool CanWrite => inner.CanWrite;
+
+        public override long Length => inner.Length;
+
+        public override long Position { get => inner.Position; set => inner.Position = value; }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            FlushCount++;
+            return inner.FlushAsync(cancellationToken);
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => inner.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count) => inner.Write(buffer, offset, count);
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
+            inner.WriteAsync(buffer, cancellationToken);
+    }
+}

--- a/frontend/src/app/api/generated/rtk/api.ts
+++ b/frontend/src/app/api/generated/rtk/api.ts
@@ -153,7 +153,7 @@ export type GetApiV1ConversationTurnsApiResponse = /** status 200 OK */ Conversa
 export type GetApiV1ConversationTurnsApiArg = void
 export type GetApiV1ConversationTimelineApiResponse = /** status 200 OK */ ConversationTimelineDto
 export type GetApiV1ConversationTimelineApiArg = void
-export type PostApiV1ConversationMessagesApiResponse = unknown
+export type PostApiV1ConversationMessagesApiResponse = /** status 200 OK */ string
 export type PostApiV1ConversationMessagesApiArg = {
   conversationMessageRequestDto: ConversationMessageRequestDto
 }

--- a/frontend/src/app/api/generated/rtk/api.ts
+++ b/frontend/src/app/api/generated/rtk/api.ts
@@ -58,6 +58,16 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: () => ({ url: `/api/v1/conversation/timeline` }),
     }),
+    postApiV1ConversationMessages: build.mutation<
+      PostApiV1ConversationMessagesApiResponse,
+      PostApiV1ConversationMessagesApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/v1/conversation/messages`,
+        method: 'POST',
+        body: queryArg.conversationMessageRequestDto,
+      }),
+    }),
     postApiV1OnboardingTurns: build.mutation<
       PostApiV1OnboardingTurnsApiResponse,
       PostApiV1OnboardingTurnsApiArg
@@ -143,6 +153,10 @@ export type GetApiV1ConversationTurnsApiResponse = /** status 200 OK */ Conversa
 export type GetApiV1ConversationTurnsApiArg = void
 export type GetApiV1ConversationTimelineApiResponse = /** status 200 OK */ ConversationTimelineDto
 export type GetApiV1ConversationTimelineApiArg = void
+export type PostApiV1ConversationMessagesApiResponse = unknown
+export type PostApiV1ConversationMessagesApiArg = {
+  conversationMessageRequestDto: ConversationMessageRequestDto
+}
 export type PostApiV1OnboardingTurnsApiResponse = /** status 200 OK */ OnboardingTurnResponseDto
 export type PostApiV1OnboardingTurnsApiArg = {
   onboardingTurnRequestDto: OnboardingTurnRequestDto
@@ -307,6 +321,10 @@ export type ConversationTimelineTurnDto = {
 }
 export type ConversationTimelineDto = {
   turns: ConversationTimelineTurnDto[]
+}
+export type ConversationMessageRequestDto = {
+  message: string
+  clientMessageId: string
 }
 export type OnboardingTurnKind = 0 | 1 | 2
 export type OnboardingTopic = 0 | 1 | 2 | 3 | 4 | 5
@@ -566,6 +584,7 @@ export const {
   usePostApiV1ClientErrorsMutation,
   useGetApiV1ConversationTurnsQuery,
   useGetApiV1ConversationTimelineQuery,
+  usePostApiV1ConversationMessagesMutation,
   usePostApiV1OnboardingTurnsMutation,
   useGetApiV1OnboardingStateQuery,
   usePostApiV1OnboardingAnswersReviseMutation,

--- a/frontend/src/app/api/generated/zod/conversation/conversation.ts
+++ b/frontend/src/app/api/generated/zod/conversation/conversation.ts
@@ -420,3 +420,10 @@ export const GetApiV1ConversationTimelineResponse = zod.strictObject({
     }),
   ),
 })
+
+export const PostApiV1ConversationMessagesBody = zod.strictObject({
+  message: zod.string(),
+  clientMessageId: zod.uuid(),
+})
+
+export const PostApiV1ConversationMessagesResponse = zod.unknown()


### PR DESCRIPTION
## Slice 4B PR4 — Streaming Q&A SSE endpoint (the integration gate)

Wires PR1 (`ICoachingLlm.StreamAsync`), PR2 (user-scoped `Conversation` persistence), and PR3 (intent classifier + `ComposeForConversationAsync`) behind a new **`POST /api/v1/conversation/messages`** Server-Sent-Events endpoint — the first interactive free-text chat path in the codebase. Spec: `docs/specs/19-spec-slice-4b-conversation-core/` (Unit 2). Decisions: DEC-073, DEC-085, DEC-084, DEC-059, DEC-060.

### What it does

Per message, `ConversationStreamService` orchestrates: **persist the user turn durable-first** → deterministic **`SafetyGate`** (on a separately-sanitized copy) → **classify** → route:

- **Green/Question** → `ComposeForConversationAsync` → `StreamAsync`, streamed as `token` frames, persisted as a coach turn on a clean finish with a terminal `done{turnId}`.
- **Red** (crisis/emergency) → scripted `988`/`741741` resources as a `safety` frame + coach turn; **no LLM** (classifier + stream never called).
- **Amber** (injury/RED-S) → scripted referral surfaced **before** the answer (distinct derived turn id, so it never collides with the answer turn), then the coach still answers.
- **WorkoutLog** → a `card` frame carrying the parsed draft + the server-resolved candidate prescription; **commits nothing** (the plan-mutating commit waits for an explicit Confirm — PR5).
- **Ambiguous** → a scripted clarification; never silently routed to a log.

Failure handling follows DEC-073/DEC-085: a classifier failure emits an `error` frame and persists nothing beyond the user turn (intent is never guessed); a mid/post-stream failure (`Transient`/`Permanent`/`Incomplete`) discards the partial, persists an **errored marker** (never a partial-as-complete), and emits an `error` frame; a **client abort** persists nothing and never 500s.

### Notable surface

- **`SseWriter`** — hand-rolled `event: …\ndata: {json}\n\n` framing + heartbeat, flush-per-frame, buffering off (no SSE dependency). The controller action returns `EmptyResult` after writing the stream manually.
- **`PostScriptedSafetyTurn`** command/handler — persists the Amber referral as a `CoachMessagePosted` coach turn (reusing the shipped event + projection; no `RegisteredEventTypes` change), keyed on a new `ConversationTurnId.DeriveSafetyTurnId` (distinct namespace from `DeriveCoachTurnId`).
- **`IWorkoutLogService.ResolveCandidatePrescriptionAsync`** — public seam over the existing prescription resolver for the card frame.
- **`IConversationFrame`** family (`token`/`safety`/`card`/`error`/`done`) — the orchestrator yields typed frames; the controller serializes.

> **Design note (worth a look):** the interactive stream (PR2) carries only User/Coach turns, so a chat safety turn is a **coach turn carrying scripted copy** (the scripted constants' own docs already call them "coach turns"). It renders as a coach bubble in the timeline at MVP-0; a tier-accented chat safety turn is deferred. Adding the `safety` SSE frame type + the `PostScriptedSafetyTurn` command is within PR4's mandate (wiring safety turns into the SSE surface), not in PR2's persistence schema.

### Tests (21 new, full suite 1979/1979 green in Replay)

- `SseWriterTests` (4) — framing, camelCase, heartbeat shape, per-frame flush.
- `ConversationTurnIdTests` (+5) — `DeriveSafetyTurnId` determinism + distinctness from the coach id.
- `ConversationMessagesEndpointIntegrationTests` (10) — Green, Green-no-plan, Red, Amber, WorkoutLog, Ambiguous, mid-stream failure, classifier failure, client abort, missing antiforgery.
- `StubCoachingLlm` gained a streaming test seam (`UseStreamBehavior`/`StreamCallCount`).

OpenAPI `swagger.json` + the frontend RTK/Zod codegen were regenerated for the new endpoint (drift gate clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCCmKo4SJT7isTLzyjwAEK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new SSE-based endpoint for streaming conversation replies, including tokenized answers, safety notices, clarification prompts, workout confirmation cards, and terminal completion signaling.
  * Introduced a request DTO with required `clientMessageId` and message idempotency to prevent duplicate results on re-sends.
  * Documented the endpoint and DTO in the OpenAPI spec.
* **Bug Fixes**
  * Improved validation (antiforgery, authenticated user id, non-blank message, non-empty `clientMessageId`) and added structured retryable/non-retryable error frames for transient vs permanent failures.
* **Tests**
  * Added comprehensive end-to-end and SSE framing tests for the new streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->