### PR TITLE
feat(slice-4c-units): PR3 — settings RTK slice + Units toggle

### DIFF
--- a/frontend/src/app/api/api-slice.ts
+++ b/frontend/src/app/api/api-slice.ts
@@ -7,6 +7,6 @@ import { baseQueryWith401Handler } from '~/api/base-query'
 export const apiSlice = createApi({
   reducerPath: 'api',
   baseQuery: baseQueryWith401Handler,
-  tagTypes: ['Auth', 'Onboarding', 'Plan', 'WorkoutLog', 'Conversation'],
+  tagTypes: ['Auth', 'Onboarding', 'Plan', 'WorkoutLog', 'Conversation', 'UserSettings'],
   endpoints: () => ({}),
 })

--- a/frontend/src/app/api/generated/index.ts
+++ b/frontend/src/app/api/generated/index.ts
@@ -126,6 +126,13 @@ export type {
   ConversationMessageRequestDto,
 } from './rtk/api'
 
+// Slice 4C units — the unit-preference DTO consumed by the settings RTK slice
+// (`settings.api.ts`). Re-exported type-only (same reasoning as the workout-log
+// DTOs above) so the wire shape stays generated, not hand-mirrored; a backend
+// rename ripples here via `codegen:check` + `tsc`. (`PreferredUnits` itself is
+// re-exported below, paired with its `as const` enum.)
+export type { UnitPreferenceDto } from './rtk/api'
+
 export const completionStatusSchema = createWorkoutLogRequestSchema.shape.completionStatus
 export type CompletionStatus = z.infer<typeof completionStatusSchema>
 

--- a/frontend/src/app/api/settings.api.spec.ts
+++ b/frontend/src/app/api/settings.api.spec.ts
@@ -1,0 +1,127 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiSlice } from '~/api/api-slice'
+import type { UnitPreferenceDto } from '~/api/generated'
+import { clearXsrfCookie, PatchedRequest, seedXsrfCookie } from './test-helpers'
+import { settingsApi } from './settings.api'
+
+// Dispatch the endpoint thunks directly with `fetch` stubbed at the global
+// level so the real `query: () => ({...})` factories and the success-gated
+// `invalidatesTags` callback execute (the component spec mocks the hooks and
+// never reaches them). Mirrors `workout-log.api.spec.ts`.
+const jsonResponse = (body: Record<string, unknown>, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const makeStore = () =>
+  configureStore({
+    reducer: { [apiSlice.reducerPath]: apiSlice.reducer },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(apiSlice.middleware),
+  })
+
+describe('settingsApi query factories', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    // A fresh `Response` per call — the same object cannot be `.clone()`d twice
+    // (undici: "Body has already been consumed").
+    fetchMock = vi.fn().mockImplementation(() => jsonResponse({ preferredUnits: 1 }))
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('Request', PatchedRequest)
+    // Mirror the booted runtime: the antiforgery cookie is present, so the base
+    // query's lazy XSRF seed stays quiet and the assertions see only the request
+    // under test.
+    seedXsrfCookie()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    clearXsrfCookie()
+  })
+
+  it('issues a GET to /api/v1/settings/units', async () => {
+    const store = makeStore()
+    const result = await store.dispatch(settingsApi.endpoints.getUnitPreference.initiate(undefined))
+
+    expect(result.data).toEqual({ preferredUnits: 1 })
+    const request = fetchMock.mock.calls[0][0] as Request
+    expect(request.method).toBe('GET')
+    expect(request.url).toContain('/api/v1/settings/units')
+  })
+
+  it('issues a PUT to /api/v1/settings/units with the preferred-units body', async () => {
+    const store = makeStore()
+    const body: UnitPreferenceDto = { preferredUnits: 1 }
+
+    await store.dispatch(settingsApi.endpoints.putUnitPreference.initiate(body))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const request = fetchMock.mock.calls[0][0] as Request
+    expect(request.method).toBe('PUT')
+    expect(request.url).toContain('/api/v1/settings/units')
+    expect(await request.clone().json()).toEqual(body)
+  })
+})
+
+describe('putUnitPreference cache invalidation', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  const callsTo = (method: string): number =>
+    fetchMock.mock.calls.filter((call) => (call[0] as Request).method === method).length
+
+  beforeEach(() => {
+    vi.stubGlobal('Request', PatchedRequest)
+    seedXsrfCookie()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    clearXsrfCookie()
+  })
+
+  it('refetches the subscribed unit preference after a successful save', async () => {
+    fetchMock = vi.fn().mockImplementation(() => jsonResponse({ preferredUnits: 1 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const store = makeStore()
+
+    // A live subscription on the GET, as the Units toggle holds while mounted.
+    await store.dispatch(settingsApi.endpoints.getUnitPreference.initiate(undefined))
+    expect(callsTo('GET')).toBe(1)
+
+    await store.dispatch(settingsApi.endpoints.putUnitPreference.initiate({ preferredUnits: 1 }))
+
+    // The success-gated `invalidatesTags` callback returns ['UserSettings'], so
+    // the subscribed GET refetches in the same interaction.
+    await vi.waitFor(() => expect(callsTo('GET')).toBe(2))
+  })
+
+  it('does not refetch the unit preference when the save fails', async () => {
+    // RTK Query applies a *static* `invalidatesTags` array on rejected-with-value
+    // mutations too, so the callback form must return `[]` on error. A failed PUT
+    // must not refetch the preference.
+    fetchMock = vi
+      .fn()
+      .mockImplementation((input: Request) =>
+        input.method === 'PUT'
+          ? Promise.resolve(jsonResponse({ title: 'bad request' }, 400))
+          : Promise.resolve(jsonResponse({ preferredUnits: 0 })),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+    const store = makeStore()
+
+    await store.dispatch(settingsApi.endpoints.getUnitPreference.initiate(undefined))
+    expect(callsTo('GET')).toBe(1)
+
+    const result = await store.dispatch(
+      settingsApi.endpoints.putUnitPreference.initiate({ preferredUnits: 1 }),
+    )
+    expect('error' in result).toBe(true)
+
+    // Give any (incorrect) invalidation a chance to fire before asserting the
+    // count held — the failed save must leave the subscription untouched.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(callsTo('GET')).toBe(1)
+  })
+})

--- a/frontend/src/app/api/settings.api.ts
+++ b/frontend/src/app/api/settings.api.ts
@@ -1,0 +1,36 @@
+import { apiSlice } from '~/api/api-slice'
+import type { UnitPreferenceDto } from '~/api/generated'
+
+// Settings endpoints are injected into the root `apiSlice` so every request
+// shares the same cookie + antiforgery base query. URL segments (e.g.
+// `/v1/settings/units`) are relative to the global `/api` prefix supplied by
+// the base query.
+//
+// `getUnitPreference` is tagged `UserSettings` so the `putUnitPreference`
+// mutation can invalidate it and have the preference refetch after a save. The
+// callback form gates invalidation on success — RTK Query applies a *static*
+// `invalidatesTags` array on rejected-with-value mutations too (an HTTP failure
+// surfaces as a rejected-with-value base-query error), so returning `[]` on
+// error keeps a failed save from firing a pointless refetch. We deliberately
+// avoid `updateQueryData` optimism — it silently no-ops on a cold cache
+// (uninitialized or pending-with-no-data), which is exactly the state a
+// first-visit Settings page is in.
+export const settingsApi = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getUnitPreference: builder.query<UnitPreferenceDto, undefined>({
+      query: () => ({ url: '/v1/settings/units', method: 'GET' }),
+      providesTags: ['UserSettings'],
+    }),
+    putUnitPreference: builder.mutation<UnitPreferenceDto, UnitPreferenceDto>({
+      query: (body) => ({
+        url: '/v1/settings/units',
+        method: 'PUT',
+        body,
+      }),
+      invalidatesTags: (_result, error) => (error === undefined ? ['UserSettings'] : []),
+    }),
+  }),
+})
+
+/** Auto-generated RTK Query hooks for the settings endpoints. */
+export const { useGetUnitPreferenceQuery, usePutUnitPreferenceMutation } = settingsApi

--- a/frontend/src/app/modules/settings/components/units-toggle.component.spec.tsx
+++ b/frontend/src/app/modules/settings/components/units-toggle.component.spec.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface UnitPreference {
+  preferredUnits: 0 | 1
+}
+
+// Hoisted so the `vi.mock` factories below can close over the same references the
+// test body drives. `getQueryRef.data` stands in for the RTK query result;
+// `putMock` records the mutation trigger's argument; `toastErrorMock` /
+// `reportClientErrorMock` capture the failure-path side effects.
+const { getQueryRef, putMock, toastErrorMock, reportClientErrorMock } = vi.hoisted(() => ({
+  getQueryRef: { data: undefined as UnitPreference | undefined },
+  putMock: vi.fn<(arg: UnitPreference) => { unwrap: () => Promise<UnitPreference> }>(),
+  toastErrorMock: vi.fn(),
+  reportClientErrorMock: vi.fn(),
+}))
+
+vi.mock('~/api/settings.api', () => ({
+  useGetUnitPreferenceQuery: () => getQueryRef,
+  usePutUnitPreferenceMutation: () => [putMock, { isLoading: false }],
+}))
+
+vi.mock('sonner', () => ({ toast: { error: toastErrorMock } }))
+
+vi.mock('~/error-boundary/report-client-error', () => ({
+  reportClientError: reportClientErrorMock,
+}))
+
+import { UnitsToggle } from './units-toggle.component'
+
+describe('UnitsToggle', () => {
+  beforeEach(() => {
+    putMock.mockReset()
+    putMock.mockReturnValue({ unwrap: () => Promise.resolve({ preferredUnits: 1 }) })
+    getQueryRef.data = { preferredUnits: 0 }
+    toastErrorMock.mockReset()
+    reportClientErrorMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders both unit options with the current one selected', () => {
+    render(<UnitsToggle />)
+    expect(screen.getByRole('radio', { name: 'Kilometers' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Miles' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Kilometers' })).toBeChecked()
+    expect(screen.getByRole('radio', { name: 'Miles' })).not.toBeChecked()
+  })
+
+  it('reflects Miles as selected when the stored preference is Miles', () => {
+    getQueryRef.data = { preferredUnits: 1 }
+    render(<UnitsToggle />)
+    expect(screen.getByRole('radio', { name: 'Miles' })).toBeChecked()
+    expect(screen.getByRole('radio', { name: 'Kilometers' })).not.toBeChecked()
+  })
+
+  it('defaults to Kilometers while the preference is loading', () => {
+    getQueryRef.data = undefined
+    render(<UnitsToggle />)
+    expect(screen.getByRole('radio', { name: 'Kilometers' })).toBeChecked()
+  })
+
+  it('dispatches the put mutation with { preferredUnits: 1 } when Miles is selected', async () => {
+    render(<UnitsToggle />)
+    await userEvent.click(screen.getByRole('radio', { name: 'Miles' }))
+    expect(putMock).toHaveBeenCalledWith({ preferredUnits: 1 })
+  })
+
+  it('reports the error and shows a toast when the save fails', async () => {
+    putMock.mockReturnValue({ unwrap: () => Promise.reject(new Error('network down')) })
+    render(<UnitsToggle />)
+    await userEvent.click(screen.getByRole('radio', { name: 'Miles' }))
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledTimes(1))
+    expect(reportClientErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'unhandled-rejection' }),
+    )
+  })
+})

--- a/frontend/src/app/modules/settings/components/units-toggle.component.tsx
+++ b/frontend/src/app/modules/settings/components/units-toggle.component.tsx
@@ -1,0 +1,79 @@
+import type { ReactElement } from 'react'
+import { toast } from 'sonner'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { Label } from '@/components/ui/label'
+import { PreferredUnits } from '~/api/generated'
+import { useGetUnitPreferenceQuery, usePutUnitPreferenceMutation } from '~/api/settings.api'
+import { reportClientError } from '~/error-boundary/report-client-error'
+
+// Selectable options in display order. `value` is the `PreferredUnits` enum
+// (`0 | 1` on the wire) stored server-side; `label` is the user-facing copy.
+// `PreferredUnits.Kilometers`/`.Miles` come from the generated const-paired enum
+// so this control never hard-codes the magic integers. Radix `RadioGroup` values
+// are strings, so we map `String(value)` ↔ the enum at the group boundary.
+const UNIT_OPTIONS: ReadonlyArray<{ value: PreferredUnits; label: string }> = [
+  { value: PreferredUnits.Kilometers, label: 'Kilometers' },
+  { value: PreferredUnits.Miles, label: 'Miles' },
+]
+
+// Radix `RadioGroup` hands `onValueChange` a raw string; resolve it back to a
+// known `PreferredUnits` by matching an option rather than casting an
+// unvalidated `Number()` into the `0 | 1` union. An unrecognized value falls
+// back to Kilometers.
+const parsePreferredUnits = (value: string): PreferredUnits =>
+  UNIT_OPTIONS.find((option) => String(option.value) === value)?.value ?? PreferredUnits.Kilometers
+
+/**
+ * 2-state distance-unit control for the Settings page (DEC-086). Reads the
+ * persisted preference via `getUnitPreference` and writes the new choice with
+ * `putUnitPreference`, whose `UserSettings` tag invalidation refetches the
+ * query. While the preference is still loading it falls back to Kilometers so
+ * the control always renders with a selection.
+ *
+ * This control only records the preference. It does not affect how distances or
+ * paces are currently rendered elsewhere in the app.
+ */
+export const UnitsToggle = (): ReactElement => {
+  const { data } = useGetUnitPreferenceQuery(undefined)
+  const [putUnitPreference] = usePutUnitPreferenceMutation()
+  const current = data?.preferredUnits ?? PreferredUnits.Kilometers
+
+  // Await `.unwrap()` so a failed PUT is a *handled* rejection we can surface:
+  // the bare trigger promise resolves either way and would swallow the error,
+  // and the success-gated invalidation means a failure leaves the toggle on the
+  // persisted unit with no other signal. Mirrors the log/coach-chat convention.
+  const persistPreference = async (preferredUnits: PreferredUnits): Promise<void> => {
+    try {
+      await putUnitPreference({ preferredUnits }).unwrap()
+    } catch (error) {
+      reportClientError({
+        kind: 'unhandled-rejection',
+        error: error instanceof Error ? error : new Error(String(error)),
+      })
+      toast.error('We could not save your unit preference. Try again in a moment.')
+    }
+  }
+
+  return (
+    <RadioGroup
+      value={String(current)}
+      onValueChange={(value) => {
+        void persistPreference(parsePreferredUnits(value))
+      }}
+      aria-label="Units"
+      data-testid="settings-units-toggle"
+      className="mt-2 grid-cols-2 gap-2"
+    >
+      {UNIT_OPTIONS.map((option) => (
+        <Label
+          key={option.value}
+          htmlFor={`units-option-${option.value}`}
+          className="flex cursor-pointer items-center gap-2 rounded-md border border-input p-3 transition-colors has-[:checked]:border-primary has-[:checked]:bg-accent motion-reduce:transition-none"
+        >
+          <RadioGroupItem id={`units-option-${option.value}`} value={String(option.value)} />
+          {option.label}
+        </Label>
+      ))}
+    </RadioGroup>
+  )
+}

--- a/frontend/src/app/modules/settings/pages/settings-page.spec.tsx
+++ b/frontend/src/app/modules/settings/pages/settings-page.spec.tsx
@@ -39,6 +39,14 @@ vi.mock('~/modules/settings/components/theme-toggle.component', () => ({
   ThemeToggle: () => <div data-testid="theme-toggle-stub">theme toggle</div>,
 }))
 
+// `UnitsToggle` drives the `settings.api` RTK hooks, which need the store
+// mounted in `main.tsx` and not in this page-scoped tree. Stubbed here — its
+// own behaviour is covered by `units-toggle.component.spec.tsx` — so this
+// suite stays focused on the SettingsPage's plan logic.
+vi.mock('~/modules/settings/components/units-toggle.component', () => ({
+  UnitsToggle: () => <div data-testid="units-toggle-stub">units toggle</div>,
+}))
+
 import { SettingsPage } from './settings.page'
 
 const renderPage = () =>

--- a/frontend/src/app/modules/settings/pages/settings.page.tsx
+++ b/frontend/src/app/modules/settings/pages/settings.page.tsx
@@ -5,6 +5,7 @@ import { Card } from '@/components/ui/card'
 import { useGetCurrentPlanQuery } from '~/api/plan.api'
 import { RegeneratePlanDialog } from '~/modules/settings/components/regenerate-plan-dialog.component'
 import { ThemeToggle } from '~/modules/settings/components/theme-toggle.component'
+import { UnitsToggle } from '~/modules/settings/components/units-toggle.component'
 
 /**
  * `/settings` route surface. Renders the "Plan" section: current plan's
@@ -59,6 +60,14 @@ export const SettingsPage = (): ReactElement => {
           Choose how RunCoach looks. System follows your device setting.
         </p>
         <ThemeToggle />
+      </Card>
+
+      <Card className="gap-2 p-6" data-testid="settings-units-section">
+        <h2 className="text-lg font-semibold text-foreground">Units</h2>
+        <p className="text-sm text-muted-foreground">
+          Choose how distances and paces are displayed.
+        </p>
+        <UnitsToggle />
       </Card>
 
       <RegeneratePlanDialog isOpen={isDialogOpen} onClose={() => setIsDialogOpen(false)} />


### PR DESCRIPTION
## Summary

PR3 of 6 in the slice-4c-units sub-slice. Adds the user-facing distance-unit **preference control** (Demoable Unit 2, part B). This is the write side only — it records the km/miles choice server-side. **Nothing renders differently yet**; distance/pace render sites are wired in PR4/PR5.

Depends on PR1's merged codegen (`useGetApiV1SettingsUnitsQuery` / `UnitPreferenceDto` / `PreferredUnits`). Consumed by PR4/PR5.

## Changes

- **`api-slice.ts`** — add `'UserSettings'` to `tagTypes`.
- **`settings.api.ts`** (new) — `apiSlice.injectEndpoints` mirroring `plan.api.ts`:
  - `getUnitPreference` — `GET /v1/settings/units`, `providesTags: ['UserSettings']`
  - `putUnitPreference` — `PUT /v1/settings/units`, body `{ preferredUnits }`, `invalidatesTags: ['UserSettings']`
  - Plain tag invalidation — **no `updateQueryData`** (it no-ops on a cold cache, exactly the first-visit Settings state).
- **`generated/index.ts`** — type-only re-export of `UnitPreferenceDto` + `PreferredUnits` through the barrel seam.
- **`units-toggle.component.tsx`** (new) — `RadioGroup` (Kilometers/Miles) mirroring `ThemeToggle`: `has-[:checked]` styling, `motion-reduce:transition-none`, `data-testid="settings-units-toggle"`. Reads the preference (defaults to Kilometers while loading); writes on change. Maps `String(PreferredUnits)` ↔ numeric enum at the group boundary.
- **`settings.page.tsx`** — new "Units" Card (heading + "Choose how distances and paces are displayed.") placed before `RegeneratePlanDialog`.
- **Tests** — `units-toggle.component.spec.tsx` (4 tests: both options render with current selected, Miles reflected when stored, Kilometers default while loading, selecting Miles dispatches `{ preferredUnits: 1 }`); `settings-page.spec.tsx` gets a `UnitsToggle` stub mirroring the existing `ThemeToggle` stub.

## Verification

- `npm run build` — pass (tsc + vite, 0 type errors)
- `npm run test` — **561/561 pass** (`units-toggle` suite 4/4)
- `npm run lint` — clean for changed files (remaining errors are pre-existing `no-hardcoded-passwords` login/register/e2e fixtures, untouched here)

### Follow-ups found

- [ ] Distance/pace render-site wiring (PR4/PR5) — this PR only records the preference.
- [ ] Shared unit-format module (PR2) — no conversion logic in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBys3jXwmr5C2QXxaGaDpL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Units section to the Settings page, allowing users to switch between kilometers and miles.
  * Persisted the user’s selected units and reflect the choice automatically across the Settings UI.

* **Bug Fixes**
  * Improved unit preference saving behavior so failed updates no longer trigger unnecessary refreshes.
  * Added user-facing error feedback and reporting when unit preference saves fail.

* **Tests**
  * Extended Units toggle and Settings page test coverage, including failure-path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->