### PR TITLE
feat(slice-4c-units): PR6 — miles→km conversion at the log write site

### DIFF
--- a/frontend/src/app/modules/common/utils/unit-format.helpers.spec.ts
+++ b/frontend/src/app/modules/common/utils/unit-format.helpers.spec.ts
@@ -4,11 +4,14 @@ import { PreferredUnits } from '~/api/generated'
 import { formatHistoryDistanceKm as historyFormatDistanceKm } from '~/modules/logging/history/history-format.helpers'
 
 import {
+  distanceUnitLabel,
   formatDistanceKm,
   formatDistanceMeters,
   formatPaceRangeSecPerKm,
   formatPaceSecPerKm,
   METERS_PER_MILE,
+  metresToPreferredDistance,
+  preferredDistanceToMeters,
 } from './unit-format.helpers'
 
 const KM = PreferredUnits.Kilometers
@@ -19,6 +22,48 @@ describe('METERS_PER_MILE', () => {
     // Asserted via the string form to pin the exact value without a
     // floating-point equality comparison (sonarjs/no-floating-point-equality).
     expect(METERS_PER_MILE.toString()).toBe('1609.344')
+  })
+})
+
+describe('distanceUnitLabel', () => {
+  it('is the literal km/mi suffix for the preferred unit', () => {
+    expect(distanceUnitLabel(KM)).toBe('km')
+    expect(distanceUnitLabel(MI)).toBe('mi')
+  })
+})
+
+describe('preferredDistanceToMeters — the single write conversion', () => {
+  it('leaves the km path byte-identical to the prior `distanceKm * 1000`', () => {
+    // Exact integers on the km path so a persisted 5 km stays 5000 m (no drift).
+    expect(preferredDistanceToMeters(5, KM)).toBe(5000)
+    expect(preferredDistanceToMeters(0, KM)).toBe(0)
+    expect(preferredDistanceToMeters(42.195, KM)).toBe(42195)
+  })
+
+  it('interprets the value as miles and converts to metres on the miles path', () => {
+    // 5 mi * 1609.344 = 8046.72 m. Asserted via the exact expression (string form
+    // pins byte-exact equality without a floating-point `===`).
+    expect(String(preferredDistanceToMeters(5, MI))).toBe(String(5 * METERS_PER_MILE))
+    expect(String(preferredDistanceToMeters(3.1, MI))).toBe(String(3.1 * METERS_PER_MILE))
+  })
+
+  it('maps a zero distance to zero metres in either unit (skipped-run fallback)', () => {
+    expect(preferredDistanceToMeters(0, KM)).toBe(0)
+    expect(preferredDistanceToMeters(0, MI)).toBe(0)
+  })
+})
+
+describe('metresToPreferredDistance — inverse for draft pre-fill', () => {
+  it('divides metres into the preferred unit', () => {
+    expect(metresToPreferredDistance(5000, KM)).toBe(5)
+    expect(String(metresToPreferredDistance(8046.72, MI))).toBe(String(8046.72 / METERS_PER_MILE))
+  })
+
+  it('round-trips a preferred-unit distance through metres and back', () => {
+    for (const units of [KM, MI]) {
+      const metres = preferredDistanceToMeters(7.3, units)
+      expect(metresToPreferredDistance(metres, units)).toBeCloseTo(7.3, 10)
+    }
   })
 })
 

--- a/frontend/src/app/modules/common/utils/unit-format.helpers.ts
+++ b/frontend/src/app/modules/common/utils/unit-format.helpers.ts
@@ -1,9 +1,15 @@
 // Shared, deterministic unit-format layer (slice 4C-units).
 //
-// A single preference-aware home for rendering canonical km/SI values in the
-// runner's chosen display unit. Storage, the wire, and the plan-gen prompt stay
-// km-native (DEC-010 / DEC-041 / DEC-086) — this module converts for *display*
-// only, and the LLM performs zero unit conversion.
+// A single preference-aware home for the runner's chosen display unit. Storage,
+// the wire, and the plan-gen prompt stay km-native (DEC-010 / DEC-041 / DEC-086),
+// and the LLM performs zero unit conversion. This module owns BOTH the display
+// formatters (canonical value → string in the preferred unit) AND the numeric
+// conversions the one real write site needs — {@link preferredDistanceToMeters}
+// (the runner's typed distance, in their preferred unit, → canonical metres) and
+// its inverse {@link metresToPreferredDistance} (used to pre-fill the log form
+// from a parsed draft). Keeping the write conversion here — not scattered at the
+// call site — is the "one shared module, one write site" guarantee: there is
+// exactly one `1609.344` in the frontend.
 //
 // The kilometre output is byte-identical to the pre-existing km-only helpers, so
 // consumers' existing null/ceiling guards continue to hold when those helpers are
@@ -44,6 +50,32 @@ const MAX_PACE_SECONDS_PER_KM = 99 * SECONDS_PER_MINUTE + 59
 const MAX_PACE_SECONDS_PER_MILE = MAX_PACE_SECONDS_PER_KM * KM_PER_MILE
 
 const isMiles = (units: PreferredUnits): boolean => units === PreferredUnits.Miles
+
+/**
+ * The user-facing distance-unit suffix for the preferred unit — the literal
+ * `km` / `mi` (trademark rule: no zone-name coupling). Used for input labels and
+ * validation-message wording so the log form speaks the runner's unit.
+ */
+export const distanceUnitLabel = (units: PreferredUnits): 'km' | 'mi' =>
+  isMiles(units) ? 'mi' : 'km'
+
+/**
+ * Interprets a distance the runner **typed in their preferred unit** and returns
+ * canonical **metres** for the wire — the single miles→km/SI write conversion
+ * (`× 1609.344` for miles; `× 1000` for kilometres, byte-identical to the prior
+ * `distanceKm * 1000`). The LLM never performs this; it is deterministic here.
+ */
+export const preferredDistanceToMeters = (value: number, units: PreferredUnits): number =>
+  isMiles(units) ? value * METERS_PER_MILE : value * METERS_PER_KM
+
+/**
+ * Inverse of {@link preferredDistanceToMeters}: canonical **metres** → the
+ * numeric value in the preferred unit, for pre-filling the log form from a parsed
+ * draft. Callers that already hold the value in the target unit should skip this
+ * (identity conversions accrue avoidable floating-point drift).
+ */
+export const metresToPreferredDistance = (metres: number, units: PreferredUnits): number =>
+  isMiles(units) ? metres / METERS_PER_MILE : metres / METERS_PER_KM
 
 /**
  * Formats a canonical distance in **kilometres** in the preferred unit as a

--- a/frontend/src/app/modules/logging/components/log-form.component.tsx
+++ b/frontend/src/app/modules/logging/components/log-form.component.tsx
@@ -24,6 +24,8 @@ export interface LogFormProps {
   onSubmit: (values: WorkoutLogFormValues) => void | Promise<void>
   isLoading: boolean
   formAlert: string | null
+  /** The distance field label, unit-aware (e.g. `Distance (km)` / `Distance (mi)`). */
+  distanceLabel: string
 }
 
 /**
@@ -32,7 +34,7 @@ export interface LogFormProps {
  * The container owns `useForm` + the create mutation + navigation; this renders
  * the field stack and gates submit on validity / in-flight state.
  */
-export const LogForm = ({ form, onSubmit, isLoading, formAlert }: LogFormProps) => {
+export const LogForm = ({ form, onSubmit, isLoading, formAlert, distanceLabel }: LogFormProps) => {
   const isSubmitDisabled = !form.formState.isValid || form.formState.isSubmitting || isLoading
 
   return (
@@ -67,7 +69,7 @@ export const LogForm = ({ form, onSubmit, isLoading, formAlert }: LogFormProps) 
           )}
         />
 
-        <LogNumericField control={form.control} name="distanceKm" label="Distance (km)" autoFocus />
+        <LogNumericField control={form.control} name="distance" label={distanceLabel} autoFocus />
         <LogNumericField control={form.control} name="durationMinutes" label="Duration (minutes)" />
 
         <CompletionStatusField control={form.control} name="completionStatus" />

--- a/frontend/src/app/modules/logging/draft-to-form.helpers.spec.ts
+++ b/frontend/src/app/modules/logging/draft-to-form.helpers.spec.ts
@@ -1,12 +1,16 @@
-import type { StructuredLogDraft } from '~/api/generated'
+import { PreferredUnits, type StructuredLogDraft } from '~/api/generated'
 import { describe, expect, it } from 'vitest'
 
 import { draftToWorkoutLogFormFields } from './draft-to-form.helpers'
 
 // The confirmation card's "Edit" affordance pre-fills the log form from the
-// parsed wire draft. The form is km-only with a single total-minutes field, so
-// the mapper must collapse the draft's stated unit + h:m:s components and emit
-// the all-strings `WorkoutLogFormFields` shape.
+// parsed wire draft. The form's single `distance` field is expressed in the
+// runner's preferred display unit (slice 4C-units), so the mapper collapses the
+// draft's stated unit + h:m:s components INTO that unit and emits the all-strings
+// `WorkoutLogFormFields` shape.
+
+const KM = PreferredUnits.Kilometers
+const MI = PreferredUnits.Miles
 
 const baseDraft: StructuredLogDraft = {
   occurredOn: '2026-06-20',
@@ -20,73 +24,93 @@ const baseDraft: StructuredLogDraft = {
 }
 
 describe('draftToWorkoutLogFormFields', () => {
-  it('passes a kilometers draft straight through to distanceKm', () => {
-    const fields = draftToWorkoutLogFormFields(baseDraft)
+  it('passes a kilometers draft straight through under a Kilometers preference', () => {
+    const fields = draftToWorkoutLogFormFields(baseDraft, KM)
 
-    expect(fields.distanceKm).toBe('5')
+    expect(fields.distance).toBe('5')
     expect(fields.durationMinutes).toBe('25')
     expect(fields.occurredOn).toBe('2026-06-20')
     expect(fields.completionStatus).toBe('0')
     expect(fields.notes).toBe('legs felt heavy')
   })
 
-  it('converts a miles draft to kilometers', () => {
-    const fields = draftToWorkoutLogFormFields({
-      ...baseDraft,
-      distanceValue: 3.1,
-      distanceUnit: 1,
-    })
+  it('converts a miles draft to kilometers under a Kilometers preference', () => {
+    const fields = draftToWorkoutLogFormFields(
+      { ...baseDraft, distanceValue: 3.1, distanceUnit: 1 },
+      KM,
+    )
 
     // 3.1 mi * 1609.344 m/mi / 1000 = 4.9889664 km
-    expect(fields.distanceKm).toBe(String(3.1 * 1.609344))
+    expect(fields.distance).toBe(String(3.1 * 1.609344))
   })
 
-  it('converts a meters draft to kilometers', () => {
-    const fields = draftToWorkoutLogFormFields({
-      ...baseDraft,
-      distanceValue: 400,
-      distanceUnit: 2,
-    })
+  it('converts a meters draft to kilometers under a Kilometers preference', () => {
+    const fields = draftToWorkoutLogFormFields(
+      { ...baseDraft, distanceValue: 400, distanceUnit: 2 },
+      KM,
+    )
 
-    expect(fields.distanceKm).toBe('0.4')
+    expect(fields.distance).toBe('0.4')
+  })
+
+  it('keeps a miles draft in miles under a Miles preference (identity, no round-trip drift)', () => {
+    // Draft already in the target unit: the value passes straight through. A
+    // unit→metres→unit round trip would yield e.g. "99.99999999999999".
+    const fields = draftToWorkoutLogFormFields(
+      { ...baseDraft, distanceValue: 100, distanceUnit: 1 },
+      MI,
+    )
+
+    expect(fields.distance).toBe('100')
+  })
+
+  it('converts a kilometers draft to miles under a Miles preference', () => {
+    // 8.04672 km = exactly 5 mi.
+    const fields = draftToWorkoutLogFormFields(
+      { ...baseDraft, distanceValue: 8.04672, distanceUnit: 0 },
+      MI,
+    )
+
+    expect(Number.parseFloat(fields.distance)).toBeCloseTo(5, 6)
   })
 
   it('folds hours and seconds into fractional total minutes', () => {
-    const fields = draftToWorkoutLogFormFields({
-      ...baseDraft,
-      durationHours: 1,
-      durationMinutes: 22,
-      durationSeconds: 30,
-    })
+    const fields = draftToWorkoutLogFormFields(
+      { ...baseDraft, durationHours: 1, durationMinutes: 22, durationSeconds: 30 },
+      KM,
+    )
 
     // 1*60 + 22 + 30/60 = 82.5
     expect(fields.durationMinutes).toBe('82.5')
   })
 
   it('maps a zero/absent distance or duration to blank, never "0"', () => {
-    const fields = draftToWorkoutLogFormFields({
-      ...baseDraft,
-      distanceValue: 0,
-      durationHours: 0,
-      durationMinutes: 0,
-      durationSeconds: 0,
-      completionStatus: 2, // Skipped
-    })
+    const fields = draftToWorkoutLogFormFields(
+      {
+        ...baseDraft,
+        distanceValue: 0,
+        durationHours: 0,
+        durationMinutes: 0,
+        durationSeconds: 0,
+        completionStatus: 2, // Skipped
+      },
+      KM,
+    )
 
     // The form's > 0 range check fires regardless of status, so a '0' would be invalid.
-    expect(fields.distanceKm).toBe('')
+    expect(fields.distance).toBe('')
     expect(fields.durationMinutes).toBe('')
     expect(fields.completionStatus).toBe('2')
   })
 
   it('maps a null note to an empty string', () => {
-    const fields = draftToWorkoutLogFormFields({ ...baseDraft, notes: null })
+    const fields = draftToWorkoutLogFormFields({ ...baseDraft, notes: null }, KM)
 
     expect(fields.notes).toBe('')
   })
 
   it('leaves the optional metric fields blank (the draft carries no metrics)', () => {
-    const fields = draftToWorkoutLogFormFields(baseDraft)
+    const fields = draftToWorkoutLogFormFields(baseDraft, KM)
 
     expect(fields.rpe).toBe('')
     expect(fields.hrAvg).toBe('')

--- a/frontend/src/app/modules/logging/draft-to-form.helpers.ts
+++ b/frontend/src/app/modules/logging/draft-to-form.helpers.ts
@@ -2,14 +2,19 @@
 // `StructuredLogDraft` (the card's wire shape, in the runner's stated units with
 // h:m:s components) → the all-strings `WorkoutLogFormFields` the log form
 // consumes. It mirrors the backend `WorkoutDraftUnitConverter` in reverse:
-// distance is collapsed to the form's km-only field and duration to a single
-// total-minutes field. A zero/non-positive distance or duration maps to blank
-// (not "0"), because the form's `> 0` range check runs regardless of completion
-// status — a Skipped draft can legitimately carry zeros.
+// distance is collapsed to the form's single `distance` field — expressed in the
+// runner's preferred display unit (km OR miles), matching how the form now reads
+// its input (slice 4C-units) — and duration to a single total-minutes field. A
+// zero/non-positive distance or duration maps to blank (not "0"), because the
+// form's `> 0` range check runs regardless of completion status — a Skipped draft
+// can legitimately carry zeros.
 
-import type { RunnerDistanceUnit, StructuredLogDraft } from '~/api/generated'
+import { PreferredUnits, type RunnerDistanceUnit, type StructuredLogDraft } from '~/api/generated'
 
-import { METERS_PER_MILE } from '~/modules/common/utils/unit-format.helpers'
+import {
+  METERS_PER_MILE,
+  metresToPreferredDistance,
+} from '~/modules/common/utils/unit-format.helpers'
 import {
   makeDefaultWorkoutLogFormFields,
   type WorkoutLogFormFields,
@@ -23,35 +28,60 @@ const RUNNER_DISTANCE_UNIT = {
 
 const METERS_PER_KILOMETER = 1000
 
-const draftDistanceKm = (value: number, unit: RunnerDistanceUnit): number => {
+const draftDistanceMeters = (value: number, unit: RunnerDistanceUnit): number => {
   switch (unit) {
     case RUNNER_DISTANCE_UNIT.miles:
-      return (value * METERS_PER_MILE) / METERS_PER_KILOMETER
+      return value * METERS_PER_MILE
     case RUNNER_DISTANCE_UNIT.meters:
-      return value / METERS_PER_KILOMETER
-    default:
       return value
+    default:
+      return value * METERS_PER_KILOMETER
   }
 }
+
+/** True when the draft's stated unit already IS the form's display unit. */
+const draftUnitIsPreferred = (unit: RunnerDistanceUnit, units: PreferredUnits): boolean =>
+  (unit === RUNNER_DISTANCE_UNIT.miles && units === PreferredUnits.Miles) ||
+  (unit === RUNNER_DISTANCE_UNIT.kilometers && units === PreferredUnits.Kilometers)
+
+/**
+ * The draft's distance expressed in the form's preferred display unit. When the
+ * draft is already stated in that unit the raw value is passed through untouched
+ * — a `unit → metres → unit` round trip would otherwise accrue avoidable
+ * floating-point drift (e.g. a 100 mi draft becoming `99.99999999999999`).
+ */
+const draftDistanceInPreferredUnit = (
+  value: number,
+  unit: RunnerDistanceUnit,
+  units: PreferredUnits,
+): number =>
+  draftUnitIsPreferred(unit, units)
+    ? value
+    : metresToPreferredDistance(draftDistanceMeters(value, unit), units)
 
 /** Blank for a non-positive value so the form's `> 0` range check stays happy. */
 const positiveString = (value: number): string => (value > 0 ? String(value) : '')
 
 /**
- * Maps a parsed workout-log {@link StructuredLogDraft} to the log form's
- * input fields, ready to seed `defaultValues`. The optional metric fields
- * (`rpe`/`hrAvg`/`hrMax`/`elevationGain`) stay blank — the draft carries no
- * metrics.
+ * Maps a parsed workout-log {@link StructuredLogDraft} to the log form's input
+ * fields, ready to seed `defaultValues`. `units` is the form's active display
+ * unit, so a miles-preferring runner's draft pre-fills in miles (and is re-read
+ * as miles on submit) rather than silently becoming kilometres. The optional
+ * metric fields (`rpe`/`hrAvg`/`hrMax`/`elevationGain`) stay blank — the draft
+ * carries no metrics.
  */
-export const draftToWorkoutLogFormFields = (draft: StructuredLogDraft): WorkoutLogFormFields => {
-  const distanceKm = draftDistanceKm(draft.distanceValue, draft.distanceUnit)
+export const draftToWorkoutLogFormFields = (
+  draft: StructuredLogDraft,
+  units: PreferredUnits,
+): WorkoutLogFormFields => {
+  const distance = draftDistanceInPreferredUnit(draft.distanceValue, draft.distanceUnit, units)
   const totalMinutes = draft.durationHours * 60 + draft.durationMinutes + draft.durationSeconds / 60
 
   return {
     ...makeDefaultWorkoutLogFormFields(),
     occurredOn: draft.occurredOn,
     completionStatus: String(draft.completionStatus),
-    distanceKm: positiveString(distanceKm),
+    distance: positiveString(distance),
     durationMinutes: positiveString(totalMinutes),
     notes: draft.notes ?? '',
   }

--- a/frontend/src/app/modules/logging/pages/log.page.spec.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.spec.tsx
@@ -8,7 +8,7 @@ import { Toaster } from '@/components/ui/sonner'
 import type { CreateWorkoutLogRequest, StructuredLogDraft } from '~/api/generated'
 import { PreferredUnits } from '~/api/generated'
 import { METERS_PER_MILE } from '~/modules/common/utils/unit-format.helpers'
-import type { PreferredUnitsResolution } from '~/modules/settings/hooks/use-preferred-units.hooks'
+import type { UsePreferredUnitsResolutionReturn } from '~/modules/settings/hooks/use-preferred-units.hooks'
 import { toIsoDateOnly } from '~/modules/logging/schemas/workout-log-form.schema'
 
 // vi.mock is hoisted above imports, so the mock fns must come from vi.hoisted.
@@ -19,6 +19,7 @@ const {
   navigateMock,
   reportClientErrorMock,
   preferredUnitsResolutionMock,
+  refetchUnitsMock,
 } = vi.hoisted(() => {
   const createWorkoutLogUnwrap = vi.fn()
   return {
@@ -31,8 +32,21 @@ const {
     mutationStateRef: { isLoading: false },
     navigateMock: vi.fn(),
     reportClientErrorMock: vi.fn(),
-    preferredUnitsResolutionMock: vi.fn<() => PreferredUnitsResolution>(),
+    preferredUnitsResolutionMock: vi.fn<() => UsePreferredUnitsResolutionReturn>(),
+    refetchUnitsMock: vi.fn(),
   }
+})
+
+// Builds a units-resolution return, defaulting the settled/error flags so each
+// test overrides only the field it exercises.
+const unitsResolution = (
+  overrides: Partial<UsePreferredUnitsResolutionReturn> = {},
+): UsePreferredUnitsResolutionReturn => ({
+  units: PreferredUnits.Kilometers,
+  isResolved: true,
+  isError: false,
+  refetch: refetchUnitsMock,
+  ...overrides,
 })
 
 vi.mock('~/api/workout-log.api', () => ({
@@ -90,12 +104,10 @@ describe('LogPage', () => {
     mutationStateRef.isLoading = false
     navigateMock.mockReset()
     reportClientErrorMock.mockReset()
+    refetchUnitsMock.mockReset()
     // Default: preference resolved to Kilometers (the common case). Individual
-    // tests override for Miles / still-loading.
-    preferredUnitsResolutionMock.mockReturnValue({
-      units: PreferredUnits.Kilometers,
-      isResolved: true,
-    })
+    // tests override for Miles / still-loading / errored.
+    preferredUnitsResolutionMock.mockReturnValue(unitsResolution())
     vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-0000-0000-00000000abcd')
   })
 
@@ -253,7 +265,7 @@ describe('LogPage', () => {
   })
 
   it('interprets distance as miles and converts to km/SI on write under a Miles preference', async () => {
-    preferredUnitsResolutionMock.mockReturnValue({ units: PreferredUnits.Miles, isResolved: true })
+    preferredUnitsResolutionMock.mockReturnValue(unitsResolution({ units: PreferredUnits.Miles }))
     const { user } = renderPage()
     await user.type(screen.getByLabelText('Distance (mi)'), '5')
     await user.type(screen.getByLabelText('Duration (minutes)'), '30')
@@ -265,7 +277,7 @@ describe('LogPage', () => {
   })
 
   it('pre-fills a miles-stated Edit draft in miles under a Miles preference (no km round trip)', async () => {
-    preferredUnitsResolutionMock.mockReturnValue({ units: PreferredUnits.Miles, isResolved: true })
+    preferredUnitsResolutionMock.mockReturnValue(unitsResolution({ units: PreferredUnits.Miles }))
     const draft: StructuredLogDraft = {
       occurredOn: '2026-06-20',
       distanceValue: 5,
@@ -289,13 +301,27 @@ describe('LogPage', () => {
   })
 
   it('shows a loading state and no form until the unit preference resolves', () => {
-    preferredUnitsResolutionMock.mockReturnValue({
-      units: PreferredUnits.Kilometers,
-      isResolved: false,
-    })
+    preferredUnitsResolutionMock.mockReturnValue(unitsResolution({ isResolved: false }))
     renderPage()
 
     expect(screen.getByTestId('log-page-loading')).toBeInTheDocument()
     expect(screen.queryByTestId('log-form')).toBeNull()
+  })
+
+  it('gates the form behind a retry when the unit-preference query errors', async () => {
+    // An errored settings GET must NOT fall through to the km default and render
+    // the form — a Miles runner would otherwise submit at km magnitude. The page
+    // surfaces a retry that re-runs the preference query instead.
+    preferredUnitsResolutionMock.mockReturnValue(
+      unitsResolution({ isResolved: false, isError: true }),
+    )
+    const { user } = renderPage()
+
+    expect(screen.getByTestId('log-page-units-error')).toBeInTheDocument()
+    expect(screen.queryByTestId('log-form')).toBeNull()
+    expect(screen.queryByTestId('log-page-loading')).toBeNull()
+
+    await user.click(screen.getByRole('button', { name: /retry/i }))
+    expect(refetchUnitsMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/app/modules/logging/pages/log.page.spec.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.spec.tsx
@@ -6,6 +6,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { Toaster } from '@/components/ui/sonner'
 import type { CreateWorkoutLogRequest, StructuredLogDraft } from '~/api/generated'
+import { PreferredUnits } from '~/api/generated'
+import { METERS_PER_MILE } from '~/modules/common/utils/unit-format.helpers'
+import type { PreferredUnitsResolution } from '~/modules/settings/hooks/use-preferred-units.hooks'
 import { toIsoDateOnly } from '~/modules/logging/schemas/workout-log-form.schema'
 
 // vi.mock is hoisted above imports, so the mock fns must come from vi.hoisted.
@@ -15,6 +18,7 @@ const {
   mutationStateRef,
   navigateMock,
   reportClientErrorMock,
+  preferredUnitsResolutionMock,
 } = vi.hoisted(() => {
   const createWorkoutLogUnwrap = vi.fn()
   return {
@@ -27,6 +31,7 @@ const {
     mutationStateRef: { isLoading: false },
     navigateMock: vi.fn(),
     reportClientErrorMock: vi.fn(),
+    preferredUnitsResolutionMock: vi.fn<() => PreferredUnitsResolution>(),
   }
 })
 
@@ -36,6 +41,13 @@ vi.mock('~/api/workout-log.api', () => ({
 
 vi.mock('~/error-boundary/report-client-error', () => ({
   reportClientError: reportClientErrorMock,
+}))
+
+// The page reads the unit preference via this hook (it wraps a real RTK Query
+// hook); the page renders here without a Redux store, so stub it through a
+// mockable ref — mirroring history.page.spec / coach-chat.component.spec.
+vi.mock('~/modules/settings/hooks/use-preferred-units.hooks', () => ({
+  usePreferredUnitsResolution: () => preferredUnitsResolutionMock(),
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -78,6 +90,12 @@ describe('LogPage', () => {
     mutationStateRef.isLoading = false
     navigateMock.mockReset()
     reportClientErrorMock.mockReset()
+    // Default: preference resolved to Kilometers (the common case). Individual
+    // tests override for Miles / still-loading.
+    preferredUnitsResolutionMock.mockReturnValue({
+      units: PreferredUnits.Kilometers,
+      isResolved: true,
+    })
     vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-0000-0000-00000000abcd')
   })
 
@@ -232,5 +250,52 @@ describe('LogPage', () => {
     expect((screen.getByLabelText('Date') as HTMLInputElement).value).toBe('2026-06-20')
     // A pre-filled Edit form is valid without the user touching a field.
     await waitFor(() => expect(screen.getByTestId('log-form-submit')).toBeEnabled())
+  })
+
+  it('interprets distance as miles and converts to km/SI on write under a Miles preference', async () => {
+    preferredUnitsResolutionMock.mockReturnValue({ units: PreferredUnits.Miles, isResolved: true })
+    const { user } = renderPage()
+    await user.type(screen.getByLabelText('Distance (mi)'), '5')
+    await user.type(screen.getByLabelText('Duration (minutes)'), '30')
+    await clickSave(user)
+
+    await waitFor(() => expect(createWorkoutLogTrigger).toHaveBeenCalledTimes(1))
+    // 5 mi -> 5 * 1609.344 m; the wire stays canonical km/SI metres.
+    expect(createWorkoutLogTrigger.mock.calls[0][0].distanceMeters).toBe(5 * METERS_PER_MILE)
+  })
+
+  it('pre-fills a miles-stated Edit draft in miles under a Miles preference (no km round trip)', async () => {
+    preferredUnitsResolutionMock.mockReturnValue({ units: PreferredUnits.Miles, isResolved: true })
+    const draft: StructuredLogDraft = {
+      occurredOn: '2026-06-20',
+      distanceValue: 5,
+      distanceUnit: 1, // miles
+      durationHours: 0,
+      durationMinutes: 25,
+      durationSeconds: 0,
+      completionStatus: 0,
+      notes: 'felt good',
+    }
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/log', state: { draft } }]}>
+        <LogPage />
+        <Toaster />
+      </MemoryRouter>,
+    )
+
+    // The 5 mi draft pre-fills the miles field as "5" (identity, not converted).
+    expect((screen.getByLabelText('Distance (mi)') as HTMLInputElement).value).toBe('5')
+    await waitFor(() => expect(screen.getByTestId('log-form-submit')).toBeEnabled())
+  })
+
+  it('shows a loading state and no form until the unit preference resolves', () => {
+    preferredUnitsResolutionMock.mockReturnValue({
+      units: PreferredUnits.Kilometers,
+      isResolved: false,
+    })
+    renderPage()
+
+    expect(screen.getByTestId('log-page-loading')).toBeInTheDocument()
+    expect(screen.queryByTestId('log-form')).toBeNull()
   })
 })

--- a/frontend/src/app/modules/logging/pages/log.page.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { toast } from 'sonner'
 
+import { Button } from '@/components/ui/button'
 import { PreferredUnits, type StructuredLogDraft } from '~/api/generated'
 import { useCreateWorkoutLogMutation } from '~/api/workout-log.api'
 import { reportClientError } from '~/error-boundary/report-client-error'
@@ -107,18 +108,85 @@ const WorkoutLogFormView = ({ units, editDraft }: WorkoutLogFormViewProps) => {
   )
 }
 
+interface UnitPreferenceUnavailableProps {
+  onRetry: () => void
+}
+
+/**
+ * Shown when the unit-preference query errors. The form stays gated rather than
+ * falling back to km, because `GET /settings/units` and the log `POST` are
+ * independent endpoints — silently defaulting to km could persist a miles
+ * runner's distance at ~1.6× the wrong magnitude (DEC-086). Retry re-runs the
+ * preference query.
+ */
+const UnitPreferenceUnavailable = ({ onRetry }: UnitPreferenceUnavailableProps) => (
+  <div
+    role="alert"
+    data-testid="log-page-units-error"
+    className="flex flex-col items-center gap-3 py-8 text-center"
+  >
+    <p className="text-sm text-muted-foreground">
+      We couldn’t load your distance-unit preference. Check your connection and try again.
+    </p>
+    <Button type="button" size="sm" onClick={onRetry}>
+      Retry
+    </Button>
+  </div>
+)
+
+interface LogPageContentProps {
+  units: PreferredUnits
+  isResolved: boolean
+  isError: boolean
+  refetch: () => void
+  editDraft: StructuredLogDraft | null
+  /** `location.key` — remounts the form on each fresh /log navigation (see below). */
+  formKey: string
+}
+
+/**
+ * Selects what renders below the `/log` header based on the preference query
+ * state: a retry on error, a loading placeholder until settled, otherwise the
+ * form. Split out of {@link LogPage} so the three states read as early returns
+ * rather than a nested ternary.
+ */
+const LogPageContent = ({
+  units,
+  isResolved,
+  isError,
+  refetch,
+  editDraft,
+  formKey,
+}: LogPageContentProps) => {
+  if (isError) {
+    return <UnitPreferenceUnavailable onRetry={refetch} />
+  }
+  if (!isResolved) {
+    return (
+      <p role="status" className="text-sm text-muted-foreground" data-testid="log-page-loading">
+        Loading…
+      </p>
+    )
+  }
+  // Key on `location.key` so re-navigating to /log with a different draft remounts
+  // the form: `useForm` only seeds `defaultValues` on mount, so a new editDraft
+  // would otherwise leave the previous draft's fields in place.
+  return <WorkoutLogFormView key={formKey} units={units} editDraft={editDraft} />
+}
+
 /**
  * The `/log` route — a mobile-first workout-logging form. The form's numeric
  * write interprets the entered distance in the runner's unit preference, so it
  * defers the form until that preference has resolved (usually instant — the
  * preference is cached app-wide; only a cold `/log` refresh shows the brief
  * loading state). This keeps a miles-preferring runner's input from ever being
- * converted against the loading-time km fallback (DEC-086).
+ * converted against the loading-time km fallback (DEC-086); an errored read
+ * surfaces a retry rather than falling through to km.
  */
 const LogPage = () => {
   const location = useLocation()
   const editDraft = (location.state as LogPageLocationState | null)?.draft ?? null
-  const { units, isResolved } = usePreferredUnitsResolution()
+  const { units, isResolved, isError, refetch } = usePreferredUnitsResolution()
 
   return (
     <main
@@ -129,13 +197,14 @@ const LogPage = () => {
         <h1 className="text-2xl font-semibold text-foreground">Log a workout</h1>
         <p className="text-sm text-muted-foreground">Record what you actually ran.</p>
       </header>
-      {isResolved ? (
-        <WorkoutLogFormView units={units} editDraft={editDraft} />
-      ) : (
-        <p role="status" className="text-sm text-muted-foreground" data-testid="log-page-loading">
-          Loading…
-        </p>
-      )}
+      <LogPageContent
+        units={units}
+        isResolved={isResolved}
+        isError={isError}
+        refetch={refetch}
+        editDraft={editDraft}
+        formKey={location.key}
+      />
     </main>
   )
 }

--- a/frontend/src/app/modules/logging/pages/log.page.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.tsx
@@ -4,56 +4,62 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { toast } from 'sonner'
 
-import type { StructuredLogDraft } from '~/api/generated'
+import { PreferredUnits, type StructuredLogDraft } from '~/api/generated'
 import { useCreateWorkoutLogMutation } from '~/api/workout-log.api'
 import { reportClientError } from '~/error-boundary/report-client-error'
+import { distanceUnitLabel } from '~/modules/common/utils/unit-format.helpers'
 import { LogForm } from '~/modules/logging/components/log-form.component'
 import { draftToWorkoutLogFormFields } from '~/modules/logging/draft-to-form.helpers'
 import {
   makeDefaultWorkoutLogFormFields,
+  makeWorkoutLogFormSchema,
   toCreateWorkoutLogRequest,
-  workoutLogFormSchema,
   type WorkoutLogFormFields,
   type WorkoutLogFormValues,
 } from '~/modules/logging/schemas/workout-log-form.schema'
+import { usePreferredUnitsResolution } from '~/modules/settings/hooks/use-preferred-units.hooks'
 
 /** Router state carried by the conversational-logging "Edit" affordance. */
 interface LogPageLocationState {
   draft?: StructuredLogDraft
 }
 
+interface WorkoutLogFormViewProps {
+  /** The runner's resolved display unit — the entered distance is read in this unit. */
+  units: PreferredUnits
+  editDraft: StructuredLogDraft | null
+}
+
 /**
- * The `/log` route — a mobile-first workout-logging form. Owns the form state,
- * the create mutation, and post-submit navigation. Create is pessimistic
- * (DEC-075): await success → success toast → navigate home; the mutation
- * invalidates the `WorkoutLog` tag so history (PR7) refetches. `OccurredOn`
- * defaults to today; the prescription snapshot is resolved server-side, so the
+ * The form itself, mounted only once the unit preference has resolved (see
+ * {@link LogPage}). Because `units` is known and stable before this mounts, the
+ * schema, the distance label, the draft pre-fill, and the miles→km write
+ * conversion are all computed once against the correct unit — no mid-form schema
+ * swap and no reset dance. Owns the form state, the create mutation, and
+ * post-submit navigation. Create is pessimistic (DEC-075): await success →
+ * success toast → navigate home; the mutation invalidates the `WorkoutLog` tag so
+ * history refetches. The prescription snapshot is resolved server-side, so the
  * form never sends prescribed values (DEC-076).
  */
-const LogPage = () => {
+const WorkoutLogFormView = ({ units, editDraft }: WorkoutLogFormViewProps) => {
   const navigate = useNavigate()
-  const location = useLocation()
   const [createWorkoutLog, { isLoading }] = useCreateWorkoutLogMutation()
   const [formAlert, setFormAlert] = useState<string | null>(null)
   // One key per mounted form so a retry after a transient failure reuses it and
   // the server dedupes rather than double-logging (DEC-077).
   const idempotencyKey = useMemo(() => crypto.randomUUID(), [])
 
-  // The conversational-logging "Edit" affordance navigates here with the parsed
-  // draft in router state — pre-fill the form from it. An edited submit still
-  // goes through the normal create path with its own idempotency key, not the
-  // confirm endpoint.
-  const editDraft = (location.state as LogPageLocationState | null)?.draft ?? null
+  const schema = useMemo(() => makeWorkoutLogFormSchema(units), [units])
   const defaultValues = useMemo(
     () =>
       editDraft !== null
-        ? draftToWorkoutLogFormFields(editDraft)
+        ? draftToWorkoutLogFormFields(editDraft, units)
         : makeDefaultWorkoutLogFormFields(),
-    [editDraft],
+    [editDraft, units],
   )
 
   const form = useForm<WorkoutLogFormFields, unknown, WorkoutLogFormValues>({
-    resolver: zodResolver(workoutLogFormSchema),
+    resolver: zodResolver(schema),
     mode: 'onChange',
     shouldUnregister: false,
     defaultValues,
@@ -73,7 +79,7 @@ const LogPage = () => {
   const onSubmit = async (values: WorkoutLogFormValues): Promise<void> => {
     setFormAlert(null)
     try {
-      await createWorkoutLog(toCreateWorkoutLogRequest(values, idempotencyKey)).unwrap()
+      await createWorkoutLog(toCreateWorkoutLogRequest(values, idempotencyKey, units)).unwrap()
       toast.success('Workout logged')
       navigate('/', { replace: true })
     } catch (error) {
@@ -91,6 +97,30 @@ const LogPage = () => {
   }
 
   return (
+    <LogForm
+      form={form}
+      onSubmit={onSubmit}
+      isLoading={isLoading}
+      formAlert={formAlert}
+      distanceLabel={`Distance (${distanceUnitLabel(units)})`}
+    />
+  )
+}
+
+/**
+ * The `/log` route — a mobile-first workout-logging form. The form's numeric
+ * write interprets the entered distance in the runner's unit preference, so it
+ * defers the form until that preference has resolved (usually instant — the
+ * preference is cached app-wide; only a cold `/log` refresh shows the brief
+ * loading state). This keeps a miles-preferring runner's input from ever being
+ * converted against the loading-time km fallback (DEC-086).
+ */
+const LogPage = () => {
+  const location = useLocation()
+  const editDraft = (location.state as LogPageLocationState | null)?.draft ?? null
+  const { units, isResolved } = usePreferredUnitsResolution()
+
+  return (
     <main
       className="mx-auto flex min-h-screen w-full max-w-md flex-col gap-6 bg-background px-4 py-8"
       data-testid="log-page"
@@ -99,7 +129,13 @@ const LogPage = () => {
         <h1 className="text-2xl font-semibold text-foreground">Log a workout</h1>
         <p className="text-sm text-muted-foreground">Record what you actually ran.</p>
       </header>
-      <LogForm form={form} onSubmit={onSubmit} isLoading={isLoading} formAlert={formAlert} />
+      {isResolved ? (
+        <WorkoutLogFormView units={units} editDraft={editDraft} />
+      ) : (
+        <p role="status" className="text-sm text-muted-foreground" data-testid="log-page-loading">
+          Loading…
+        </p>
+      )}
     </main>
   )
 }

--- a/frontend/src/app/modules/logging/schemas/workout-log-form.schema.spec.ts
+++ b/frontend/src/app/modules/logging/schemas/workout-log-form.schema.spec.ts
@@ -1,12 +1,22 @@
 import { describe, expect, it } from 'vitest'
 
+import { PreferredUnits } from '~/api/generated'
+import { METERS_PER_MILE } from '~/modules/common/utils/unit-format.helpers'
+
 import {
   makeDefaultWorkoutLogFormFields,
+  makeWorkoutLogFormSchema,
   toCreateWorkoutLogRequest,
   toIsoDateOnly,
-  workoutLogFormSchema,
   type WorkoutLogFormFields,
 } from './workout-log-form.schema'
+
+const KM = PreferredUnits.Kilometers
+const MI = PreferredUnits.Miles
+
+// The field shape is unit-independent, so the km-pinned instance drives the
+// shape/validation suites; a dedicated block below exercises the Miles instance.
+const kmSchema = makeWorkoutLogFormSchema(KM)
 
 // Local-time Date so toIsoDateOnly is timezone-stable on CI.
 const FIXED_DATE = new Date(2026, 5, 6)
@@ -27,7 +37,7 @@ describe('makeDefaultWorkoutLogFormFields', () => {
     expect(makeDefaultWorkoutLogFormFields(FIXED_DATE)).toEqual({
       occurredOn: '2026-06-06',
       completionStatus: '0',
-      distanceKm: '',
+      distance: '',
       durationMinutes: '',
       notes: '',
       rpe: '',
@@ -38,18 +48,16 @@ describe('makeDefaultWorkoutLogFormFields', () => {
   })
 })
 
-describe('workoutLogFormSchema', () => {
+describe('makeWorkoutLogFormSchema', () => {
   it('accepts a minimum payload (distance + duration only) with optional metrics undefined', () => {
-    const result = workoutLogFormSchema.safeParse(
-      fields({ distanceKm: '5', durationMinutes: '30' }),
-    )
+    const result = kmSchema.safeParse(fields({ distance: '5', durationMinutes: '30' }))
 
     expect(result.success).toBe(true)
     if (!result.success) return
     expect(result.data).toMatchObject({
       occurredOn: '2026-06-06',
       completionStatus: 0,
-      distanceKm: 5,
+      distance: 5,
       durationMinutes: 30,
     })
     expect(result.data.rpe).toBeUndefined()
@@ -58,73 +66,95 @@ describe('workoutLogFormSchema', () => {
   })
 
   it('resolves a blank optional numeric to undefined, never 0 or NaN', () => {
-    const parsed = workoutLogFormSchema.parse(
-      fields({ distanceKm: '5', durationMinutes: '30', rpe: '   ' }),
-    )
+    const parsed = kmSchema.parse(fields({ distance: '5', durationMinutes: '30', rpe: '   ' }))
     expect(parsed.rpe).toBeUndefined()
   })
 
   it('keeps an explicit 0 (elevation gain) as 0 rather than dropping it', () => {
-    const parsed = workoutLogFormSchema.parse(
-      fields({ distanceKm: '5', durationMinutes: '30', elevationGain: '0' }),
+    const parsed = kmSchema.parse(
+      fields({ distance: '5', durationMinutes: '30', elevationGain: '0' }),
     )
     expect(parsed.elevationGain).toBe(0)
   })
 
   it('coerces the completion status string to its numeric enum value', () => {
-    const parsed = workoutLogFormSchema.parse(
-      fields({ completionStatus: '1', distanceKm: '5', durationMinutes: '30' }),
+    const parsed = kmSchema.parse(
+      fields({ completionStatus: '1', distance: '5', durationMinutes: '30' }),
     )
     expect(parsed.completionStatus).toBe(1)
   })
 
   it('requires distance when the workout is not Skipped', () => {
-    const result = workoutLogFormSchema.safeParse(fields({ distanceKm: '', durationMinutes: '30' }))
+    const result = kmSchema.safeParse(fields({ distance: '', durationMinutes: '30' }))
 
     expect(result.success).toBe(false)
     if (result.success) return
-    expect(result.error.issues.some((issue) => issue.path[0] === 'distanceKm')).toBe(true)
+    expect(result.error.issues.some((issue) => issue.path[0] === 'distance')).toBe(true)
   })
 
   it('rejects a zero distance for a completed run (must be greater than zero)', () => {
-    const result = workoutLogFormSchema.safeParse(
-      fields({ distanceKm: '0', durationMinutes: '30' }),
-    )
+    const result = kmSchema.safeParse(fields({ distance: '0', durationMinutes: '30' }))
     expect(result.success).toBe(false)
   })
 
   it('rejects a non-numeric distance', () => {
-    const result = workoutLogFormSchema.safeParse(
-      fields({ distanceKm: 'abc', durationMinutes: '30' }),
-    )
+    const result = kmSchema.safeParse(fields({ distance: 'abc', durationMinutes: '30' }))
     expect(result.success).toBe(false)
   })
 
   it('rejects an RPE outside 1–10', () => {
-    const result = workoutLogFormSchema.safeParse(
-      fields({ distanceKm: '5', durationMinutes: '30', rpe: '11' }),
-    )
+    const result = kmSchema.safeParse(fields({ distance: '5', durationMinutes: '30', rpe: '11' }))
     expect(result.success).toBe(false)
   })
 
   it('allows a Skipped workout to omit distance and duration', () => {
-    const result = workoutLogFormSchema.safeParse(
-      fields({ completionStatus: '2', distanceKm: '', durationMinutes: '' }),
+    const result = kmSchema.safeParse(
+      fields({ completionStatus: '2', distance: '', durationMinutes: '' }),
     )
 
     expect(result.success).toBe(true)
     if (!result.success) return
     expect(result.data.completionStatus).toBe(2)
-    expect(result.data.distanceKm).toBeUndefined()
+    expect(result.data.distance).toBeUndefined()
     expect(result.data.durationMinutes).toBeUndefined()
+  })
+})
+
+describe('makeWorkoutLogFormSchema — Miles instance', () => {
+  const milesSchema = makeWorkoutLogFormSchema(MI)
+
+  it('phrases the required-distance message in miles', () => {
+    const result = milesSchema.safeParse(fields({ distance: '', durationMinutes: '30' }))
+
+    expect(result.success).toBe(false)
+    if (result.success) return
+    const distanceIssue = result.error.issues.find((issue) => issue.path[0] === 'distance')
+    expect(distanceIssue?.message).toBe('Enter a distance in mi.')
+  })
+
+  it('caps the miles distance at the ceil-rounded mile-equivalent of the 1000 km guard (622 mi)', () => {
+    // Math.ceil(1_000_000 / 1609.344) = 622, so the mile guard is only ever looser
+    // than the km-native ceiling, never stricter: 622 mi accepted, 623 mi rejected.
+    expect(milesSchema.safeParse(fields({ distance: '622', durationMinutes: '30' })).success).toBe(
+      true,
+    )
+    expect(milesSchema.safeParse(fields({ distance: '623', durationMinutes: '30' })).success).toBe(
+      false,
+    )
+  })
+
+  it('still accepts a normal miles distance the km cap would also allow', () => {
+    expect(milesSchema.safeParse(fields({ distance: '5', durationMinutes: '30' })).success).toBe(
+      true,
+    )
   })
 })
 
 describe('toCreateWorkoutLogRequest', () => {
   it('maps km→meters, minutes→seconds, trims notes, and builds the metrics bag from present values', () => {
-    const parsed = workoutLogFormSchema.parse(
+    const parsed = kmSchema.parse(
       fields({
-        distanceKm: '5',
+        distance: '5',
         durationMinutes: '30',
         notes: '  felt strong  ',
         rpe: '6',
@@ -132,7 +162,7 @@ describe('toCreateWorkoutLogRequest', () => {
       }),
     )
 
-    expect(toCreateWorkoutLogRequest(parsed, 'idem-1')).toEqual({
+    expect(toCreateWorkoutLogRequest(parsed, 'idem-1', KM)).toEqual({
       idempotencyKey: 'idem-1',
       occurredOn: '2026-06-06',
       distanceMeters: 5000,
@@ -143,9 +173,22 @@ describe('toCreateWorkoutLogRequest', () => {
     })
   })
 
+  it('interprets the entered distance as miles and converts to km/SI metres under a Miles preference', () => {
+    // The T06.2 proof: a miles-entered distance round-trips to the correct
+    // canonical `distanceMeters` (5 mi * 1609.344 = 8046.72 m). The wire stays
+    // km/SI; only the interpretation of the runner's input differs.
+    const milesSchema = makeWorkoutLogFormSchema(MI)
+    const parsed = milesSchema.parse(fields({ distance: '5', durationMinutes: '30' }))
+
+    const body = toCreateWorkoutLogRequest(parsed, 'idem-1', MI)
+    expect(body.distanceMeters).toBe(5 * METERS_PER_MILE)
+    // Duration is unit-agnostic; only distance is reinterpreted.
+    expect(body.durationSeconds).toBe(1800)
+  })
+
   it('omits notes and metrics entirely when none are provided', () => {
-    const parsed = workoutLogFormSchema.parse(fields({ distanceKm: '5', durationMinutes: '30' }))
-    const body = toCreateWorkoutLogRequest(parsed, 'idem-1')
+    const parsed = kmSchema.parse(fields({ distance: '5', durationMinutes: '30' }))
+    const body = toCreateWorkoutLogRequest(parsed, 'idem-1', KM)
 
     expect(body.notes).toBeUndefined()
     expect(body.metrics).toBeUndefined()
@@ -159,10 +202,10 @@ describe('toCreateWorkoutLogRequest', () => {
   })
 
   it('sends zero distance/duration for a Skipped workout with blank fields', () => {
-    const parsed = workoutLogFormSchema.parse(
-      fields({ completionStatus: '2', distanceKm: '', durationMinutes: '' }),
+    const parsed = kmSchema.parse(
+      fields({ completionStatus: '2', distance: '', durationMinutes: '' }),
     )
-    const body = toCreateWorkoutLogRequest(parsed, 'idem-1')
+    const body = toCreateWorkoutLogRequest(parsed, 'idem-1', KM)
 
     expect(body.distanceMeters).toBe(0)
     expect(body.durationSeconds).toBe(0)
@@ -173,10 +216,10 @@ describe('toCreateWorkoutLogRequest', () => {
     // The distance/duration inputs stay rendered when Skipped is selected, so a
     // typed value remains visible to the user; the mapper ships what they see
     // rather than silently zeroing it. Pins the deliberate pass-through semantics.
-    const parsed = workoutLogFormSchema.parse(
-      fields({ completionStatus: '2', distanceKm: '5', durationMinutes: '30' }),
+    const parsed = kmSchema.parse(
+      fields({ completionStatus: '2', distance: '5', durationMinutes: '30' }),
     )
-    const body = toCreateWorkoutLogRequest(parsed, 'idem-1')
+    const body = toCreateWorkoutLogRequest(parsed, 'idem-1', KM)
 
     expect(body.distanceMeters).toBe(5000)
     expect(body.durationSeconds).toBe(1800)

--- a/frontend/src/app/modules/logging/schemas/workout-log-form.schema.ts
+++ b/frontend/src/app/modules/logging/schemas/workout-log-form.schema.ts
@@ -6,7 +6,13 @@ import {
   completionStatusSchema,
   createWorkoutLogRequestSchema,
   type CreateWorkoutLogRequest,
+  PreferredUnits,
 } from '~/api/generated'
+import {
+  distanceUnitLabel,
+  metresToPreferredDistance,
+  preferredDistanceToMeters,
+} from '~/modules/common/utils/unit-format.helpers'
 import { FORM_METRIC_KEYS } from '~/modules/logging/metric-meta'
 
 // DEC-075 form conventions. The `/log` form holds every field as a STRING (the
@@ -60,58 +66,88 @@ const numericField = (options: NumericFieldOptions) =>
       return value === '' ? undefined : Number(value)
     })
 
-// The form schema is DERIVED from the generated request body via `.pick().extend()`
-// (DEC-075, the first such derivation in the repo). Picking `occurredOn` keeps
-// its ISO-date format honest against the backend; `completionStatus` is rebuilt
-// off the generated `0|1|2` union (via `completionStatusSchema`) so the enum
-// can't drift. The remaining fields are UI-shaped (km / minutes rather than the
-// wire's meters / seconds, plus the self-reportable optional metrics) and are
-// mapped down to the wire contract by `toCreateWorkoutLogRequest`.
-export const workoutLogFormSchema = createWorkoutLogRequestSchema
-  .pick({ occurredOn: true })
-  .extend({
-    completionStatus: z
-      .string()
-      .transform((raw) => Number(raw))
-      .pipe(completionStatusSchema),
-    distanceKm: numericField({ min: 0, minExclusive: true, max: 1000, label: 'distance in km' }),
-    durationMinutes: numericField({
-      min: 0,
-      minExclusive: true,
-      max: 1440,
-      label: 'duration in minutes',
-    }),
-    notes: z.string().transform((raw) => {
-      const value = raw.trim()
-      return value.length === 0 ? undefined : value
-    }),
-    rpe: numericField({ min: 1, max: 10, label: 'RPE' }),
-    hrAvg: numericField({ min: 1, max: 300, label: 'average heart rate' }),
-    hrMax: numericField({ min: 1, max: 300, label: 'maximum heart rate' }),
-    elevationGain: numericField({ min: 0, max: 100000, label: 'elevation gain' }),
-  })
-  .superRefine((values, ctx) => {
-    // Distance + duration are required for a Complete/Partial run but optional
-    // for a Skipped one (it resolves to 0 m / 0 s on the wire). Spec § Unit 6
-    // open-question resolution.
-    if (values.completionStatus === CompletionStatus.Skipped) return
-    if (values.distanceKm === undefined) {
-      ctx.addIssue({ code: 'custom', path: ['distanceKm'], message: 'Enter a distance in km.' })
-    }
-    if (values.durationMinutes === undefined) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['durationMinutes'],
-        message: 'Enter a duration in minutes.',
-      })
-    }
-  })
+/**
+ * The km-native distance ceiling, in canonical metres (1000 km). The `distance`
+ * field's `max` is this ceiling expressed in the runner's active display unit —
+ * a client-only fat-finger sanity guard (the backend enforces no upper bound).
+ * Rounded UP (`Math.ceil`) so the mile-mode cap (622 mi ≈ 1001 km) never rejects
+ * an entry the km-native ceiling would accept; the guard is only ever looser, not
+ * stricter, than the canonical limit.
+ */
+const MAX_DISTANCE_METERS = 1_000_000
+
+/**
+ * Builds the workout-log form schema for a given display unit (slice 4C-units).
+ * The schema is DERIVED from the generated request body via `.pick().extend()`
+ * (DEC-075, the first such derivation in the repo). Picking `occurredOn` keeps
+ * its ISO-date format honest against the backend; `completionStatus` is rebuilt
+ * off the generated `0|1|2` union (via `completionStatusSchema`) so the enum
+ * can't drift. The remaining fields are UI-shaped (the entered `distance` is in
+ * the runner's preferred unit — km OR miles — and duration is minutes rather than
+ * the wire's meters / seconds) and are mapped down to the wire contract by
+ * `toCreateWorkoutLogRequest`, which converts `distance` → canonical metres for
+ * the active unit. `units` parameterises only the distance field's label and
+ * `max`; the field *shape* is unit-independent, so the exported form types are
+ * derived from one canonical instance.
+ */
+export const makeWorkoutLogFormSchema = (units: PreferredUnits) => {
+  const distanceLabel = `distance in ${distanceUnitLabel(units)}`
+  const distanceMax = Math.ceil(metresToPreferredDistance(MAX_DISTANCE_METERS, units))
+
+  return createWorkoutLogRequestSchema
+    .pick({ occurredOn: true })
+    .extend({
+      completionStatus: z
+        .string()
+        .transform((raw) => Number(raw))
+        .pipe(completionStatusSchema),
+      distance: numericField({
+        min: 0,
+        minExclusive: true,
+        max: distanceMax,
+        label: distanceLabel,
+      }),
+      durationMinutes: numericField({
+        min: 0,
+        minExclusive: true,
+        max: 1440,
+        label: 'duration in minutes',
+      }),
+      notes: z.string().transform((raw) => {
+        const value = raw.trim()
+        return value.length === 0 ? undefined : value
+      }),
+      rpe: numericField({ min: 1, max: 10, label: 'RPE' }),
+      hrAvg: numericField({ min: 1, max: 300, label: 'average heart rate' }),
+      hrMax: numericField({ min: 1, max: 300, label: 'maximum heart rate' }),
+      elevationGain: numericField({ min: 0, max: 100000, label: 'elevation gain' }),
+    })
+    .superRefine((values, ctx) => {
+      // Distance + duration are required for a Complete/Partial run but optional
+      // for a Skipped one (it resolves to 0 m / 0 s on the wire). Spec § Unit 6
+      // open-question resolution.
+      if (values.completionStatus === CompletionStatus.Skipped) return
+      if (values.distance === undefined) {
+        ctx.addIssue({ code: 'custom', path: ['distance'], message: `Enter a ${distanceLabel}.` })
+      }
+      if (values.durationMinutes === undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['durationMinutes'],
+          message: 'Enter a duration in minutes.',
+        })
+      }
+    })
+}
+
+/** The distance-field shape is unit-independent, so the form types derive from one instance. */
+type WorkoutLogFormSchema = ReturnType<typeof makeWorkoutLogFormSchema>
 
 /** Form state shape (every field a string — the raw `<input>` value). */
-export type WorkoutLogFormFields = z.input<typeof workoutLogFormSchema>
+export type WorkoutLogFormFields = z.input<WorkoutLogFormSchema>
 
 /** Validated, typed output handed to the submit handler. */
-export type WorkoutLogFormValues = z.output<typeof workoutLogFormSchema>
+export type WorkoutLogFormValues = z.output<WorkoutLogFormSchema>
 
 /**
  * The form's `control` type. Spelled out with all three RHF generics because
@@ -135,7 +171,7 @@ export const makeDefaultWorkoutLogFormFields = (
 ): WorkoutLogFormFields => ({
   occurredOn: toIsoDateOnly(today),
   completionStatus: String(CompletionStatus.Complete),
-  distanceKm: '',
+  distance: '',
   durationMinutes: '',
   notes: '',
   rpe: '',
@@ -145,10 +181,17 @@ export const makeDefaultWorkoutLogFormFields = (
 })
 
 /**
- * Maps validated form values down to the wire contract: km → meters, minutes →
- * seconds, present optional metrics into the open `metrics` bag (absent ones
- * omitted entirely — never sent as `0`). The `idempotencyKey` is supplied by the
- * caller so it stays stable across retries of the same logical submit (DEC-077).
+ * Maps validated form values down to the wire contract: `distance` (in the
+ * runner's preferred unit) → canonical metres, minutes → seconds, present
+ * optional metrics into the open `metrics` bag (absent ones omitted entirely —
+ * never sent as `0`). The `idempotencyKey` is supplied by the caller so it stays
+ * stable across retries of the same logical submit (DEC-077).
+ *
+ * `units` is REQUIRED (not defaulted): it is the interpretation of the runner's
+ * typed `distance`, not incidental metadata — under Miles the entered value is
+ * miles and is converted `× 1609.344` to metres, under Kilometers `× 1000`
+ * (byte-identical to the prior km-only mapping). Storage and the wire stay
+ * canonical km/SI; the LLM performs zero conversion (DEC-086).
  *
  * Distance/duration are pass-through, not status-gated: a Skipped workout that
  * still carries a typed distance/duration sends those values unchanged. The
@@ -159,6 +202,7 @@ export const makeDefaultWorkoutLogFormFields = (
 export const toCreateWorkoutLogRequest = (
   values: WorkoutLogFormValues,
   idempotencyKey: string,
+  units: PreferredUnits,
 ): CreateWorkoutLogRequest => {
   const metrics: Record<string, number> = {}
   for (const key of FORM_METRIC_KEYS) {
@@ -171,7 +215,7 @@ export const toCreateWorkoutLogRequest = (
   return {
     idempotencyKey,
     occurredOn: values.occurredOn,
-    distanceMeters: (values.distanceKm ?? 0) * 1000,
+    distanceMeters: preferredDistanceToMeters(values.distance ?? 0, units),
     durationSeconds: (values.durationMinutes ?? 0) * 60,
     completionStatus: values.completionStatus,
     ...(values.notes !== undefined ? { notes: values.notes } : {}),

--- a/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.spec.ts
+++ b/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.spec.ts
@@ -6,22 +6,23 @@ interface UnitPreference {
   preferredUnits: PreferredUnits
 }
 
-// The hook only reads `data` off the query result, so a plain hoisted ref
-// standing in for `useGetUnitPreferenceQuery` keeps the test free of a Redux
+// The hooks read `data` + `isLoading` off the query result, so a plain hoisted
+// ref standing in for `useGetUnitPreferenceQuery` keeps the test free of a Redux
 // store while exercising the real fallback/selection logic.
 const { getQueryRef } = vi.hoisted(() => ({
-  getQueryRef: { data: undefined as UnitPreference | undefined },
+  getQueryRef: { data: undefined as UnitPreference | undefined, isLoading: false },
 }))
 
 vi.mock('~/api/settings.api', () => ({
   useGetUnitPreferenceQuery: () => getQueryRef,
 }))
 
-import { usePreferredUnits } from './use-preferred-units.hooks'
+import { usePreferredUnits, usePreferredUnitsResolution } from './use-preferred-units.hooks'
 
 describe('usePreferredUnits', () => {
   beforeEach(() => {
     getQueryRef.data = undefined
+    getQueryRef.isLoading = false
   })
 
   it('falls back to Kilometers while the preference is unresolved', () => {
@@ -44,5 +45,33 @@ describe('usePreferredUnits', () => {
     getQueryRef.data = { preferredUnits: PreferredUnits.Kilometers }
     const { result } = renderHook(() => usePreferredUnits())
     expect(result.current).toBe(PreferredUnits.Kilometers)
+  })
+})
+
+describe('usePreferredUnitsResolution', () => {
+  beforeEach(() => {
+    getQueryRef.data = undefined
+    getQueryRef.isLoading = false
+  })
+
+  it('is unresolved (Kilometers) while the preference query is loading', () => {
+    getQueryRef.data = undefined
+    getQueryRef.isLoading = true
+    const { result } = renderHook(() => usePreferredUnitsResolution())
+    expect(result.current).toEqual({ units: PreferredUnits.Kilometers, isResolved: false })
+  })
+
+  it('resolves to the persisted Miles preference once the query settles', () => {
+    getQueryRef.data = { preferredUnits: PreferredUnits.Miles }
+    getQueryRef.isLoading = false
+    const { result } = renderHook(() => usePreferredUnitsResolution())
+    expect(result.current).toEqual({ units: PreferredUnits.Miles, isResolved: true })
+  })
+
+  it('resolves to the Kilometers default once settled with no row (read-or-default 200)', () => {
+    getQueryRef.data = undefined
+    getQueryRef.isLoading = false
+    const { result } = renderHook(() => usePreferredUnitsResolution())
+    expect(result.current).toEqual({ units: PreferredUnits.Kilometers, isResolved: true })
   })
 })

--- a/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.spec.ts
+++ b/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.spec.ts
@@ -6,12 +6,21 @@ interface UnitPreference {
   preferredUnits: PreferredUnits
 }
 
-// The hooks read `data` + `isLoading` off the query result, so a plain hoisted
-// ref standing in for `useGetUnitPreferenceQuery` keeps the test free of a Redux
-// store while exercising the real fallback/selection logic.
-const { getQueryRef } = vi.hoisted(() => ({
-  getQueryRef: { data: undefined as UnitPreference | undefined, isLoading: false },
-}))
+// The hooks read `data` + the settled flags off the query result, so a plain
+// hoisted ref standing in for `useGetUnitPreferenceQuery` keeps the test free of
+// a Redux store while exercising the real fallback/selection logic.
+const { getQueryRef, refetchMock } = vi.hoisted(() => {
+  const refetchMock = vi.fn()
+  return {
+    refetchMock,
+    getQueryRef: {
+      data: undefined as UnitPreference | undefined,
+      isSuccess: false,
+      isError: false,
+      refetch: refetchMock,
+    },
+  }
+})
 
 vi.mock('~/api/settings.api', () => ({
   useGetUnitPreferenceQuery: () => getQueryRef,
@@ -22,7 +31,9 @@ import { usePreferredUnits, usePreferredUnitsResolution } from './use-preferred-
 describe('usePreferredUnits', () => {
   beforeEach(() => {
     getQueryRef.data = undefined
-    getQueryRef.isLoading = false
+    getQueryRef.isSuccess = false
+    getQueryRef.isError = false
+    refetchMock.mockClear()
   })
 
   it('falls back to Kilometers while the preference is unresolved', () => {
@@ -51,27 +62,56 @@ describe('usePreferredUnits', () => {
 describe('usePreferredUnitsResolution', () => {
   beforeEach(() => {
     getQueryRef.data = undefined
-    getQueryRef.isLoading = false
+    getQueryRef.isSuccess = false
+    getQueryRef.isError = false
+    refetchMock.mockClear()
   })
 
   it('is unresolved (Kilometers) while the preference query is loading', () => {
     getQueryRef.data = undefined
-    getQueryRef.isLoading = true
+    getQueryRef.isSuccess = false
+    getQueryRef.isError = false
     const { result } = renderHook(() => usePreferredUnitsResolution())
-    expect(result.current).toEqual({ units: PreferredUnits.Kilometers, isResolved: false })
+    expect(result.current.units).toBe(PreferredUnits.Kilometers)
+    expect(result.current.isResolved).toBe(false)
+    expect(result.current.isError).toBe(false)
   })
 
-  it('resolves to the persisted Miles preference once the query settles', () => {
+  it('resolves to the persisted Miles preference once the query succeeds', () => {
     getQueryRef.data = { preferredUnits: PreferredUnits.Miles }
-    getQueryRef.isLoading = false
+    getQueryRef.isSuccess = true
     const { result } = renderHook(() => usePreferredUnitsResolution())
-    expect(result.current).toEqual({ units: PreferredUnits.Miles, isResolved: true })
+    expect(result.current.units).toBe(PreferredUnits.Miles)
+    expect(result.current.isResolved).toBe(true)
+    expect(result.current.isError).toBe(false)
   })
 
-  it('resolves to the Kilometers default once settled with no row (read-or-default 200)', () => {
+  it('resolves to the Kilometers default once the query succeeds with no row (read-or-default 200)', () => {
     getQueryRef.data = undefined
-    getQueryRef.isLoading = false
+    getQueryRef.isSuccess = true
     const { result } = renderHook(() => usePreferredUnitsResolution())
-    expect(result.current).toEqual({ units: PreferredUnits.Kilometers, isResolved: true })
+    expect(result.current.units).toBe(PreferredUnits.Kilometers)
+    expect(result.current.isResolved).toBe(true)
+    expect(result.current.isError).toBe(false)
+  })
+
+  it('reports isError (never resolved) when the preference query errors, so the write path stays gated', () => {
+    // RTK Query's `isLoading` goes false on error too; gating on `isSuccess`
+    // keeps an errored settings GET from being treated as a resolved km default,
+    // which would silently convert a Miles runner's distance at km magnitude.
+    getQueryRef.data = undefined
+    getQueryRef.isSuccess = false
+    getQueryRef.isError = true
+    const { result } = renderHook(() => usePreferredUnitsResolution())
+    expect(result.current.isResolved).toBe(false)
+    expect(result.current.isError).toBe(true)
+    expect(result.current.units).toBe(PreferredUnits.Kilometers)
+  })
+
+  it('exposes refetch for the error-state retry affordance', () => {
+    getQueryRef.isError = true
+    const { result } = renderHook(() => usePreferredUnitsResolution())
+    result.current.refetch()
+    expect(refetchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.ts
+++ b/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.ts
@@ -10,8 +10,43 @@ import { useGetUnitPreferenceQuery } from '~/api/settings.api'
  * only — storage, the wire, and the plan-gen prompt stay km-native, and the LLM
  * performs zero unit conversion (DEC-086). The single home for the read so
  * plan / history / adaptation render sites resolve the preference the same way.
+ *
+ * NOT for the write path: the km fallback collapses "loading", "errored", and
+ * "genuinely km" into one value, so a miles-preferring runner submitting on a
+ * cold cache would have their input silently interpreted as km. The log form's
+ * numeric write uses {@link usePreferredUnitsResolution} and defers until the
+ * preference is actually resolved.
  */
 export const usePreferredUnits = (): PreferredUnits => {
   const { data } = useGetUnitPreferenceQuery(undefined)
   return data?.preferredUnits ?? PreferredUnits.Kilometers
+}
+
+export interface PreferredUnitsResolution {
+  /** The resolved preference, or the {@link PreferredUnits.Kilometers} default once settled. */
+  units: PreferredUnits
+  /**
+   * `false` until the preference query has settled (success OR error). The write
+   * path must wait for this before interpreting a typed distance, so a miles
+   * runner's input is never converted against the loading-time km fallback.
+   */
+  isResolved: boolean
+}
+
+/**
+ * Reads the unit preference for the **write** path — pairs the resolved unit with
+ * a settled flag so a numeric write (the log form) can hold off until the runner's
+ * unit is actually known, rather than converting against the display fallback.
+ *
+ * `isResolved` flips true on both success and error: once the query has settled,
+ * the {@link PreferredUnits.Kilometers} default is authoritative (the `GET` is
+ * read-or-default 200, so an error means the whole API — including the log `POST`
+ * — is unavailable, and no wrong-unit write can be persisted anyway).
+ */
+export const usePreferredUnitsResolution = (): PreferredUnitsResolution => {
+  const { data, isLoading } = useGetUnitPreferenceQuery(undefined)
+  return {
+    units: data?.preferredUnits ?? PreferredUnits.Kilometers,
+    isResolved: !isLoading,
+  }
 }

--- a/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.ts
+++ b/frontend/src/app/modules/settings/hooks/use-preferred-units.hooks.ts
@@ -22,15 +22,25 @@ export const usePreferredUnits = (): PreferredUnits => {
   return data?.preferredUnits ?? PreferredUnits.Kilometers
 }
 
-export interface PreferredUnitsResolution {
-  /** The resolved preference, or the {@link PreferredUnits.Kilometers} default once settled. */
+export interface UsePreferredUnitsResolutionReturn {
+  /** The resolved preference, or the {@link PreferredUnits.Kilometers} default once settled successfully. */
   units: PreferredUnits
   /**
-   * `false` until the preference query has settled (success OR error). The write
+   * `false` until the preference query has settled **successfully**. The write
    * path must wait for this before interpreting a typed distance, so a miles
    * runner's input is never converted against the loading-time km fallback.
    */
   isResolved: boolean
+  /**
+   * `true` when the preference query settled in error. The write path must not
+   * silently interpret a typed distance against the km fallback in this state:
+   * `GET /settings/units` and the log `POST` are independent endpoints, so an
+   * isolated GET failure can leave a miles runner submitting at km magnitude.
+   * The `/log` page surfaces a retry instead of rendering the form.
+   */
+  isError: boolean
+  /** Re-runs the preference query — wired to the error-state retry affordance. */
+  refetch: () => void
 }
 
 /**
@@ -38,15 +48,18 @@ export interface PreferredUnitsResolution {
  * a settled flag so a numeric write (the log form) can hold off until the runner's
  * unit is actually known, rather than converting against the display fallback.
  *
- * `isResolved` flips true on both success and error: once the query has settled,
- * the {@link PreferredUnits.Kilometers} default is authoritative (the `GET` is
- * read-or-default 200, so an error means the whole API — including the log `POST`
- * — is unavailable, and no wrong-unit write can be persisted anyway).
+ * `isResolved` is `true` only on **success**. An errored read is reported via
+ * `isError` (not folded into the km fallback): a settings-GET failure does not
+ * imply the log `POST` endpoint is also down, so silently defaulting to km could
+ * persist a miles runner's distance at ~1.6× the wrong magnitude. Callers gate
+ * the write on `isResolved` and offer a retry on `isError`.
  */
-export const usePreferredUnitsResolution = (): PreferredUnitsResolution => {
-  const { data, isLoading } = useGetUnitPreferenceQuery(undefined)
+export const usePreferredUnitsResolution = (): UsePreferredUnitsResolutionReturn => {
+  const { data, isSuccess, isError, refetch } = useGetUnitPreferenceQuery(undefined)
   return {
     units: data?.preferredUnits ?? PreferredUnits.Kilometers,
-    isResolved: !isLoading,
+    isResolved: isSuccess,
+    isError,
+    refetch,
   }
 }


### PR DESCRIPTION
## Slice 4C-units — PR6 (final PR of the sub-slice)

Makes the one real numeric **write** unit-aware: a Miles-preferring runner enters distance in miles on the `/log` form and it persists as canonical km/SI, while storage, the wire, and the plan-gen prompt stay km-native and **the LLM performs zero conversion** (DEC-086). Frontend-only.

### What changed
- **Shared module** (`unit-format.helpers.ts`): the single write conversion `preferredDistanceToMeters` (km path byte-identical to the prior `distanceKm * 1000`), its inverse `metresToPreferredDistance` (draft pre-fill), and `distanceUnitLabel`. All unit math lives in one module — one shared conversion, one write site, one `1609.344`.
- **Schema** (`workout-log-form.schema.ts`): the form-local distance field is renamed **`distanceKm` → `distance`** because it now holds the value in the runner's *display* unit (km OR miles) — `distanceKm` would be a misnomer under miles. The schema is now a `makeWorkoutLogFormSchema(units)` factory: unit-aware label + a `Math.ceil` mile-equivalent `max` (622 mi — a client sanity guard that is only ever *looser* than the km-native 1000 km ceiling, never stricter). `toCreateWorkoutLogRequest` takes a **required** `units` param.
- **`/log` page**: split into an outer that resolves the preference (new `usePreferredUnitsResolution`) and gates, and an inner form that mounts only once the unit is **known**. This means the miles→km write is never interpreted against the loading-time km fallback (a cold-cache data-corruption risk), the draft-edit pre-fill computes once in the correct unit, and there's no mid-form schema swap.
- **Draft pre-fill** (`draft-to-form.helpers.ts`): units-aware, and short-circuits the identity case (draft already in the preferred unit) to avoid FP round-trip drift (`100 mi → 99.99999999999999`).
- The **log-confirmation card is deliberately untouched** — it keeps echoing the runner-*stated* unit (build decision, per spec).

### Rename footprint
The `distanceKm → distance` rename is deliberate (the honest structural fix, not scope creep): it touches 3 prod + 4 spec files but the value at the conversion site now reads `values.distance * METERS_PER_MILE` instead of a `distanceKm`-named value multiplied by metres-per-mile.

### Design de-risking
The design was **adversarially red-teamed before implementation** (3 independent lenses + synthesis). Top finding — feeding the display-only km fallback into the *write* path could silently persist km for a miles runner on a cold cache — drove the resolve-then-mount split above. FP round-trip drift, the max-bound rounding direction (`ceil`, not `round`), and the resolver-swap/revalidation risk were all folded in.

### Proofs
- Schema unit test: a miles-entered distance round-trips to the correct `distanceMeters` (5 mi → `5 * 1609.344`). **[T06.2]**
- 109 unit/RTL tests across the five touched specs; full frontend suite **642/642**.
- Coaching **eval suite 193/193 green in Replay** locally (`--filter-namespace …Coaching.Eval*`); zero backend/prompt/wire files changed, so the km-native prompt and wire are unchanged by construction. **[T06.3, acceptance criterion 4]**
- `npm run build` (tsc + vite) green; touched files ESLint-clean.

### Follow-ups found
- No Miles-path E2E yet (`e2e/workout-logging.spec.ts` covers km only; it relies on fresh accounts server-side-defaulting to Kilometers). Tracked for the slice-level live pass.
- Onboarding weekly-distance entry is a second, LLM-mediated distance write path — explicitly out of scope here (belongs to `4C-onboarding`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logging now supports preferred distance units, showing the distance input label and values in **km** or **mi** based on user settings.
  * The **/log** page waits for unit preferences to resolve before rendering the form.

* **Bug Fixes**
  * Miles and kilometers are now converted and saved consistently, including edit/draft pre-fill without round-trip drift.
  * Empty distance and duration fields remain blank (no unwanted `"0"` values).

* **Tests**
  * Updated and expanded unit-conversion and form-schema coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->