### PR TITLE
feat(slice-4c-units): PR4 — plan render sites read the km/miles preference

### DIFF
--- a/frontend/src/app/modules/common/utils/unit-format.helpers.spec.ts
+++ b/frontend/src/app/modules/common/utils/unit-format.helpers.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { PreferredUnits } from '~/api/generated'
-import { formatDistanceKm as historyFormatDistanceKm } from '~/modules/logging/history/history-format.helpers'
+import { formatHistoryDistanceKm as historyFormatDistanceKm } from '~/modules/logging/history/history-format.helpers'
 import { formatPacePerKm, formatPaceRangePerKm } from '~/modules/plan/utils/pace-format.helpers'
 
 import {

--- a/frontend/src/app/modules/common/utils/unit-format.helpers.spec.ts
+++ b/frontend/src/app/modules/common/utils/unit-format.helpers.spec.ts
@@ -72,11 +72,12 @@ describe('formatDistanceMeters', () => {
   })
 })
 
-describe('formatDistanceMeters — kilometres path is byte-identical to history formatDistanceKm', () => {
-  // Locks the load-bearing km distance parity to the SOURCE (not just literals),
-  // mirroring the pace-parity tests: the existing metre-taking `formatDistanceKm`
-  // and this module's `formatDistanceMeters` must agree on km output — including
-  // the null (skipped-run) contract — when the two are consolidated.
+describe('formatDistanceMeters — km path agrees with the km-pinned history formatDistanceKm delegate', () => {
+  // As of slice 4C-units the legacy `formatDistanceKm` delegates to this
+  // module pinned to Kilometers, so this block now guards that the delegation
+  // passes Kilometers (a Miles-pinned delegate would diverge here) rather than
+  // independently re-verifying the km formatting — the literal-expectation tests
+  // above pin the byte output, including the null (skipped-run) contract.
   it.each([8000, 5000, 42195, 1, 0, -100])(
     'matches history formatDistanceKm for %d metres',
     (meters) => {
@@ -85,7 +86,7 @@ describe('formatDistanceMeters — kilometres path is byte-identical to history 
   )
 })
 
-describe('formatPaceSecPerKm — kilometres path is byte-identical to formatPacePerKm', () => {
+describe('formatPaceSecPerKm — km path agrees with the km-pinned formatPacePerKm delegate', () => {
   it.each([0, 59, 60, 240, 300, 330, 600, 99 * 60 + 59])(
     'matches formatPacePerKm for %d sec/km',
     (secondsPerKm) => {
@@ -149,7 +150,7 @@ describe('formatPaceSecPerKm — ceiling and invalid contract', () => {
   })
 })
 
-describe('formatPaceRangeSecPerKm — kilometres path is byte-identical to formatPaceRangePerKm', () => {
+describe('formatPaceRangeSecPerKm — km path agrees with the km-pinned formatPaceRangePerKm delegate', () => {
   it.each([
     [240, 330],
     [330, 240],

--- a/frontend/src/app/modules/logging/history/history-format.helpers.spec.ts
+++ b/frontend/src/app/modules/logging/history/history-format.helpers.spec.ts
@@ -3,22 +3,22 @@ import { describe, expect, it } from 'vitest'
 import { CompletionStatus } from '~/api/generated'
 import {
   COMPLETION_STATUS_LABELS,
-  formatDistanceKm,
+  formatHistoryDistanceKm,
   formatDuration,
   formatLogDate,
   formatLogPace,
 } from './history-format.helpers'
 
-describe('formatDistanceKm', () => {
+describe('formatHistoryDistanceKm', () => {
   it('renders metres as one-decimal kilometres', () => {
-    expect(formatDistanceKm(5000)).toBe('5.0 km')
-    expect(formatDistanceKm(1234)).toBe('1.2 km')
+    expect(formatHistoryDistanceKm(5000)).toBe('5.0 km')
+    expect(formatHistoryDistanceKm(1234)).toBe('1.2 km')
   })
 
   it('returns null for a non-positive distance (e.g. a skipped run)', () => {
-    expect(formatDistanceKm(0)).toBeNull()
-    expect(formatDistanceKm(-10)).toBeNull()
-    expect(formatDistanceKm(Number.NaN)).toBeNull()
+    expect(formatHistoryDistanceKm(0)).toBeNull()
+    expect(formatHistoryDistanceKm(-10)).toBeNull()
+    expect(formatHistoryDistanceKm(Number.NaN)).toBeNull()
   })
 })
 

--- a/frontend/src/app/modules/logging/history/history-format.helpers.ts
+++ b/frontend/src/app/modules/logging/history/history-format.helpers.ts
@@ -7,7 +7,8 @@
 // presentation. Per the root `CLAUDE.md` trademark rule, no zone-name coupling
 // lives here — only neutral distance/duration/pace strings.
 
-import { CompletionStatus } from '~/api/generated'
+import { CompletionStatus, PreferredUnits } from '~/api/generated'
+import { formatDistanceMeters } from '~/modules/common/utils/unit-format.helpers'
 import { formatPacePerKm } from '~/modules/plan/utils/pace-format.helpers'
 
 const METERS_PER_KM = 1000
@@ -38,13 +39,13 @@ const pad2 = (value: number): string => value.toString().padStart(2, '0')
  * Returns `null` for a non-positive or non-finite distance — a skipped run
  * persists `0 m`, which the caller renders as a placeholder rather than
  * a misleading `"0.0 km"`.
+ *
+ * Km-pinned adapter over the shared `formatDistanceMeters`; the history render
+ * sites become preference-aware in a later 4C-units PR. Output is byte-identical
+ * to the previous inline `(metres / 1000).toFixed(1)` implementation.
  */
-export const formatDistanceKm = (distanceMeters: number): string | null => {
-  if (!Number.isFinite(distanceMeters) || distanceMeters <= 0) {
-    return null
-  }
-  return `${(distanceMeters / METERS_PER_KM).toFixed(1)} km`
-}
+export const formatDistanceKm = (distanceMeters: number): string | null =>
+  formatDistanceMeters(distanceMeters, PreferredUnits.Kilometers)
 
 /**
  * Formats a duration in seconds as `M:SS` under an hour and `H:MM:SS` at or

--- a/frontend/src/app/modules/logging/history/history-format.helpers.ts
+++ b/frontend/src/app/modules/logging/history/history-format.helpers.ts
@@ -40,11 +40,11 @@ const pad2 = (value: number): string => value.toString().padStart(2, '0')
  * persists `0 m`, which the caller renders as a placeholder rather than
  * a misleading `"0.0 km"`.
  *
- * Km-pinned adapter over the shared `formatDistanceMeters`; the history render
- * sites become preference-aware in a later 4C-units PR. Output is byte-identical
- * to the previous inline `(metres / 1000).toFixed(1)` implementation.
+ * Km-pinned adapter over the shared `formatDistanceMeters`. Output is
+ * byte-identical to the previous inline `(metres / 1000).toFixed(1)`
+ * implementation.
  */
-export const formatDistanceKm = (distanceMeters: number): string | null =>
+export const formatHistoryDistanceKm = (distanceMeters: number): string | null =>
   formatDistanceMeters(distanceMeters, PreferredUnits.Kilometers)
 
 /**

--- a/frontend/src/app/modules/logging/history/workout-log-entry.component.tsx
+++ b/frontend/src/app/modules/logging/history/workout-log-entry.component.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from 'react'
 import type { WorkoutLogDto } from '~/api/generated'
 import {
   COMPLETION_STATUS_LABELS,
-  formatDistanceKm,
+  formatHistoryDistanceKm,
   formatDuration,
   formatLogDate,
   formatLogPace,
@@ -23,7 +23,7 @@ interface CoreStat {
 
 const buildCoreStats = (log: WorkoutLogDto): CoreStat[] => {
   const stats: CoreStat[] = []
-  const distance = formatDistanceKm(log.distanceMeters)
+  const distance = formatHistoryDistanceKm(log.distanceMeters)
   if (distance !== null) {
     stats.push({ label: 'Distance', value: distance })
   }

--- a/frontend/src/app/modules/logging/history/workout-log-splits.component.tsx
+++ b/frontend/src/app/modules/logging/history/workout-log-splits.component.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import type { WorkoutLogSplitDto } from '~/api/generated'
 import { formatPacePerKm } from '~/modules/plan/utils/pace-format.helpers'
-import { formatDistanceKm, formatDuration } from './history-format.helpers'
+import { formatHistoryDistanceKm, formatDuration } from './history-format.helpers'
 
 export interface WorkoutLogSplitsProps {
   /** The per-lap splits of a logged workout (display-only at MVP-0). */
@@ -85,7 +85,9 @@ export const WorkoutLogSplits = ({ splits }: WorkoutLogSplitsProps): ReactElemen
             {splits.map((split) => (
               <tr key={split.index} className="border-b border-border last:border-0">
                 <td className={dataCellClass}>{split.index + 1}</td>
-                <td className={dataCellClass}>{formatDistanceKm(split.distanceMeters) ?? '—'}</td>
+                <td className={dataCellClass}>
+                  {formatHistoryDistanceKm(split.distanceMeters) ?? '—'}
+                </td>
                 <td className={dataCellClass}>{formatDuration(split.durationSeconds) ?? '—'}</td>
                 <td className={dataCellClass}>{formatPacePerKm(split.paceSecPerKm) ?? '—/km'}</td>
                 {showHeartRate ? (

--- a/frontend/src/app/modules/plan/components/meso-week-block.component.spec.tsx
+++ b/frontend/src/app/modules/plan/components/meso-week-block.component.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
+import { PreferredUnits } from '~/api/generated'
 import { MesoWeekBlock } from './meso-week-block.component'
 import { buildPlanFixture } from './plan-display.fixture'
 
@@ -35,6 +36,14 @@ describe('MesoWeekBlock', () => {
     render(<MesoWeekBlock weeks={plan.mesoWeeks} currentWeek={1} />)
     expect(screen.getAllByText(/30\.0 km/u).length).toBeGreaterThan(0)
     expect(screen.getByText(/aerobic base/u)).toBeInTheDocument()
+  })
+
+  it('renders weekly target volume in miles when units=Miles', () => {
+    const plan = buildPlanFixture()
+    render(<MesoWeekBlock weeks={plan.mesoWeeks} currentWeek={1} units={PreferredUnits.Miles} />)
+    // Standard weeks 30 km / 1.609344 = 18.64 -> 18.6 mi; deload 22 km -> 13.7 mi
+    expect(screen.getAllByText(/18\.6 mi/u).length).toBeGreaterThan(0)
+    expect(screen.getByText(/13\.7 mi/u)).toBeInTheDocument()
   })
 
   it('renders all cards in the neutral state when currentWeek is null', () => {

--- a/frontend/src/app/modules/plan/components/meso-week-block.component.spec.tsx
+++ b/frontend/src/app/modules/plan/components/meso-week-block.component.spec.tsx
@@ -46,6 +46,19 @@ describe('MesoWeekBlock', () => {
     expect(screen.getByText(/13\.7 mi/u)).toBeInTheDocument()
   })
 
+  it('renders a placeholder when a weekly target is unavailable', () => {
+    const plan = buildPlanFixture()
+    // Zero out the first week's target so `formatDistanceKm` returns null and
+    // the "—" fallback renders (the only em-dash source in a meso card).
+    const weeks = plan.mesoWeeks.map((week, index) =>
+      index === 0 ? { ...week, weeklyTargetKm: 0 } : week,
+    )
+    render(<MesoWeekBlock weeks={weeks} currentWeek={1} />)
+    const firstCard = screen.getAllByTestId('meso-week-card')[0]
+    expect(firstCard.textContent).toContain('—')
+    expect(firstCard.textContent).not.toMatch(/0\.0 km/u)
+  })
+
   it('renders all cards in the neutral state when currentWeek is null', () => {
     const plan = buildPlanFixture()
     render(<MesoWeekBlock weeks={plan.mesoWeeks} currentWeek={null} />)

--- a/frontend/src/app/modules/plan/components/meso-week-block.component.tsx
+++ b/frontend/src/app/modules/plan/components/meso-week-block.component.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from 'react'
 import { Badge } from '@/components/ui/badge'
+import { PreferredUnits } from '~/api/generated'
+import { formatDistanceKm } from '~/modules/common/utils/unit-format.helpers'
 import type { MesoWeekTemplateDto } from '~/modules/plan/models/plan.model'
 import { labelForPhase } from './plan-display.helpers'
 
@@ -13,6 +15,12 @@ export interface MesoWeekBlockProps {
    * (used by tests and previews).
    */
   currentWeek: number | null
+  /**
+   * Display unit for the weekly target volume. Defaults to Kilometers so
+   * callers that predate the unit preference (and isolated tests) render the
+   * km form unchanged.
+   */
+  units?: PreferredUnits
   className?: string
 }
 
@@ -53,6 +61,7 @@ const STATE_STYLES: Record<'past' | 'current' | 'future' | 'neutral', string> = 
 export const MesoWeekBlock = ({
   weeks,
   currentWeek,
+  units = PreferredUnits.Kilometers,
   className,
 }: MesoWeekBlockProps): ReactElement => (
   <ol
@@ -79,7 +88,9 @@ export const MesoWeekBlock = ({
             </span>
             <span className="text-xs font-medium opacity-80">{labelForPhase(week.phaseType)}</span>
           </header>
-          <p className="text-lg font-semibold leading-tight">{week.weeklyTargetKm.toFixed(1)} km</p>
+          <p className="text-lg font-semibold leading-tight">
+            {formatDistanceKm(week.weeklyTargetKm, units) ?? '—'}
+          </p>
           {week.isDeloadWeek ? (
             <Badge
               variant="secondary"

--- a/frontend/src/app/modules/plan/components/micro-workout-card.component.spec.tsx
+++ b/frontend/src/app/modules/plan/components/micro-workout-card.component.spec.tsx
@@ -39,6 +39,30 @@ describe('MicroWorkoutCard', () => {
     expect(segments[1].textContent).toMatch(/06:26\/mi/u)
   })
 
+  it('renders unit-aware placeholders in miles when distance and pace are unavailable', () => {
+    // A skipped/zero-distance workout with unusable paces exercises the null
+    // fallbacks: distance -> "—" and the miles pace placeholder -> "—/mi".
+    const workout = {
+      ...fixtureWeekOneWorkouts()[0],
+      targetDistanceKm: 0,
+      targetPaceFastSecPerKm: Number.NaN,
+      targetPaceEasySecPerKm: Number.NaN,
+    }
+    render(<MicroWorkoutCard workout={workout} units={PreferredUnits.Miles} />)
+    expect(screen.getByTestId('micro-workout-distance').textContent).toBe('—')
+    expect(screen.getByTestId('micro-workout-pace').textContent).toBe('—/mi')
+  })
+
+  it('falls back to the km pace placeholder when the pace is unavailable in kilometres', () => {
+    const workout = {
+      ...fixtureWeekOneWorkouts()[0],
+      targetPaceFastSecPerKm: Number.NaN,
+      targetPaceEasySecPerKm: Number.NaN,
+    }
+    render(<MicroWorkoutCard workout={workout} />)
+    expect(screen.getByTestId('micro-workout-pace').textContent).toBe('—/km')
+  })
+
   it('renders structured segments with intensity labels and trademark-clean phrasing', () => {
     const workout = fixtureWeekOneWorkouts()[1] // Threshold intervals
     render(<MicroWorkoutCard workout={workout} />)

--- a/frontend/src/app/modules/plan/components/micro-workout-card.component.spec.tsx
+++ b/frontend/src/app/modules/plan/components/micro-workout-card.component.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen, within } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
+import { PreferredUnits } from '~/api/generated'
 import { MicroWorkoutCard } from './micro-workout-card.component'
 import { fixtureWeekOneWorkouts } from './plan-display.fixture'
 
@@ -19,6 +20,23 @@ describe('MicroWorkoutCard', () => {
     const pace = screen.getByTestId('micro-workout-pace')
     // fast 330s = 05:30, slow 360s = 06:00 → "05:30-06:00/km"
     expect(pace.textContent).toBe('05:30-06:00/km')
+  })
+
+  it('renders distance and pace range in miles when units=Miles', () => {
+    const workout = fixtureWeekOneWorkouts()[0] // 6 km, fast 330, slow 360 sec/km
+    render(<MicroWorkoutCard workout={workout} units={PreferredUnits.Miles} />)
+    // 6 km / 1.609344 = 3.728 -> 3.7 mi
+    expect(screen.getByTestId('micro-workout-distance').textContent).toBe('3.7 mi')
+    // fast 330*1.609344=531.08->531->08:51 ; slow 360*1.609344=579.36->579->09:39
+    expect(screen.getByTestId('micro-workout-pace').textContent).toBe('08:51-09:39/mi')
+  })
+
+  it('threads the unit preference down to the segment paces', () => {
+    const workout = fixtureWeekOneWorkouts()[1] // Threshold intervals with segments
+    render(<MicroWorkoutCard workout={workout} units={PreferredUnits.Miles} />)
+    const segments = screen.getAllByTestId('micro-workout-segment')
+    // Work segment pace 240 sec/km -> 386 sec/mi -> 06:26/mi
+    expect(segments[1].textContent).toMatch(/06:26\/mi/u)
   })
 
   it('renders structured segments with intensity labels and trademark-clean phrasing', () => {

--- a/frontend/src/app/modules/plan/components/micro-workout-card.component.tsx
+++ b/frontend/src/app/modules/plan/components/micro-workout-card.component.tsx
@@ -1,6 +1,10 @@
 import type { ReactElement } from 'react'
+import { PreferredUnits } from '~/api/generated'
+import {
+  formatDistanceKm,
+  formatPaceRangeSecPerKm,
+} from '~/modules/common/utils/unit-format.helpers'
 import type { MicroWorkoutCardDto } from '~/modules/plan/models/plan.model'
-import { formatPaceRangePerKm } from '~/modules/plan/utils/pace-format.helpers'
 import { MicroWorkoutSegmentRow } from './micro-workout-segment-row.component'
 import { DAY_OF_WEEK_LABELS, WORKOUT_TYPE_LABELS } from './plan-display.helpers'
 
@@ -10,29 +14,41 @@ export interface MicroWorkoutCardProps {
   workout: MicroWorkoutCardDto
   /** Optional emphasis flag used by `TodayCard` to render the prominent variant. */
   emphasized?: boolean
+  /**
+   * Display unit for the distance + pace. Defaults to Kilometers so callers
+   * that predate the unit preference (and isolated tests) render the km form
+   * unchanged.
+   */
+  units?: PreferredUnits
   className?: string
 }
 
 /**
  * Detail card for a single workout. Renders title, workout-type label,
- * target distance, target pace range (`MM:SS/km`), structured segments,
- * and the LLM-emitted coaching note. Segment list collapses cleanly when
- * the structured-output schema emits zero segments (typical for an easy run).
+ * target distance, target pace range (`MM:SS/km` or `MM:SS/mi`), structured
+ * segments, and the LLM-emitted coaching note. Segment list collapses cleanly
+ * when the structured-output schema emits zero segments (typical for an easy
+ * run).
  *
- * The pace string flows through `formatPaceRangePerKm` from `pace-format.helpers`
- * — the single home for `MM:SS/km` formatting in this module. Workout-type
- * labels and intensity labels live in `plan-display.helpers.ts` to keep
- * trademark-clean phrasing in one auditable place.
+ * Distance and pace flow through the shared `unit-format.helpers` module — the
+ * single preference-aware home for km/mi formatting — so the card renders in the
+ * runner's chosen unit (`units`). Workout-type and intensity labels live in
+ * `plan-display.helpers.ts` to keep trademark-clean phrasing in one auditable
+ * place. The stored/wire values stay km-native; conversion is display-only.
  */
 export const MicroWorkoutCard = ({
   workout,
   emphasized = false,
+  units = PreferredUnits.Kilometers,
   className,
 }: MicroWorkoutCardProps): ReactElement => {
-  const paceRange = formatPaceRangePerKm(
+  const distance = formatDistanceKm(workout.targetDistanceKm, units)
+  const paceRange = formatPaceRangeSecPerKm(
     workout.targetPaceFastSecPerKm,
     workout.targetPaceEasySecPerKm,
+    units,
   )
+  const pacePlaceholder = units === PreferredUnits.Miles ? '—/mi' : '—/km'
   const dayLabel = DAY_OF_WEEK_LABELS[workout.dayOfWeek] ?? ''
 
   return (
@@ -64,8 +80,8 @@ export const MicroWorkoutCard = ({
           <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
             Distance
           </dt>
-          <dd className="text-base font-semibold text-foreground">
-            {workout.targetDistanceKm.toFixed(1)} km
+          <dd data-testid="micro-workout-distance" className="text-base font-semibold text-foreground">
+            {distance ?? '—'}
           </dd>
         </div>
         <div>
@@ -73,7 +89,7 @@ export const MicroWorkoutCard = ({
             Target pace
           </dt>
           <dd data-testid="micro-workout-pace" className="text-base font-semibold text-foreground">
-            {paceRange ?? '—/km'}
+            {paceRange ?? pacePlaceholder}
           </dd>
         </div>
       </dl>
@@ -93,6 +109,7 @@ export const MicroWorkoutCard = ({
               key={`${segment.segmentType}-${index}`}
               segment={segment}
               index={index}
+              units={units}
             />
           ))}
         </ul>

--- a/frontend/src/app/modules/plan/components/micro-workout-segment-row.component.spec.tsx
+++ b/frontend/src/app/modules/plan/components/micro-workout-segment-row.component.spec.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { PreferredUnits } from '~/api/generated'
+import type { WorkoutSegmentDto } from '~/modules/plan/models/plan.model'
+import { MicroWorkoutSegmentRow } from './micro-workout-segment-row.component'
+
+const segment = (overrides: Partial<WorkoutSegmentDto> = {}): WorkoutSegmentDto => ({
+  segmentType: 'Work',
+  durationMinutes: 4,
+  targetPaceSecPerKm: 240,
+  intensity: 'Threshold',
+  repetitions: 5,
+  notes: '',
+  ...overrides,
+})
+
+// The row renders an <li>, which must live inside a list to stay valid DOM
+// (and to keep React from warning), so every render wraps it in a <ul>.
+const renderRow = (seg: WorkoutSegmentDto, units?: PreferredUnits) =>
+  render(
+    <ul>
+      <MicroWorkoutSegmentRow segment={seg} index={0} units={units} />
+    </ul>,
+  )
+
+describe('MicroWorkoutSegmentRow', () => {
+  it('defaults to kilometres, rendering the pace as MM:SS/km', () => {
+    renderRow(segment())
+    const row = screen.getByTestId('micro-workout-segment')
+    // 240 sec/km -> 04:00/km
+    expect(row.textContent).toMatch(/04:00\/km/u)
+    expect(row.textContent).toMatch(/4 min/u)
+  })
+
+  it('renders the pace in miles when units=Miles', () => {
+    renderRow(segment(), PreferredUnits.Miles)
+    const row = screen.getByTestId('micro-workout-segment')
+    // 240 sec/km * 1.609344 = 386.24 -> 386 -> 06:26/mi
+    expect(row.textContent).toMatch(/06:26\/mi/u)
+    expect(row.textContent).not.toMatch(/\/km/u)
+  })
+
+  it('omits the pace fragment entirely when the pace is out of range', () => {
+    renderRow(segment({ repetitions: 1, targetPaceSecPerKm: 6000 }), PreferredUnits.Miles)
+    const row = screen.getByTestId('micro-workout-segment')
+    // 6000 sec/km is above the ceiling in both units -> null -> just the duration.
+    expect(row.textContent).toMatch(/4 min/u)
+    expect(row.textContent).not.toMatch(/·/u)
+    expect(row.textContent).not.toMatch(/\/mi|\/km/u)
+  })
+})

--- a/frontend/src/app/modules/plan/components/micro-workout-segment-row.component.tsx
+++ b/frontend/src/app/modules/plan/components/micro-workout-segment-row.component.tsx
@@ -1,18 +1,26 @@
 import type { ReactElement } from 'react'
+import { PreferredUnits } from '~/api/generated'
+import { formatPaceSecPerKm } from '~/modules/common/utils/unit-format.helpers'
 import type { WorkoutSegmentDto } from '~/modules/plan/models/plan.model'
-import { formatPacePerKm } from '~/modules/plan/utils/pace-format.helpers'
 import { INTENSITY_LABELS } from './plan-display.helpers'
 
 export interface MicroWorkoutSegmentRowProps {
   segment: WorkoutSegmentDto
   index: number
+  /**
+   * Display unit for the segment pace. Defaults to Kilometers so callers that
+   * predate the unit preference (and isolated tests) render the km form
+   * unchanged.
+   */
+  units?: PreferredUnits
 }
 
 export const MicroWorkoutSegmentRow = ({
   segment,
   index,
+  units = PreferredUnits.Kilometers,
 }: MicroWorkoutSegmentRowProps): ReactElement => {
-  const pace = formatPacePerKm(segment.targetPaceSecPerKm)
+  const pace = formatPaceSecPerKm(segment.targetPaceSecPerKm, units)
   return (
     <li
       data-testid="micro-workout-segment"

--- a/frontend/src/app/modules/plan/components/today-card.component.spec.tsx
+++ b/frontend/src/app/modules/plan/components/today-card.component.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
+import { PreferredUnits } from '~/api/generated'
 import { TodayCard, type TodayCardProps } from './today-card.component'
 import { buildPlanFixture, fixtureWeekOneWorkouts } from './plan-display.fixture'
 
@@ -34,6 +35,18 @@ describe('TodayCard', () => {
     expect(screen.getByRole('heading', { name: 'Easy aerobic shakeout' })).toBeInTheDocument()
     const inner = screen.getByTestId('micro-workout-card')
     expect(inner.dataset.emphasized).toBe('true')
+  })
+
+  it('threads the unit preference into the embedded workout card', () => {
+    const plan = buildPlanFixture()
+    renderCard({
+      currentWeek: plan.mesoWeeks[0],
+      workouts: fixtureWeekOneWorkouts(),
+      today: monday,
+      units: PreferredUnits.Miles,
+    })
+    // Monday's easy run is 6 km -> 3.7 mi
+    expect(screen.getByTestId('micro-workout-distance').textContent).toBe('3.7 mi')
   })
 
   it('renders a "Log run" action linking to /log in the workout variant', () => {

--- a/frontend/src/app/modules/plan/components/today-card.component.tsx
+++ b/frontend/src/app/modules/plan/components/today-card.component.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
+import { PreferredUnits } from '~/api/generated'
 import type { MesoWeekTemplateDto, MicroWorkoutCardDto } from '~/modules/plan/models/plan.model'
 import {
   DAY_OF_WEEK_LABELS,
@@ -23,6 +24,8 @@ export interface TodayCardProps {
    * deterministic snapshot, or omit in production to use `new Date()`.
    */
   today?: Date
+  /** Display unit for the embedded workout card. Defaults to Kilometers. */
+  units?: PreferredUnits
   className?: string
 }
 
@@ -40,6 +43,7 @@ export const TodayCard = ({
   currentWeek,
   workouts,
   today,
+  units = PreferredUnits.Kilometers,
   className,
 }: TodayCardProps): ReactElement => {
   const date = today ?? new Date()
@@ -63,7 +67,7 @@ export const TodayCard = ({
             {todayLabel}
           </span>
         </header>
-        <MicroWorkoutCard workout={todaysWorkout} emphasized={true} />
+        <MicroWorkoutCard workout={todaysWorkout} emphasized={true} units={units} />
         <Button asChild size="sm" className="self-start" data-testid="today-card-log-action">
           <Link to="/log">Log run</Link>
         </Button>

--- a/frontend/src/app/modules/plan/components/upcoming-list.component.spec.tsx
+++ b/frontend/src/app/modules/plan/components/upcoming-list.component.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
+import { PreferredUnits } from '~/api/generated'
 import { UpcomingList } from './upcoming-list.component'
 import { buildPlanFixture, fixtureWeekOneWorkouts } from './plan-display.fixture'
 
@@ -24,6 +25,25 @@ describe('UpcomingList', () => {
     const cards = screen.getAllByTestId('micro-workout-card')
     const titles = cards.map((card) => card.querySelector('h3')?.textContent ?? '')
     expect(titles).toEqual(['Threshold intervals', 'Long aerobic run'])
+  })
+
+  it('threads the unit preference into both the workout cards and the meso block', () => {
+    const plan = buildPlanFixture()
+    render(
+      <UpcomingList
+        currentWeekWorkouts={fixtureWeekOneWorkouts()}
+        weeks={plan.mesoWeeks}
+        currentWeek={1}
+        today={monday}
+        units={PreferredUnits.Miles}
+      />,
+    )
+    // Wednesday interval 9 km -> 5.6 mi (a remaining workout card); meso 30 km -> 18.6 mi
+    const distances = screen
+      .getAllByTestId('micro-workout-distance')
+      .map((cell) => cell.textContent)
+    expect(distances).toContain('5.6 mi')
+    expect(screen.getAllByText(/18\.6 mi/u).length).toBeGreaterThan(0)
   })
 
   it('omits the rest-of-week section when no workouts remain', () => {

--- a/frontend/src/app/modules/plan/components/upcoming-list.component.tsx
+++ b/frontend/src/app/modules/plan/components/upcoming-list.component.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react'
+import { PreferredUnits } from '~/api/generated'
 import type { MesoWeekTemplateDto, MicroWorkoutCardDto } from '~/modules/plan/models/plan.model'
 import { MesoWeekBlock } from './meso-week-block.component'
 import { MicroWorkoutCard } from './micro-workout-card.component'
@@ -17,6 +18,8 @@ export interface UpcomingListProps {
   currentWeek: number
   /** Local date used to compute "today's" day-of-week index. */
   today?: Date
+  /** Display unit for the embedded workout cards + meso block. Defaults to Kilometers. */
+  units?: PreferredUnits
   className?: string
 }
 
@@ -35,6 +38,7 @@ export const UpcomingList = ({
   weeks,
   currentWeek,
   today,
+  units = PreferredUnits.Kilometers,
   className,
 }: UpcomingListProps): ReactElement => {
   const date = today ?? new Date()
@@ -62,7 +66,7 @@ export const UpcomingList = ({
               // because the structured-output schema emits one workout per
               // day at most.
               <li key={`day-${workout.dayOfWeek}`} data-testid="upcoming-workout-item">
-                <MicroWorkoutCard workout={workout} />
+                <MicroWorkoutCard workout={workout} units={units} />
               </li>
             ))}
           </ol>
@@ -72,7 +76,7 @@ export const UpcomingList = ({
       {weeks.length > 0 ? (
         <div className="flex flex-col gap-3">
           <h2 className="text-lg font-semibold text-foreground">Upcoming weeks</h2>
-          <MesoWeekBlock weeks={weeks} currentWeek={currentWeek} />
+          <MesoWeekBlock weeks={weeks} currentWeek={currentWeek} units={units} />
         </div>
       ) : null}
     </section>

--- a/frontend/src/app/modules/plan/pages/home.page.spec.tsx
+++ b/frontend/src/app/modules/plan/pages/home.page.spec.tsx
@@ -39,6 +39,14 @@ vi.mock('~/modules/coaching/hooks/use-coach-stream.hooks', () => ({
   useCoachStream: () => coachStreamMock(),
 }))
 
+// `HomePage` reads the unit preference via this hook, which wraps a real RTK
+// Query hook; the page renders here without a Redux store, so stub it to a
+// concrete unit. Kilometers keeps the existing km-based assertions intact.
+vi.mock('~/modules/settings/hooks/use-preferred-units.hooks', async () => {
+  const { PreferredUnits } = await import('~/api/generated')
+  return { usePreferredUnits: () => PreferredUnits.Kilometers }
+})
+
 const idleStream = (): UseCoachStreamReturn => ({
   pendingUserMessage: null,
   streamingText: '',

--- a/frontend/src/app/modules/plan/pages/home.page.spec.tsx
+++ b/frontend/src/app/modules/plan/pages/home.page.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PreferredUnits } from '~/api/generated'
 import type { UseCoachStreamReturn } from '~/modules/coaching/hooks/use-coach-stream.hooks'
 import type { ConversationTimelineDto } from '~/modules/coaching/models/conversation.model'
 import { buildPlanFixture } from '~/modules/plan/components/plan-display.fixture'
@@ -20,11 +21,13 @@ interface TimelineQueryResult {
   isError: boolean
 }
 
-const { getCurrentPlanMock, getConversationTimelineMock, coachStreamMock } = vi.hoisted(() => ({
-  getCurrentPlanMock: vi.fn<() => QueryResult>(),
-  getConversationTimelineMock: vi.fn<() => TimelineQueryResult>(),
-  coachStreamMock: vi.fn<() => UseCoachStreamReturn>(),
-}))
+const { getCurrentPlanMock, getConversationTimelineMock, coachStreamMock, preferredUnitsMock } =
+  vi.hoisted(() => ({
+    getCurrentPlanMock: vi.fn<() => QueryResult>(),
+    getConversationTimelineMock: vi.fn<() => TimelineQueryResult>(),
+    coachStreamMock: vi.fn<() => UseCoachStreamReturn>(),
+    preferredUnitsMock: vi.fn<() => PreferredUnits>(),
+  }))
 
 vi.mock('~/api/plan.api', () => ({
   useGetCurrentPlanQuery: () => getCurrentPlanMock(),
@@ -40,12 +43,13 @@ vi.mock('~/modules/coaching/hooks/use-coach-stream.hooks', () => ({
 }))
 
 // `HomePage` reads the unit preference via this hook, which wraps a real RTK
-// Query hook; the page renders here without a Redux store, so stub it to a
-// concrete unit. Kilometers keeps the existing km-based assertions intact.
-vi.mock('~/modules/settings/hooks/use-preferred-units.hooks', async () => {
-  const { PreferredUnits } = await import('~/api/generated')
-  return { usePreferredUnits: () => PreferredUnits.Kilometers }
-})
+// Query hook; the page renders here without a Redux store, so stub it through a
+// mockable ref. Defaulted to Kilometers in `beforeEach` (keeps the existing
+// km-based assertions intact); the miles-wiring test overrides it to prove the
+// page actually threads the preference into the render sections.
+vi.mock('~/modules/settings/hooks/use-preferred-units.hooks', () => ({
+  usePreferredUnits: () => preferredUnitsMock(),
+}))
 
 const idleStream = (): UseCoachStreamReturn => ({
   pendingUserMessage: null,
@@ -81,6 +85,7 @@ describe('HomePage', () => {
       isError: false,
     })
     coachStreamMock.mockReturnValue(idleStream())
+    preferredUnitsMock.mockReturnValue(PreferredUnits.Kilometers)
   })
 
   afterEach(() => {
@@ -116,6 +121,29 @@ describe('HomePage', () => {
     expect(screen.getByTestId('macro-phase-strip')).toBeInTheDocument()
     expect(screen.getByTestId('today-card')).toBeInTheDocument()
     expect(screen.getByTestId('upcoming-list')).toBeInTheDocument()
+  })
+
+  it('threads the Miles preference from the hook into the rendered distances', () => {
+    vi.useFakeTimers()
+    // Monday of training week 1 (planStartDate 2026-04-19), so the fixture's
+    // Monday easy run is the prominent workout card and week-1 micro workouts
+    // populate the upcoming list.
+    vi.setSystemTime(new Date(2026, 3, 20)) // Mon 2026-04-20 → dayOfWeek = 1, week 1
+    preferredUnitsMock.mockReturnValue(PreferredUnits.Miles)
+
+    getCurrentPlanMock.mockReturnValue({
+      data: buildPlanFixture(),
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    })
+    renderHome()
+
+    // Monday's easy run is 6 km -> 3.7 mi (today card); meso targets 30 km -> 18.6 mi.
+    expect(screen.getByTestId('today-card').textContent).toContain('3.7 mi')
+    expect(screen.getAllByText(/18\.6 mi/u).length).toBeGreaterThan(0)
+    // Nothing on the plan surface should still be rendering kilometres.
+    expect(screen.queryByText(/\d\.\d km/u)).not.toBeInTheDocument()
   })
 
   it('renders the rest-day variant of TodayCard when today maps to a rest slot', () => {

--- a/frontend/src/app/modules/plan/pages/home.page.tsx
+++ b/frontend/src/app/modules/plan/pages/home.page.tsx
@@ -12,6 +12,7 @@ import {
   usePlan,
 } from '~/modules/plan/hooks/use-plan.hooks'
 import type { PlanProjectionDto } from '~/modules/plan/models/plan.model'
+import { usePreferredUnits } from '~/modules/settings/hooks/use-preferred-units.hooks'
 
 /**
  * Top-level container for the protected home route (`/`). Composes the
@@ -88,6 +89,7 @@ const PlanLayout = ({ plan }: PlanLayoutProps): ReactElement => {
   const currentWeek = resolveCurrentWeek(plan)
   const currentWeekTemplate = findCurrentMesoWeek(plan, currentWeek)
   const currentWeekWorkouts = findCurrentWeekWorkouts(plan, currentWeek)
+  const units = usePreferredUnits()
 
   return (
     <main
@@ -107,7 +109,11 @@ const PlanLayout = ({ plan }: PlanLayoutProps): ReactElement => {
       )}
 
       {currentWeekTemplate === undefined ? null : (
-        <TodayCard currentWeek={currentWeekTemplate} workouts={currentWeekWorkouts} />
+        <TodayCard
+          currentWeek={currentWeekTemplate}
+          workouts={currentWeekWorkouts}
+          units={units}
+        />
       )}
 
       <CoachChat />
@@ -116,6 +122,7 @@ const PlanLayout = ({ plan }: PlanLayoutProps): ReactElement => {
         currentWeekWorkouts={currentWeekWorkouts}
         weeks={plan.mesoWeeks}
         currentWeek={currentWeek}
+        units={units}
       />
     </main>
   )

--- a/frontend/src/app/modules/plan/utils/pace-format.helpers.ts
+++ b/frontend/src/app/modules/plan/utils/pace-format.helpers.ts
@@ -4,16 +4,13 @@
 // structured-output records (`TargetPaceEasySecPerKm`, `TargetPaceFastSecPerKm`,
 // `WorkoutSegmentOutput.TargetPaceSecPerKm`) and on logged splits.
 //
-// As of slice 4C-units the single home for `MM:SS` pace formatting is the
-// shared, preference-aware `unit-format.helpers` module. These two helpers stay
-// as thin km-pinned adapters over it: the plan render sites now read the unit
-// preference directly, but the logging/history render sites (`workout-log-*`,
-// `history-format.helpers`) are still km-only until they are wired to the
-// preference. Pinning `PreferredUnits.Kilometers` here keeps their output
+// The single home for `MM:SS` pace formatting is the shared, preference-aware
+// `unit-format.helpers` module. These two helpers stay as thin km-pinned
+// adapters over it, pinning `PreferredUnits.Kilometers` to keep their output
 // byte-identical while removing the duplicate rounding/ceiling/formatting logic.
 //
-// Per the trademark rule in the root `CLAUDE.md`, the user-facing strings
-// produced here use the literal `/km` suffix; no zone-name coupling lives here.
+// The user-facing strings produced here use the literal `/km` suffix and no
+// zone-name coupling, per the trademark restriction on the VDOT mark (DEC-042).
 
 import { PreferredUnits } from '~/api/generated'
 import {

--- a/frontend/src/app/modules/plan/utils/pace-format.helpers.ts
+++ b/frontend/src/app/modules/plan/utils/pace-format.helpers.ts
@@ -1,88 +1,42 @@
-// Pace formatting helpers for the plan view.
+// Kilometre-fixed pace formatters for the still-km logging/history surfaces.
 //
 // The backend emits paces as integer **seconds-per-kilometer** on the
-// structured-output records (`TargetPaceEasySecPerKm`,
-// `TargetPaceFastSecPerKm`, `WorkoutSegmentOutput.TargetPaceSecPerKm`). The
-// home surface renders them as `MM:SS/km` strings.
+// structured-output records (`TargetPaceEasySecPerKm`, `TargetPaceFastSecPerKm`,
+// `WorkoutSegmentOutput.TargetPaceSecPerKm`) and on logged splits.
 //
-// Distances are expressed in kilometers (spec 13 § Unit 4 R04.6).
+// As of slice 4C-units the single home for `MM:SS` pace formatting is the
+// shared, preference-aware `unit-format.helpers` module. These two helpers stay
+// as thin km-pinned adapters over it: the plan render sites now read the unit
+// preference directly, but the logging/history render sites (`workout-log-*`,
+// `history-format.helpers`) are still km-only until they are wired to the
+// preference. Pinning `PreferredUnits.Kilometers` here keeps their output
+// byte-identical while removing the duplicate rounding/ceiling/formatting logic.
 //
 // Per the trademark rule in the root `CLAUDE.md`, the user-facing strings
-// produced here use the literal `/km` suffix; no zone-name coupling lives
-// in this module.
+// produced here use the literal `/km` suffix; no zone-name coupling lives here.
 
-/** Maximum pace value the formatter accepts, in seconds-per-kilometer. */
-const MAX_PACE_SECONDS_PER_KM = 99 * 60 + 59 // 99:59/km
-const SECONDS_PER_MINUTE = 60
+import { PreferredUnits } from '~/api/generated'
+import {
+  formatPaceRangeSecPerKm,
+  formatPaceSecPerKm,
+} from '~/modules/common/utils/unit-format.helpers'
 
 /**
  * Formats a pace expressed in **seconds per kilometer** as a `MM:SS/km`
- * string suitable for direct rendering.
- *
- * Inputs are rounded to the nearest whole second before formatting — the
- * structured-output schema already emits integer seconds, but the helper is
- * defensive against fractional inputs that future logged-workout surfaces
- * may produce.
- *
- * Returns `null` when the input is invalid (NaN, infinite, negative, or
- * above the documented `99:59/km` ceiling). Callers render a placeholder
- * (`—/km` or similar) on `null` rather than crashing.
+ * string. Returns `null` when the input is invalid (NaN, infinite, negative,
+ * or above the documented `99:59/km` ceiling); callers render a placeholder.
  */
-export const formatPacePerKm = (secondsPerKm: number): string | null => {
-  if (!Number.isFinite(secondsPerKm)) {
-    return null
-  }
-
-  const rounded = Math.round(secondsPerKm)
-  if (rounded < 0 || rounded > MAX_PACE_SECONDS_PER_KM) {
-    return null
-  }
-
-  const minutes = Math.floor(rounded / SECONDS_PER_MINUTE)
-  const seconds = rounded - minutes * SECONDS_PER_MINUTE
-  const paddedMinutes = minutes.toString().padStart(2, '0')
-  const paddedSeconds = seconds.toString().padStart(2, '0')
-  return `${paddedMinutes}:${paddedSeconds}/km`
-}
+export const formatPacePerKm = (secondsPerKm: number): string | null =>
+  formatPaceSecPerKm(secondsPerKm, PreferredUnits.Kilometers)
 
 /**
- * Formats a pace **range** (typically from `targetPaceEasySecPerKm` and
- * `targetPaceFastSecPerKm` on `MicroWorkoutCardDto`) as a single
- * `FAST-SLOW/km` string. Faster (smaller seconds-per-km) is rendered first
- * to match the conventional display order.
- *
- * When the two values resolve to the same `MM:SS` after rounding, returns
- * the single-pace formatting (no degenerate `MM:SS-MM:SS/km`). When either
- * value is invalid, returns whichever side is valid; when both are invalid,
- * returns `null`.
+ * Formats a pace **range** (both bounds in seconds-per-kilometer) as a single
+ * `FAST-SLOW/km` string, faster (smaller seconds) first. Collapses to a single
+ * pace when both bounds round equal; returns whichever side is valid when one
+ * is invalid; returns `null` when both are invalid.
  */
 export const formatPaceRangePerKm = (
   fastSecondsPerKm: number,
   slowSecondsPerKm: number,
-): string | null => {
-  const formattedFast = formatPacePerKm(fastSecondsPerKm)
-  const formattedSlow = formatPacePerKm(slowSecondsPerKm)
-
-  if (formattedFast === null && formattedSlow === null) {
-    return null
-  }
-  if (formattedFast === null) {
-    return formattedSlow
-  }
-  if (formattedSlow === null) {
-    return formattedFast
-  }
-
-  // Order so the **faster** pace (lower seconds) renders first.
-  const fastRounded = Math.round(fastSecondsPerKm)
-  const slowRounded = Math.round(slowSecondsPerKm)
-  const [first, second] =
-    fastRounded <= slowRounded ? [formattedFast, formattedSlow] : [formattedSlow, formattedFast]
-
-  if (first === second) {
-    return first
-  }
-  // Strip the trailing `/km` from the first half so the suffix is shown once.
-  const firstWithoutSuffix = first.replace(/\/km$/u, '')
-  return `${firstWithoutSuffix}-${second}`
-}
+): string | null =>
+  formatPaceRangeSecPerKm(fastSecondsPerKm, slowSecondsPerKm, PreferredUnits.Kilometers)

--- a/frontend/src/app/modules/settings/components/units-toggle.component.tsx
+++ b/frontend/src/app/modules/settings/components/units-toggle.component.tsx
@@ -30,8 +30,9 @@ const parsePreferredUnits = (value: string): PreferredUnits =>
  * query. While the preference is still loading it falls back to Kilometers so
  * the control always renders with a selection.
  *
- * This control only records the preference. It does not affect how distances or
- * paces are currently rendered elsewhere in the app.
+ * This preference drives the plan render tree (`TodayCard`, `UpcomingList`,
+ * `MesoWeekBlock`, `MicroWorkoutCard`) via `usePreferredUnits`. The
+ * logging/history and adaptation surfaces remain km-only.
  */
 export const UnitsToggle = (): ReactElement => {
   const { data } = useGetUnitPreferenceQuery(undefined)

--- a/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.spec.ts
+++ b/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.spec.ts
@@ -36,7 +36,11 @@ describe('usePreferredUnits', () => {
     expect(result.current).toBe(PreferredUnits.Miles)
   })
 
-  it('returns the persisted Kilometers preference (0 is not treated as absent)', () => {
+  it('returns the persisted Kilometers preference', () => {
+    // Kilometers is the enum value 0, which also happens to be the fallback, so
+    // this case cannot by itself distinguish `??` from `||` — over the whole
+    // {undefined, 0, 1} domain the two operators are provably equivalent here.
+    // It still guards that a persisted Kilometers reads back as Kilometers.
     getQueryRef.data = { preferredUnits: PreferredUnits.Kilometers }
     const { result } = renderHook(() => usePreferredUnits())
     expect(result.current).toBe(PreferredUnits.Kilometers)

--- a/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.spec.ts
+++ b/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.spec.ts
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PreferredUnits } from '~/api/generated'
+
+interface UnitPreference {
+  preferredUnits: PreferredUnits
+}
+
+// The hook only reads `data` off the query result, so a plain hoisted ref
+// standing in for `useGetUnitPreferenceQuery` keeps the test free of a Redux
+// store while exercising the real fallback/selection logic.
+const { getQueryRef } = vi.hoisted(() => ({
+  getQueryRef: { data: undefined as UnitPreference | undefined },
+}))
+
+vi.mock('~/api/settings.api', () => ({
+  useGetUnitPreferenceQuery: () => getQueryRef,
+}))
+
+import { usePreferredUnits } from './use-preferred-units.hooks'
+
+describe('usePreferredUnits', () => {
+  beforeEach(() => {
+    getQueryRef.data = undefined
+  })
+
+  it('falls back to Kilometers while the preference is unresolved', () => {
+    getQueryRef.data = undefined
+    const { result } = renderHook(() => usePreferredUnits())
+    expect(result.current).toBe(PreferredUnits.Kilometers)
+  })
+
+  it('returns the persisted Miles preference', () => {
+    getQueryRef.data = { preferredUnits: PreferredUnits.Miles }
+    const { result } = renderHook(() => usePreferredUnits())
+    expect(result.current).toBe(PreferredUnits.Miles)
+  })
+
+  it('returns the persisted Kilometers preference (0 is not treated as absent)', () => {
+    getQueryRef.data = { preferredUnits: PreferredUnits.Kilometers }
+    const { result } = renderHook(() => usePreferredUnits())
+    expect(result.current).toBe(PreferredUnits.Kilometers)
+  })
+})

--- a/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.ts
+++ b/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.ts
@@ -1,0 +1,17 @@
+import { PreferredUnits } from '~/api/generated'
+import { useGetUnitPreferenceQuery } from '~/api/settings.api'
+
+/**
+ * Reads the runner's persisted distance-unit preference for **display**.
+ *
+ * Falls back to {@link PreferredUnits.Kilometers} while the query is loading,
+ * uninitialized, or errored, so every render site receives a concrete unit and
+ * never has to branch on an undefined preference. This is a display concern
+ * only — storage, the wire, and the plan-gen prompt stay km-native, and the LLM
+ * performs zero unit conversion (DEC-086). The single home for the read so
+ * plan / history / adaptation render sites resolve the preference the same way.
+ */
+export const usePreferredUnits = (): PreferredUnits => {
+  const { data } = useGetUnitPreferenceQuery(undefined)
+  return data?.preferredUnits ?? PreferredUnits.Kilometers
+}


### PR DESCRIPTION
## Summary

Slice 4C-units **PR4** — the first PR that displays plan distances/paces in **miles**. The plan view now renders in the runner's chosen display unit (km or miles), reading the preference persisted by PR1–PR3. Conversion is **display-only** (DEC-086): storage, the wire, and the plan-gen prompt stay km-native, and the LLM performs zero unit conversion.

## What changed

**Preference-aware plan render sites** (the three named PR4 targets):
- `micro-workout-card` — target distance + target pace range, with unit-correct placeholders (`—/mi` vs `—/km`)
- `meso-week-block` — weekly target volume
- `micro-workout-segment-row` — segment pace

**Plumbing:**
- New `usePreferredUnits()` hook — single home for the display-preference read; falls back to Kilometers while the query is loading/uninitialized/errored so every render site gets a concrete unit.
- `units` threaded `home.page → TodayCard/UpcomingList → components` as a **km-defaulted prop**, so callers (and isolated tests) that predate the preference render the km form unchanged.

**Helper consolidation:**
- The km-only `pace-format.helpers` and `history-format.helpers` distance/pace formatters are reduced to thin **km-pinned delegates** over the shared, preference-aware `common/utils/unit-format.helpers` module (introduced in PR2). This removes the duplicated MM:SS/ceiling/distance logic while keeping km output **byte-identical**.
- The logging/history + adaptation render sites are deliberately left km-only — they are wired to the preference in **PR5**, and the miles→km log-write lands in **PR6**.

## Testing
- Full frontend suite green: **63 files / 642 tests**
- Type-check + production build pass
- Changed files lint-clean

## Review
A 4-lens adversarial review (correctness/byte-parity, PR scope/boundary, conventions/trademark, test quality) with per-finding verification was run over the diff. The correctness, scope, and conventions lenses returned **zero findings** — the km byte-parity of the delegates and the PR4/PR5 boundary both held. The 5 surfaced test-quality findings (all minor/nit) are addressed in the second commit: placeholder-branch coverage, a page-level miles-wiring test, and two honesty fixes to test names/titles that were over-claiming what they guard.

## Notes for the reviewer
- **Branch name:** the slice plan named this PR's branch `feat/slice-4c-wire-plan`; it landed on `claude/catchup-l17qln` (the session's designated branch) instead. It branches cleanly off `main` with no stacking, so the content is equivalent — flag if you'd prefer it re-pointed.
- **Scope is intentionally narrow to the plan view.** `MacroPhaseStrip` renders no distance/pace, so it needs no change; logging/history/adaptation surfaces stay km until PR5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7tb9b1s5NtMCPuV9XmQJd

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7tb9b1s5NtMCPuV9XmQJd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The plan now follows your saved unit preference (kilometers or miles) on the home page, today card, upcoming list, and workout/weekly blocks—showing matching distance and pace units (e.g., `/mi` when set to miles).
  * Missing distance/pace values now display clearer placeholders for unit-aware formatting.
* **Bug Fixes**
  * Workout-history distance formatting is now standardized, and pace/distance formatting uses shared logic for more consistent output.  
  * Invalid or non-positive values show an em dash instead of awkward numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->