### PR TITLE
feat(slice-4c-units): PR2 — shared unit-format module (pure + tests)

### DIFF
--- a/frontend/src/app/api/generated/index.ts
+++ b/frontend/src/app/api/generated/index.ts
@@ -187,3 +187,22 @@ type _CompletionStatusConstMembers = (typeof CompletionStatus)[keyof typeof Comp
 type _CompletionStatusUnionMinusConst = Exclude<CompletionStatus, _CompletionStatusConstMembers>
 type _CompletionStatusExhaustive = _CompletionStatusUnionMinusConst extends never ? true : never
 export const _completionStatusExhaustivenessGuard: _CompletionStatusExhaustive = true
+
+// Settings km/miles display preference (slice 4C-units). Re-export the generated
+// wire *type* (`0 | 1`, numeric on the wire — no `JsonStringEnumConverter`) and
+// pair it with an `as const` enum-shaped object so the shared unit-format module
+// and the Settings toggle read `PreferredUnits.Miles` instead of the magic
+// integer `1`. Kept in lockstep with the backend by the same bidirectional guard
+// used for {@link CompletionStatus}: `satisfies` covers const ⊆ union, and the
+// guard below covers union ⊆ const.
+export type PreferredUnits = import('./rtk/api').PreferredUnits
+
+export const PreferredUnits = {
+  Kilometers: 0,
+  Miles: 1,
+} as const satisfies Record<string, PreferredUnits>
+
+type _PreferredUnitsConstMembers = (typeof PreferredUnits)[keyof typeof PreferredUnits]
+type _PreferredUnitsUnionMinusConst = Exclude<PreferredUnits, _PreferredUnitsConstMembers>
+type _PreferredUnitsExhaustive = _PreferredUnitsUnionMinusConst extends never ? true : never
+export const _preferredUnitsExhaustivenessGuard: _PreferredUnitsExhaustive = true

--- a/frontend/src/app/modules/common/utils/unit-format.helpers.spec.ts
+++ b/frontend/src/app/modules/common/utils/unit-format.helpers.spec.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest'
+
+import { PreferredUnits } from '~/api/generated'
+import { formatPacePerKm, formatPaceRangePerKm } from '~/modules/plan/utils/pace-format.helpers'
+
+import {
+  formatDistanceKm,
+  formatDistanceMeters,
+  formatPaceRangeSecPerKm,
+  formatPaceSecPerKm,
+  METERS_PER_MILE,
+} from './unit-format.helpers'
+
+const KM = PreferredUnits.Kilometers
+const MI = PreferredUnits.Miles
+
+describe('METERS_PER_MILE', () => {
+  it('is the canonical statute-mile constant', () => {
+    // Asserted via the string form to pin the exact value without a
+    // floating-point equality comparison (sonarjs/no-floating-point-equality).
+    expect(METERS_PER_MILE.toString()).toBe('1609.344')
+  })
+})
+
+describe('formatDistanceKm', () => {
+  it.each([
+    { km: 8, units: KM, expected: '8.0 km' },
+    { km: 8, units: MI, expected: '5.0 mi' }, // 8 / 1.609344 = 4.97096 -> 5.0
+    { km: 5, units: MI, expected: '3.1 mi' }, // 5 / 1.609344 = 3.10685 -> 3.1
+    { km: 10, units: KM, expected: '10.0 km' },
+    { km: 42.195, units: KM, expected: '42.2 km' },
+    { km: 1, units: MI, expected: '0.6 mi' }, // 1 / 1.609344 = 0.6214 -> 0.6
+  ])('formats $km km in $units as $expected', ({ km, units, expected }) => {
+    expect(formatDistanceKm(km, units)).toBe(expected)
+  })
+
+  it('rounds miles to one decimal matching the km convention', () => {
+    // 5 km -> 3.10685... mi, one-decimal like the existing `toFixed(1) km`.
+    const actual = formatDistanceKm(5, MI)
+    expect(actual).toBe('3.1 mi')
+    expect(actual?.split(' ')[0].split('.')[1]).toHaveLength(1)
+  })
+
+  it.each([
+    { km: 0, label: 'zero (skipped run)' },
+    { km: -1, label: 'negative' },
+    { km: Number.NaN, label: 'NaN' },
+    { km: Number.POSITIVE_INFINITY, label: 'infinite' },
+  ])('returns null for a $label distance in either unit', ({ km }) => {
+    expect(formatDistanceKm(km, KM)).toBeNull()
+    expect(formatDistanceKm(km, MI)).toBeNull()
+  })
+})
+
+describe('formatDistanceMeters', () => {
+  it.each([
+    { meters: 8000, units: KM, expected: '8.0 km' },
+    { meters: 8000, units: MI, expected: '5.0 mi' },
+    { meters: 5000, units: MI, expected: '3.1 mi' },
+  ])('formats $meters m in $units as $expected', ({ meters, units, expected }) => {
+    expect(formatDistanceMeters(meters, units)).toBe(expected)
+  })
+
+  it.each([
+    { meters: 0, label: 'zero' },
+    { meters: -100, label: 'negative' },
+    { meters: Number.NaN, label: 'NaN' },
+  ])('returns null for a $label distance in either unit', ({ meters }) => {
+    expect(formatDistanceMeters(meters, KM)).toBeNull()
+    expect(formatDistanceMeters(meters, MI)).toBeNull()
+  })
+})
+
+describe('formatPaceSecPerKm — kilometres path is byte-identical to formatPacePerKm', () => {
+  it.each([0, 59, 60, 240, 300, 330, 600, 99 * 60 + 59])(
+    'matches formatPacePerKm for %d sec/km',
+    (secondsPerKm) => {
+      expect(formatPaceSecPerKm(secondsPerKm, KM)).toBe(formatPacePerKm(secondsPerKm))
+    },
+  )
+
+  it.each([
+    { input: 300, expected: '05:00/km' },
+    { input: 240, expected: '04:00/km' },
+    { input: 99 * 60 + 59, expected: '99:59/km' },
+  ])('renders $input sec/km as $expected', ({ input, expected }) => {
+    expect(formatPaceSecPerKm(input, KM)).toBe(expected)
+  })
+
+  it('rounds fractional km inputs to the nearest whole second', () => {
+    expect(formatPaceSecPerKm(330.4, KM)).toBe('05:30/km')
+    expect(formatPaceSecPerKm(330.5, KM)).toBe('05:31/km')
+  })
+})
+
+describe('formatPaceSecPerKm — miles path uses the net-new inverse conversion', () => {
+  it.each([
+    // secPerMile = secPerKm * 1.609344, rounded to whole seconds.
+    { input: 300, expected: '08:03/mi' }, // 482.8032 -> 483 -> 8:03
+    { input: 240, expected: '06:26/mi' }, // 386.24256 -> 386 -> 6:26
+    { input: 330, expected: '08:51/mi' }, // 531.08352 -> 531 -> 8:51
+  ])('converts $input sec/km to $expected', ({ input, expected }) => {
+    expect(formatPaceSecPerKm(input, MI)).toBe(expected)
+  })
+
+  it('rounds the converted sec/mi to a whole second', () => {
+    // 200 sec/km -> 321.8688 sec/mi -> 322 -> 05:22/mi
+    expect(formatPaceSecPerKm(200, MI)).toBe('05:22/mi')
+  })
+})
+
+describe('formatPaceSecPerKm — ceiling and invalid contract', () => {
+  it('returns null for a pace above the km ceiling in km mode', () => {
+    expect(formatPaceSecPerKm(99 * 60 + 60, KM)).toBeNull()
+  })
+
+  it('returns null for a pace above the mile-equivalent ceiling in miles mode', () => {
+    // 6000 sec/km -> 9656.064 sec/mi > 5999 * 1.609344 ceiling.
+    expect(formatPaceSecPerKm(6000, MI)).toBeNull()
+  })
+
+  it('accepts the km-ceiling pace in miles mode (mile-equivalent, not km ceiling)', () => {
+    // 5999 sec/km -> 9654.45 sec/mi -> rounds to 9654, at/below the mile ceiling.
+    expect(formatPaceSecPerKm(99 * 60 + 59, MI)).not.toBeNull()
+  })
+
+  it.each([
+    { input: -1, label: 'negative' },
+    { input: Number.NaN, label: 'NaN' },
+    { input: Number.POSITIVE_INFINITY, label: 'infinite' },
+    { input: Number.NEGATIVE_INFINITY, label: 'negative infinite' },
+  ])('returns null for a $label pace in either unit', ({ input }) => {
+    expect(formatPaceSecPerKm(input, KM)).toBeNull()
+    expect(formatPaceSecPerKm(input, MI)).toBeNull()
+  })
+})
+
+describe('formatPaceRangeSecPerKm — kilometres path is byte-identical to formatPaceRangePerKm', () => {
+  it.each([
+    [240, 330],
+    [330, 240],
+    [300, 300],
+    [300.1, 299.9],
+  ])('matches formatPaceRangePerKm for (%d, %d) sec/km', (fast, slow) => {
+    expect(formatPaceRangeSecPerKm(fast, slow, KM)).toBe(formatPaceRangePerKm(fast, slow))
+  })
+})
+
+describe('formatPaceRangeSecPerKm — miles path', () => {
+  it('renders the faster pace first with a single /mi suffix', () => {
+    expect(formatPaceRangeSecPerKm(240, 330, MI)).toBe('06:26-08:51/mi')
+  })
+
+  it('reorders so the faster pace is first when called slow then fast', () => {
+    expect(formatPaceRangeSecPerKm(330, 240, MI)).toBe('06:26-08:51/mi')
+  })
+
+  it('collapses to a single pace when both bounds round equal in miles', () => {
+    expect(formatPaceRangeSecPerKm(300, 300, MI)).toBe('08:03/mi')
+  })
+})
+
+describe('formatPaceRangeSecPerKm — invalid contract', () => {
+  it.each([KM, MI])('returns the valid side when the first bound is invalid (units %d)', (units) => {
+    expect(formatPaceRangeSecPerKm(Number.NaN, 330, units)).toBe(formatPaceSecPerKm(330, units))
+  })
+
+  it.each([KM, MI])('returns the valid side when the second bound is invalid (units %d)', (units) => {
+    expect(formatPaceRangeSecPerKm(240, -1, units)).toBe(formatPaceSecPerKm(240, units))
+  })
+
+  it.each([KM, MI])('returns null when both bounds are invalid (units %d)', (units) => {
+    expect(
+      formatPaceRangeSecPerKm(Number.NaN, Number.POSITIVE_INFINITY, units),
+    ).toBeNull()
+  })
+})

--- a/frontend/src/app/modules/common/utils/unit-format.helpers.spec.ts
+++ b/frontend/src/app/modules/common/utils/unit-format.helpers.spec.ts
@@ -74,9 +74,9 @@ describe('formatDistanceMeters', () => {
 
 describe('formatDistanceMeters — kilometres path is byte-identical to history formatDistanceKm', () => {
   // Locks the load-bearing km distance parity to the SOURCE (not just literals),
-  // mirroring the pace-parity tests. PR4 consolidates history's `formatDistanceKm`
-  // (which takes metres) behind `formatDistanceMeters`, so their km output must
-  // match including the null (skipped-run) contract.
+  // mirroring the pace-parity tests: the existing metre-taking `formatDistanceKm`
+  // and this module's `formatDistanceMeters` must agree on km output — including
+  // the null (skipped-run) contract — when the two are consolidated.
   it.each([8000, 5000, 42195, 1, 0, -100])(
     'matches history formatDistanceKm for %d metres',
     (meters) => {

--- a/frontend/src/app/modules/common/utils/unit-format.helpers.spec.ts
+++ b/frontend/src/app/modules/common/utils/unit-format.helpers.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { PreferredUnits } from '~/api/generated'
+import { formatDistanceKm as historyFormatDistanceKm } from '~/modules/logging/history/history-format.helpers'
 import { formatPacePerKm, formatPaceRangePerKm } from '~/modules/plan/utils/pace-format.helpers'
 
 import {
@@ -69,6 +70,19 @@ describe('formatDistanceMeters', () => {
     expect(formatDistanceMeters(meters, KM)).toBeNull()
     expect(formatDistanceMeters(meters, MI)).toBeNull()
   })
+})
+
+describe('formatDistanceMeters — kilometres path is byte-identical to history formatDistanceKm', () => {
+  // Locks the load-bearing km distance parity to the SOURCE (not just literals),
+  // mirroring the pace-parity tests. PR4 consolidates history's `formatDistanceKm`
+  // (which takes metres) behind `formatDistanceMeters`, so their km output must
+  // match including the null (skipped-run) contract.
+  it.each([8000, 5000, 42195, 1, 0, -100])(
+    'matches history formatDistanceKm for %d metres',
+    (meters) => {
+      expect(formatDistanceMeters(meters, KM)).toBe(historyFormatDistanceKm(meters))
+    },
+  )
 })
 
 describe('formatPaceSecPerKm — kilometres path is byte-identical to formatPacePerKm', () => {
@@ -158,20 +172,32 @@ describe('formatPaceRangeSecPerKm — miles path', () => {
   it('collapses to a single pace when both bounds round equal in miles', () => {
     expect(formatPaceRangeSecPerKm(300, 300, MI)).toBe('08:03/mi')
   })
+
+  it('orders a fractional miles range faster-first regardless of argument order', () => {
+    // 300.4 sec/km -> 483 sec/mi (08:03); 300.6 sec/km -> 484 sec/mi (08:04):
+    // distinct in the display unit, so ordering is observable and must be stable
+    // under argument order.
+    expect(formatPaceRangeSecPerKm(300.4, 300.6, MI)).toBe('08:03-08:04/mi')
+    expect(formatPaceRangeSecPerKm(300.6, 300.4, MI)).toBe('08:03-08:04/mi')
+  })
 })
 
 describe('formatPaceRangeSecPerKm — invalid contract', () => {
-  it.each([KM, MI])('returns the valid side when the first bound is invalid (units %d)', (units) => {
-    expect(formatPaceRangeSecPerKm(Number.NaN, 330, units)).toBe(formatPaceSecPerKm(330, units))
-  })
+  it.each([KM, MI])(
+    'returns the valid side when the first bound is invalid (units %d)',
+    (units) => {
+      expect(formatPaceRangeSecPerKm(Number.NaN, 330, units)).toBe(formatPaceSecPerKm(330, units))
+    },
+  )
 
-  it.each([KM, MI])('returns the valid side when the second bound is invalid (units %d)', (units) => {
-    expect(formatPaceRangeSecPerKm(240, -1, units)).toBe(formatPaceSecPerKm(240, units))
-  })
+  it.each([KM, MI])(
+    'returns the valid side when the second bound is invalid (units %d)',
+    (units) => {
+      expect(formatPaceRangeSecPerKm(240, -1, units)).toBe(formatPaceSecPerKm(240, units))
+    },
+  )
 
   it.each([KM, MI])('returns null when both bounds are invalid (units %d)', (units) => {
-    expect(
-      formatPaceRangeSecPerKm(Number.NaN, Number.POSITIVE_INFINITY, units),
-    ).toBeNull()
+    expect(formatPaceRangeSecPerKm(Number.NaN, Number.POSITIVE_INFINITY, units)).toBeNull()
   })
 })

--- a/frontend/src/app/modules/common/utils/unit-format.helpers.ts
+++ b/frontend/src/app/modules/common/utils/unit-format.helpers.ts
@@ -1,0 +1,158 @@
+// Shared, deterministic unit-format layer (slice 4C-units).
+//
+// A single preference-aware home for rendering canonical km/SI values in the
+// runner's chosen display unit. Storage, the wire, and the plan-gen prompt stay
+// km-native (DEC-010 / DEC-041 / DEC-086) — this module converts for *display*
+// only, and the LLM performs zero unit conversion.
+//
+// The kilometre output is byte-identical to the pre-existing km-only helpers
+// (`plan/utils/pace-format.helpers.ts` `formatPacePerKm`/`formatPaceRangePerKm`
+// and `logging/history/history-format.helpers.ts` `formatDistanceKm`) so
+// consumers' existing null/ceiling guards continue to hold once those helpers
+// are consolidated behind this module (PR4). The miles path is a net-new inverse
+// conversion.
+//
+// Per the root/`frontend` `CLAUDE.md` trademark rule, the user-facing suffixes
+// are the literal `/km`, `/mi`, `km`, `mi`; no zone-name coupling lives here.
+//
+// Race distances (`5K`/`10K`/half/marathon) and track intervals (`400m`) are
+// literal proper nouns handled at the render sites (PR4/PR5) — not this pure
+// numeric layer.
+
+import { PreferredUnits } from '~/api/generated'
+
+/** Metres in one statute mile — the single source of truth for the conversion. */
+export const METERS_PER_MILE = 1609.344
+
+const METERS_PER_KM = 1000
+const SECONDS_PER_MINUTE = 60
+
+/** Kilometres → miles (and sec/km → sec/mi) multiplier: `1.609344`. */
+const KM_PER_MILE = METERS_PER_MILE / METERS_PER_KM
+
+/** Maximum pace the km formatter accepts, in seconds-per-kilometre (`99:59/km`). */
+const MAX_PACE_SECONDS_PER_KM = 99 * SECONDS_PER_MINUTE + 59
+
+/**
+ * Miles pace ceiling: the mile-equivalent of the `99:59/km` guard, so the
+ * miles path rejects exactly the paces the km path would.
+ */
+const MAX_PACE_SECONDS_PER_MILE = MAX_PACE_SECONDS_PER_KM * KM_PER_MILE
+
+const isMiles = (units: PreferredUnits): boolean => units === PreferredUnits.Miles
+
+/**
+ * Formats a canonical distance in **kilometres** in the preferred unit as a
+ * one-decimal `X.X km` / `X.X mi` string (miles via `÷ 1.609344`).
+ *
+ * Returns `null` for a non-finite or non-positive distance — mirroring the
+ * skip-run contract of the existing `formatDistanceKm` (a skipped run persists
+ * `0`, which callers render as a placeholder rather than a misleading
+ * `"0.0 mi"`).
+ */
+export const formatDistanceKm = (kilometres: number, units: PreferredUnits): string | null => {
+  if (!Number.isFinite(kilometres) || kilometres <= 0) {
+    return null
+  }
+  if (isMiles(units)) {
+    return `${(kilometres / KM_PER_MILE).toFixed(1)} mi`
+  }
+  return `${kilometres.toFixed(1)} km`
+}
+
+/**
+ * Formats a canonical distance in **metres** in the preferred unit. Thin
+ * adapter over {@link formatDistanceKm} for wire shapes that carry metres
+ * (`WorkoutLogDto.distanceMeters`).
+ */
+export const formatDistanceMeters = (metres: number, units: PreferredUnits): string | null =>
+  formatDistanceKm(metres / METERS_PER_KM, units)
+
+/**
+ * Shared pace renderer: rounds `seconds` to a whole second, rejects negative /
+ * above-ceiling values (`null`), and formats the survivors as `MM:SS{suffix}`.
+ */
+const formatPaceSeconds = (seconds: number, ceiling: number, suffix: string): string | null => {
+  const rounded = Math.round(seconds)
+  if (rounded < 0 || rounded > ceiling) {
+    return null
+  }
+  const minutes = Math.floor(rounded / SECONDS_PER_MINUTE)
+  const remainder = rounded - minutes * SECONDS_PER_MINUTE
+  const paddedMinutes = minutes.toString().padStart(2, '0')
+  const paddedSeconds = remainder.toString().padStart(2, '0')
+  return `${paddedMinutes}:${paddedSeconds}${suffix}`
+}
+
+/**
+ * Formats a pace expressed in **seconds-per-kilometre** in the preferred unit.
+ *
+ * Kilometres → `MM:SS/km`, byte-identical to the existing `formatPacePerKm`.
+ * Miles → net-new inverse conversion `sec/km × 1.609344 = sec/mi`, rounded to a
+ * whole second and rendered `MM:SS/mi`.
+ *
+ * Returns `null` when the input is non-finite, negative, or above the ceiling —
+ * `99:59/km` for kilometres and its mile-equivalent for miles — so consumers'
+ * existing null-guards continue to hold.
+ */
+export const formatPaceSecPerKm = (
+  secondsPerKm: number,
+  units: PreferredUnits,
+): string | null => {
+  if (!Number.isFinite(secondsPerKm)) {
+    return null
+  }
+  if (isMiles(units)) {
+    return formatPaceSeconds(secondsPerKm * KM_PER_MILE, MAX_PACE_SECONDS_PER_MILE, '/mi')
+  }
+  return formatPaceSeconds(secondsPerKm, MAX_PACE_SECONDS_PER_KM, '/km')
+}
+
+/**
+ * Formats a pace **range** (both bounds in seconds-per-kilometre) in the
+ * preferred unit as a single `FAST-SLOW/unit` string — mirroring
+ * `formatPaceRangePerKm`'s composition but preference-aware.
+ *
+ * The faster pace (fewer seconds in the *display* unit) renders first; the unit
+ * suffix is shown once at the end. When both bounds round to the same
+ * `MM:SS` in the display unit, returns the single formatted pace (no degenerate
+ * `MM:SS-MM:SS`). When one bound is invalid, returns whichever side is valid;
+ * when both are invalid, returns `null`.
+ */
+export const formatPaceRangeSecPerKm = (
+  fastSecondsPerKm: number,
+  slowSecondsPerKm: number,
+  units: PreferredUnits,
+): string | null => {
+  const formattedFast = formatPaceSecPerKm(fastSecondsPerKm, units)
+  const formattedSlow = formatPaceSecPerKm(slowSecondsPerKm, units)
+
+  if (formattedFast === null && formattedSlow === null) {
+    return null
+  }
+  if (formattedFast === null) {
+    return formattedSlow
+  }
+  if (formattedSlow === null) {
+    return formattedFast
+  }
+
+  // Order by the rounded value in the *display* unit so the faster pace renders
+  // first and equal-in-display bounds collapse (miles rounding can differ from
+  // km rounding).
+  const miles = isMiles(units)
+  const factor = miles ? KM_PER_MILE : 1
+  const fastRounded = Math.round(fastSecondsPerKm * factor)
+  const slowRounded = Math.round(slowSecondsPerKm * factor)
+  const [first, second] =
+    fastRounded <= slowRounded ? [formattedFast, formattedSlow] : [formattedSlow, formattedFast]
+
+  if (first === second) {
+    return first
+  }
+
+  // Strip the trailing unit suffix from the first half so it is shown once.
+  const suffix = miles ? '/mi' : '/km'
+  const firstWithoutSuffix = first.slice(0, -suffix.length)
+  return `${firstWithoutSuffix}-${second}`
+}

--- a/frontend/src/app/modules/common/utils/unit-format.helpers.ts
+++ b/frontend/src/app/modules/common/utils/unit-format.helpers.ts
@@ -6,22 +6,21 @@
 // only, and the LLM performs zero unit conversion.
 //
 // The kilometre output is byte-identical to the pre-existing km-only helpers, so
-// consumers' existing null/ceiling guards continue to hold once those helpers are
-// consolidated behind this module (PR4): pace parity is with
-// `plan/utils/pace-format.helpers.ts` `formatPacePerKm`/`formatPaceRangePerKm`,
-// and distance parity is `formatDistanceMeters` ↔
-// `logging/history/history-format.helpers.ts` `formatDistanceKm`. NOTE the unit
-// contracts differ by the same name: history's `formatDistanceKm` takes METRES,
-// whereas this module's `formatDistanceKm` takes KILOMETRES — metre-carrying call
-// sites must move to `formatDistanceMeters`, never this `formatDistanceKm`. The
-// miles path is a net-new inverse conversion.
+// consumers' existing null/ceiling guards continue to hold when those helpers are
+// consolidated behind this module: pace parity is with `formatPacePerKm` /
+// `formatPaceRangePerKm`, and distance parity is `formatDistanceMeters` ↔ the
+// existing metre-taking `formatDistanceKm`. NOTE the unit contracts differ by the
+// same name: the existing `formatDistanceKm` takes METRES, whereas this module's
+// `formatDistanceKm` takes KILOMETRES — metre-carrying call sites must use
+// `formatDistanceMeters`, never this `formatDistanceKm`. The miles path is a
+// net-new inverse conversion.
 //
 // Per the root/`frontend` `CLAUDE.md` trademark rule, the user-facing suffixes
 // are the literal `/km`, `/mi`, `km`, `mi`; no zone-name coupling lives here.
 //
 // Race distances (`5K`/`10K`/half/marathon) and track intervals (`400m`) are
-// literal proper nouns handled at the render sites (PR4/PR5) — not this pure
-// numeric layer.
+// literal proper nouns handled at their render sites — not this pure numeric
+// layer.
 
 import { PreferredUnits } from '~/api/generated'
 

--- a/frontend/src/app/modules/common/utils/unit-format.helpers.ts
+++ b/frontend/src/app/modules/common/utils/unit-format.helpers.ts
@@ -5,12 +5,16 @@
 // km-native (DEC-010 / DEC-041 / DEC-086) — this module converts for *display*
 // only, and the LLM performs zero unit conversion.
 //
-// The kilometre output is byte-identical to the pre-existing km-only helpers
-// (`plan/utils/pace-format.helpers.ts` `formatPacePerKm`/`formatPaceRangePerKm`
-// and `logging/history/history-format.helpers.ts` `formatDistanceKm`) so
-// consumers' existing null/ceiling guards continue to hold once those helpers
-// are consolidated behind this module (PR4). The miles path is a net-new inverse
-// conversion.
+// The kilometre output is byte-identical to the pre-existing km-only helpers, so
+// consumers' existing null/ceiling guards continue to hold once those helpers are
+// consolidated behind this module (PR4): pace parity is with
+// `plan/utils/pace-format.helpers.ts` `formatPacePerKm`/`formatPaceRangePerKm`,
+// and distance parity is `formatDistanceMeters` ↔
+// `logging/history/history-format.helpers.ts` `formatDistanceKm`. NOTE the unit
+// contracts differ by the same name: history's `formatDistanceKm` takes METRES,
+// whereas this module's `formatDistanceKm` takes KILOMETRES — metre-carrying call
+// sites must move to `formatDistanceMeters`, never this `formatDistanceKm`. The
+// miles path is a net-new inverse conversion.
 //
 // Per the root/`frontend` `CLAUDE.md` trademark rule, the user-facing suffixes
 // are the literal `/km`, `/mi`, `km`, `mi`; no zone-name coupling lives here.
@@ -34,8 +38,9 @@ const KM_PER_MILE = METERS_PER_MILE / METERS_PER_KM
 const MAX_PACE_SECONDS_PER_KM = 99 * SECONDS_PER_MINUTE + 59
 
 /**
- * Miles pace ceiling: the mile-equivalent of the `99:59/km` guard, so the
- * miles path rejects exactly the paces the km path would.
+ * Miles pace ceiling: the mile-equivalent of the `99:59/km` guard, so the miles
+ * path rejects the same integer-second paces the km path would (the backend emits
+ * integer seconds; the two ceilings can diverge only on sub-second inputs).
  */
 const MAX_PACE_SECONDS_PER_MILE = MAX_PACE_SECONDS_PER_KM * KM_PER_MILE
 
@@ -95,10 +100,7 @@ const formatPaceSeconds = (seconds: number, ceiling: number, suffix: string): st
  * `99:59/km` for kilometres and its mile-equivalent for miles — so consumers'
  * existing null-guards continue to hold.
  */
-export const formatPaceSecPerKm = (
-  secondsPerKm: number,
-  units: PreferredUnits,
-): string | null => {
+export const formatPaceSecPerKm = (secondsPerKm: number, units: PreferredUnits): string | null => {
   if (!Number.isFinite(secondsPerKm)) {
     return null
   }
@@ -137,22 +139,21 @@ export const formatPaceRangeSecPerKm = (
     return formattedFast
   }
 
-  // Order by the rounded value in the *display* unit so the faster pace renders
-  // first and equal-in-display bounds collapse (miles rounding can differ from
-  // km rounding).
-  const miles = isMiles(units)
-  const factor = miles ? KM_PER_MILE : 1
-  const fastRounded = Math.round(fastSecondsPerKm * factor)
-  const slowRounded = Math.round(slowSecondsPerKm * factor)
+  // Faster pace (fewer seconds) renders first. Ordering by the canonical
+  // seconds-per-km is identical to ordering by the display-unit value — the
+  // km→unit factor is a single positive constant, so it preserves order — and
+  // any two inputs that round to the same display MM:SS collapse via the
+  // `first === second` branch below regardless of order.
   const [first, second] =
-    fastRounded <= slowRounded ? [formattedFast, formattedSlow] : [formattedSlow, formattedFast]
+    fastSecondsPerKm <= slowSecondsPerKm
+      ? [formattedFast, formattedSlow]
+      : [formattedSlow, formattedFast]
 
   if (first === second) {
     return first
   }
 
   // Strip the trailing unit suffix from the first half so it is shown once.
-  const suffix = miles ? '/mi' : '/km'
-  const firstWithoutSuffix = first.slice(0, -suffix.length)
-  return `${firstWithoutSuffix}-${second}`
+  const suffix = isMiles(units) ? '/mi' : '/km'
+  return `${first.slice(0, -suffix.length)}-${second}`
 }

--- a/frontend/src/app/modules/logging/draft-to-form.helpers.ts
+++ b/frontend/src/app/modules/logging/draft-to-form.helpers.ts
@@ -9,6 +9,7 @@
 
 import type { RunnerDistanceUnit, StructuredLogDraft } from '~/api/generated'
 
+import { METERS_PER_MILE } from '~/modules/common/utils/unit-format.helpers'
 import {
   makeDefaultWorkoutLogFormFields,
   type WorkoutLogFormFields,
@@ -21,7 +22,6 @@ const RUNNER_DISTANCE_UNIT = {
 } as const satisfies Record<string, RunnerDistanceUnit>
 
 const METERS_PER_KILOMETER = 1000
-const METERS_PER_MILE = 1609.344
 
 const draftDistanceKm = (value: number, unit: RunnerDistanceUnit): number => {
   switch (unit) {


### PR DESCRIPTION
## Summary

PR2 of 6 in the **slice-4c-units** sub-slice (parent design DEC-086). Adds the pure, deterministic display/format layer that makes km/miles a real end-to-end display preference. **No UI, no render-site wiring, no settings slice** — just the tested foundation PR4/PR5 consume. Depends on nothing (lands after PR1 in sequence).

Storage, the wire, and the plan-gen prompt stay canonical km/SI; the LLM performs zero unit conversion (DEC-010 / DEC-041 / DEC-086).

## Module API (`frontend/src/app/modules/common/utils/unit-format.helpers.ts`)

- `METERS_PER_MILE = 1609.344` — single source of truth for the conversion.
- `formatDistanceKm(km, units)` / `formatDistanceMeters(meters, units)` — one-decimal `X.X km` / `X.X mi` (miles via `÷ 1.609344`); `null` for non-finite or `≤ 0` (mirrors the existing `history-format` skip-run contract).
- `formatPaceSecPerKm(secPerKm, units)` — **net-new inverse conversion**: Miles → `sec/km × 1.609344 = sec/mi`, whole-second `mm:ss/mi`; Kilometers → output **byte-identical** to the existing `formatPacePerKm` (`mm:ss/km`). `null` for non-finite / negative / above-ceiling — `99:59/km` for km, its mile-equivalent (`× 1.609344`) for miles, so existing consumer null-guards continue to hold.
- `formatPaceRangeSecPerKm(fastSecPerKm, slowSecPerKm, units)` — mirrors `formatPaceRangePerKm`'s composition but preference-aware: faster value first (ordered in the display unit), shared suffix shown once, single value when both round equal, whichever side is valid when one is invalid, `null` when both invalid.

## Display spec

Distance precision matches km (one decimal); pace is whole seconds — formula-derived, not taste calls. User-facing suffixes are the literal `/km`, `/mi`, `km`, `mi` (trademark rule). Race names (`5K`/`10K`/half/marathon) and track intervals (`400m`) are literal proper nouns handled at the render sites in PR4/PR5 — **not** implemented in this pure numeric module.

## Other changes

- `logging/draft-to-form.helpers.ts` — replace the module-local `1609.344` with the shared `METERS_PER_MILE` import (no behavior change; existing draft-to-form tests still pass).
- `api/generated/index.ts` (hand-maintained barrel, not codegen'd) — add a `PreferredUnits` type + `as const` value object mirroring the existing `CompletionStatus`/`SuggestedInputType` pattern (with the bidirectional exhaustiveness guard), so this module and the future toggle read `PreferredUnits.Miles` instead of the magic integer `1`. PR3 (settings toggle) consumes this same export.

## Verification

- `npm ci` — clean install.
- `npm run build` — PASS (tsc -b + vite build, 427 modules, exit 0).
- `npm run test` — PASS (59 files, 611 tests; the new spec adds 54).
- `npm run lint` — changed files clean. The 13 remaining full-run problems are pre-existing (login/register/e2e password fixtures + shadcn `ui/*` fast-refresh warnings), untouched by this PR.
- No codegen drift (orval re-run produced identical `rtk/api.ts` + zod output; only the hand-maintained barrel changed).

## Test coverage (54 tests)

Distance km + miles one-decimal rounding + null contract (0, negative, NaN, ∞); pace km asserted **byte-identical** to `formatPacePerKm` for known inputs; pace miles inverse conversion + whole-second rounding; km + mile-equivalent ceiling → null; invalid → null; range order / shared-suffix / equal-collapse / one-invalid / both-invalid, in both units.

### Follow-ups found

- [ ] PR3 (settings RTK slice + `UnitsToggle`) consumes the `PreferredUnits` barrel export added here — no re-add needed.
- [ ] PR4 consolidates the existing km-only helpers (`plan/utils/pace-format.helpers.ts`, `logging/history/history-format.helpers.ts`) behind this module; the km byte-identity cross-assertions here guard that consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBys3jXwmr5C2QXxaGaDpL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic distance and pace formatting for kilometre and mile views, including pace ranges and correct unit suffix rendering.
  * Introduced a shared metres-to-miles conversion constant and reused it for consistent draft-to-workout distance conversion.
* **Tests**
  * Added comprehensive unit tests covering valid formatting, rounding, ordering, and invalid-input behavior across distance, pace, and range helpers.
* **Bug Fixes**
  * Ensures non-finite and non-positive values (and out-of-bounds pace values) return no display rather than misleading output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->