### PR TITLE
fix(slice-4c-onboarding): start-or-append shared per-user stream to avoid onboarding/chat collision

### DIFF
--- a/backend/src/RunCoach.Api/Infrastructure/MartenEventStreamExtensions.cs
+++ b/backend/src/RunCoach.Api/Infrastructure/MartenEventStreamExtensions.cs
@@ -1,0 +1,46 @@
+using Marten;
+
+namespace RunCoach.Api.Infrastructure;
+
+/// <summary>
+/// Extension helpers for RunCoach's per-user Marten event streams.
+/// </summary>
+internal static class MartenEventStreamExtensions
+{
+    /// <summary>
+    /// Appends <paramref name="firstEvent"/> to the stream at <paramref name="streamId"/>,
+    /// starting the stream (tagged as <typeparamref name="TAggregate"/>) only when no physical
+    /// stream exists there yet, otherwise appending. Several single-stream projections are keyed
+    /// by the bare user id (e.g. the onboarding profile and the interactive conversation view),
+    /// so more than one aggregate materializes from ONE physical stream at that id. Bootstrap
+    /// must therefore key off physical stream existence, not any single projection's materialized
+    /// document: a <c>StartStream</c> over an already-existing stream throws
+    /// <c>ExistingStreamIdCollisionException</c>. The inline projection still runs its
+    /// <c>Create</c> overload for the first event it recognizes (keyed on aggregate existence,
+    /// not stream position), so appending a bootstrap event mid-stream still materializes the view.
+    /// </summary>
+    /// <typeparam name="TAggregate">The aggregate type tagging the stream when it is started.</typeparam>
+    /// <param name="session">The Marten session (bracketed by Wolverine's transaction).</param>
+    /// <param name="streamId">The per-user stream id.</param>
+    /// <param name="firstEvent">The event to start-or-append.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public static async Task StartStreamOrAppendAsync<TAggregate>(
+        this IDocumentSession session,
+        Guid streamId,
+        object firstEvent,
+        CancellationToken ct)
+        where TAggregate : class
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        var state = await session.Events.FetchStreamStateAsync(streamId, ct).ConfigureAwait(false);
+        if (state is null)
+        {
+            session.Events.StartStream<TAggregate>(streamId, firstEvent);
+        }
+        else
+        {
+            session.Events.Append(streamId, firstEvent);
+        }
+    }
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostUserConversationTurnHandler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Conversation/PostUserConversationTurnHandler.cs
@@ -1,5 +1,6 @@
 using Marten;
 using Microsoft.Extensions.Logging;
+using RunCoach.Api.Infrastructure;
 using RunCoach.Api.Infrastructure.Idempotency;
 
 namespace RunCoach.Api.Modules.Coaching.Conversation;
@@ -7,11 +8,13 @@ namespace RunCoach.Api.Modules.Coaching.Conversation;
 /// <summary>
 /// Wolverine command handler for <see cref="PostUserConversationTurn"/> (Slice 4B
 /// Unit 3, DEC-085) — the durable-first user-turn write. Idempotent on the client
-/// message id, so a retried POST appends nothing the second time. Bootstraps the
-/// user-scoped <c>Conversation</c> stream on the runner's first message, then
-/// appends to it on subsequent turns. Wolverine's transactional middleware brackets
-/// a single Marten <c>SaveChangesAsync</c> around the handler; it never calls
-/// <c>SaveChangesAsync</c> itself.
+/// message id, so a retried POST appends nothing the second time. Onboarding and
+/// conversation both materialize from a single physical per-user Marten stream (both
+/// projections are keyed by the bare user id), so this handler bootstraps that stream
+/// only when it does not yet physically exist and appends otherwise — including the
+/// first chat message after onboarding already created the stream. Wolverine's
+/// transactional middleware brackets a single Marten <c>SaveChangesAsync</c> around the
+/// handler; it never calls <c>SaveChangesAsync</c> itself.
 /// </summary>
 /// <remarks>
 /// Two-write persistence (DEC-085): this user-turn write and the
@@ -59,22 +62,14 @@ public sealed partial class PostUserConversationTurnHandler
         }
 
         var streamId = cmd.UserId;
-        var view = await session
-            .LoadAsync<ConversationView>(streamId, ct)
-            .ConfigureAwait(false);
-
         var @event = new UserMessagePosted(cmd.UserId, cmd.ClientMessageId, cmd.Content);
 
-        // First message bootstraps the stream; subsequent messages append. The inline
-        // InteractiveConversationProjection materializes the view in the same transaction.
-        if (view is null)
-        {
-            session.Events.StartStream<ConversationView>(streamId, @event);
-        }
-        else
-        {
-            session.Events.Append(streamId, @event);
-        }
+        // Bootstrap on physical stream existence, not ConversationView existence: a runner who
+        // onboarded already has the shared per-user stream (no ConversationView yet), so a
+        // StartStream here would collide on the first chat message. See StartStreamOrAppendAsync.
+        await session
+            .StartStreamOrAppendAsync<ConversationView>(streamId, @event, ct)
+            .ConfigureAwait(false);
 
         var response = new ConversationTurnPostedResponse(cmd.ClientMessageId);
         idempotency.Record(cmd.ClientMessageId, response);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnHandler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingTurnHandler.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Marten;
+using RunCoach.Api.Infrastructure;
 using RunCoach.Api.Infrastructure.Idempotency;
 using RunCoach.Api.Modules.Coaching.Onboarding.Models;
 using RunCoach.Api.Modules.Coaching.Sanitization;
@@ -149,13 +150,17 @@ public sealed partial class OnboardingTurnHandler
             .ConfigureAwait(false);
 
         // (2) bootstrap the stream on the very first turn — `OnboardingStarted`
-        //     is the create event the Marten projection's `Create` overload
-        //     keys off. The session call stages the stream creation; commit
+        //     is the create event the Marten projection's `Create` overload keys
+        //     off. Start-or-append on physical stream existence (not OnboardingView
+        //     existence): a runner who chatted before onboarding already has the
+        //     shared per-user stream, so a StartStream here would collide. Commit
         //     happens after the handler returns under Wolverine's transaction.
         var isFirstTurn = view is null;
         if (isFirstTurn)
         {
-            session.Events.StartStream<OnboardingView>(streamId, new OnboardingStarted(streamId, now));
+            await session
+                .StartStreamOrAppendAsync<OnboardingView>(streamId, new OnboardingStarted(streamId, now), ct)
+                .ConfigureAwait(false);
         }
         else if (view!.Status == OnboardingStatus.Completed)
         {

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/ConversationMessagesEndpointIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/ConversationMessagesEndpointIntegrationTests.cs
@@ -12,8 +12,9 @@ using RunCoach.Api.Infrastructure;
 using RunCoach.Api.Modules.Coaching;
 using RunCoach.Api.Modules.Coaching.Conversation;
 using RunCoach.Api.Modules.Coaching.Conversation.Streaming;
-using RunCoach.Api.Modules.Coaching.Onboarding.Entities;
+using RunCoach.Api.Modules.Coaching.Onboarding;
 using RunCoach.Api.Modules.Identity.Contracts;
+using RunCoach.Api.Modules.Training.Plan;
 using RunCoach.Api.Modules.Training.Plan.Models;
 using RunCoach.Api.Modules.Training.Safety;
 using RunCoach.Api.Modules.Training.Workouts;
@@ -41,6 +42,14 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
 
     private static readonly Uri BaseUri = new("https://localhost");
     private static readonly DateTimeOffset PlanGeneratedAt = new(2026, 4, 25, 12, 0, 0, TimeSpan.Zero);
+
+    // The Sunday that opens PlanGeneratedAt's training week (week 1, day 0). SeedActivePlanAsync's
+    // canonical plan only prescribes a workout on that day-0 Sunday, so it is the one OccurredOn
+    // that resolves a server-authoritative on-plan prescription. Wall-clock "today" would land in
+    // a later week the stub leaves without micro detail, resolving no prescription.
+    private static readonly DateOnly Week1SundayRunDate =
+        PlanCalendar.StartOfTrainingWeek(DateOnly.FromDateTime(PlanGeneratedAt.UtcDateTime));
+
     private static readonly JsonSerializerOptions WebOptions = new(JsonSerializerDefaults.Web);
 
     [Fact]
@@ -179,7 +188,7 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
     {
         // Arrange
         StubCoachingLlm.Reset();
-        StubCoachingLlm.UseStructuredBehavior(() => WorkoutLog(LocalToday()));
+        StubCoachingLlm.UseStructuredBehavior(() => WorkoutLog(Week1SundayRunDate));
         var (client, userId, token) = await RegisterLoginAndPrimeAsync();
         await SeedActivePlanAsync(userId);
         var clientMessageId = Guid.NewGuid();
@@ -194,6 +203,11 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
         var payload = Payload<CardPayload>(card);
         payload.Draft.DistanceValue.Should().Be(5);
         payload.Draft.DistanceUnit.Should().Be(RunnerDistanceUnit.Kilometers);
+        payload.Prescription.Should().NotBeNull(
+            because: "the seeded active plan resolves a server-authoritative on-plan prescription for "
+                + "the week-1/day-0 run (the onboarding-event seed survives the reprojection)");
+        payload.Prescription!.WorkoutType.Should().Be(
+            "Easy", because: "the seeded plan prescribes an Easy run on the week-1 Sunday");
         frames.Should().NotContain(f => f.Event == "token", because: "a workout-log card streams no answer");
 
         StubCoachingLlm.StreamCallCount.Should().Be(0, because: "the card path never streams");
@@ -204,6 +218,35 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
         var view = await LoadConversationViewAsync(userId);
         view!.Turns.Should().ContainSingle(because: "only the durable-first user turn persists for a card")
             .Which.Participant.Should().Be(ConversationParticipant.User);
+    }
+
+    [Fact]
+    public async Task PostMessage_AfterOnboardingCreatedTheStream_AppendsWithoutStreamCollision()
+    {
+        // Arrange — SeedActivePlanAsync onboards the runner, which starts the per-user event
+        // stream (id = user id). The runner's first chat message must append to that stream,
+        // not StartStream: a StartStream over the existing onboarding stream would throw
+        // ExistingStreamIdCollisionException (the regression this guards).
+        StubCoachingLlm.Reset();
+        StubCoachingLlm.UseStructuredBehavior(() => Question());
+        StubCoachingLlm.UseStreamBehavior(_ => YieldTokensAsync("Welcome back."));
+        var (client, userId, token) = await RegisterLoginAndPrimeAsync();
+        await SeedActivePlanAsync(userId);
+        var clientMessageId = Guid.NewGuid();
+
+        // Act
+        using var response = await PostMessageAsync(client, token, "What's on tap today?", clientMessageId);
+        var frames = await ReadFramesAsync(response);
+
+        // Assert — a collision would surface as an error frame; instead the stream appends and the
+        // InteractiveConversationProjection creates the view from this first UserMessagePosted.
+        frames.Should().NotContain(
+            f => f.Event == "error",
+            because: "the first message after onboarding appends to the existing per-user stream");
+        frames.Should().Contain(f => f.Event == "token");
+        var view = await LoadConversationViewAsync(userId);
+        view!.Turns.Should().Contain(t => t.Participant == ConversationParticipant.User
+            && t.TurnId == clientMessageId);
     }
 
     [Fact]
@@ -819,8 +862,6 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
             request, HttpCompletionOption.ResponseHeadersRead, TestContext.Current.CancellationToken);
     }
 
-    private static DateOnly LocalToday() => DateOnly.FromDateTime(DateTime.UtcNow);
-
     private static (HttpClient Client, System.Net.CookieContainer Container) CreateCookieClient(RunCoachAppFactory factory)
     {
         var container = new System.Net.CookieContainer();
@@ -906,40 +947,29 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
     private async Task SeedActivePlanAsync(Guid userId)
     {
         var planId = Guid.NewGuid();
-        using (var scope = Factory.Services.CreateScope())
-        {
-            var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
-            await using var session = store.LightweightSession(userId.ToString());
-            var sequence = StubPlanGenerationService.BuildCanonicalSequence(
-                planId, userId, goal: "Half Marathon", PlanGeneratedAt, previousPlanId: null);
-            session.Events.StartStream<PlanProjectionDto>(planId, [.. sequence.ToEvents()]);
-            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
-        }
+        using var scope = Factory.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
 
-        using (var scope = Factory.Services.CreateScope())
-        {
-            var db = scope.ServiceProvider.GetRequiredService<RunCoachDbContext>();
-            var profile = await EntityFrameworkQueryableExtensions.SingleOrDefaultAsync(
-                db.RunnerOnboardingProfiles.Where(p => p.UserId == userId), TestContext.Current.CancellationToken);
-            if (profile is null)
-            {
-                var now = DateTimeOffset.UtcNow;
-                db.RunnerOnboardingProfiles.Add(new RunnerOnboardingProfile
-                {
-                    UserId = userId,
-                    TenantId = userId.ToString(),
-                    CurrentPlanId = planId,
-                    CreatedOn = now,
-                    ModifiedOn = now,
-                });
-            }
-            else
-            {
-                profile.CurrentPlanId = planId;
-            }
+        var sequence = StubPlanGenerationService.BuildCanonicalSequence(
+            planId, userId, goal: "Half Marathon", PlanGeneratedAt, previousPlanId: null);
+        session.Events.StartStream<PlanProjectionDto>(planId, [.. sequence.ToEvents()]);
 
-            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
-        }
+        // Seed the runner's profile through their onboarding event stream (id = user id),
+        // exactly as production does — the PlanLinkedToUser event drives the inline
+        // UserProfileFromOnboardingProjection to set CurrentPlanId. A direct EF insert would
+        // NOT survive the SSE flow: onboarding and conversation share one per-user stream, so
+        // the first UserMessagePosted starts that stream and the single-stream projection runs
+        // with a null snapshot, whose default branch returns null — Marten then DELETES the
+        // manually inserted UserProfile row outright (not merely clearing CurrentPlanId).
+        var now = DateTimeOffset.UtcNow;
+        session.Events.StartStream<OnboardingView>(
+            userId,
+            new OnboardingStarted(userId, now),
+            new PlanLinkedToUser(userId, planId),
+            new OnboardingCompleted(planId, now));
+
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
     }
 
     private sealed record SseFrame(string Event, string Data);

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/ConversationMessagesEndpointIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Conversation/Streaming/ConversationMessagesEndpointIntegrationTests.cs
@@ -43,8 +43,8 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
     private static readonly Uri BaseUri = new("https://localhost");
     private static readonly DateTimeOffset PlanGeneratedAt = new(2026, 4, 25, 12, 0, 0, TimeSpan.Zero);
 
-    // The Sunday that opens PlanGeneratedAt's training week (week 1, day 0). SeedActivePlanAsync's
-    // canonical plan only prescribes a workout on that day-0 Sunday, so it is the one OccurredOn
+    // The Sunday that opens `PlanGeneratedAt`'s training week (week 1, day 0). The seeded
+    // canonical plan only prescribes a workout on that day-0 Sunday, so it is the one run date
     // that resolves a server-authoritative on-plan prescription. Wall-clock "today" would land in
     // a later week the stub leaves without micro detail, resolving no prescription.
     private static readonly DateOnly Week1SundayRunDate =
@@ -223,10 +223,10 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
     [Fact]
     public async Task PostMessage_AfterOnboardingCreatedTheStream_AppendsWithoutStreamCollision()
     {
-        // Arrange — SeedActivePlanAsync onboards the runner, which starts the per-user event
-        // stream (id = user id). The runner's first chat message must append to that stream,
-        // not StartStream: a StartStream over the existing onboarding stream would throw
-        // ExistingStreamIdCollisionException (the regression this guards).
+        // Arrange — `SeedActivePlanAsync` onboards the runner, which starts the per-user event
+        // stream (id = user id). The runner's first chat message must append to that stream
+        // rather than start it again — starting an already-existing stream throws
+        // `ExistingStreamIdCollisionException` (the regression this guards).
         StubCoachingLlm.Reset();
         StubCoachingLlm.UseStructuredBehavior(() => Question());
         StubCoachingLlm.UseStreamBehavior(_ => YieldTokensAsync("Welcome back."));
@@ -245,8 +245,10 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
             because: "the first message after onboarding appends to the existing per-user stream");
         frames.Should().Contain(f => f.Event == "token");
         var view = await LoadConversationViewAsync(userId);
-        view!.Turns.Should().Contain(t => t.Participant == ConversationParticipant.User
-            && t.TurnId == clientMessageId);
+        view!.Turns.Should().ContainSingle(
+            t => t.Participant == ConversationParticipant.User
+                && t.TurnId == clientMessageId,
+            because: "the first chat message appends exactly one durable user turn");
     }
 
     [Fact]
@@ -956,12 +958,12 @@ public class ConversationMessagesEndpointIntegrationTests(RunCoachAppFactory fac
         session.Events.StartStream<PlanProjectionDto>(planId, [.. sequence.ToEvents()]);
 
         // Seed the runner's profile through their onboarding event stream (id = user id),
-        // exactly as production does — the PlanLinkedToUser event drives the inline
-        // UserProfileFromOnboardingProjection to set CurrentPlanId. A direct EF insert would
-        // NOT survive the SSE flow: onboarding and conversation share one per-user stream, so
-        // the first UserMessagePosted starts that stream and the single-stream projection runs
-        // with a null snapshot, whose default branch returns null — Marten then DELETES the
-        // manually inserted UserProfile row outright (not merely clearing CurrentPlanId).
+        // exactly as production does — the `PlanLinkedToUser` event drives the inline
+        // `UserProfileFromOnboardingProjection` to set the current plan. A direct EF insert
+        // would NOT survive the streaming flow: onboarding and conversation share one per-user
+        // stream, so the first `UserMessagePosted` starts that stream and the single-stream
+        // projection runs from a null snapshot whose default branch returns null — Marten then
+        // deletes the manually inserted profile row outright (not merely clearing the plan id).
         var now = DateTimeOffset.UtcNow;
         session.Events.StartStream<OnboardingView>(
             userId,

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnConcurrencyIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnConcurrencyIntegrationTests.cs
@@ -172,7 +172,7 @@ public sealed class OnboardingTurnConcurrencyIntegrationTests(RunCoachAppFactory
     public async Task FirstOnboardingTurn_WhenConversationStreamAlreadyExists_AppendsWithoutCollision()
     {
         // Arrange — a runner who has chatted (their per-user stream exists, tagged
-        // ConversationView) but has never onboarded (no OnboardingView document yet).
+        // `ConversationView`) but has never onboarded (no `OnboardingView` document yet).
         var userId = await SeedUserAsync();
         await PreseedConversationStreamAsync(userId);
 
@@ -191,9 +191,9 @@ public sealed class OnboardingTurnConcurrencyIntegrationTests(RunCoachAppFactory
             scope.Dispose();
         }
 
-        // Assert — the OnboardingView materialized from the appended OnboardingStarted, proving
-        // the projection's Create ran on the bootstrap event even though it was not the stream's
-        // first event.
+        // Assert — the `OnboardingView` materialized from the appended `OnboardingStarted`,
+        // proving the projection's `Create` ran on the bootstrap event even though it was not
+        // the stream's first event.
         using var readScope = Factory.Services.CreateScope();
         var store = readScope.ServiceProvider.GetRequiredService<IDocumentStore>();
         await using var readSession = store.LightweightSession(userId.ToString());

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnConcurrencyIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingTurnConcurrencyIntegrationTests.cs
@@ -11,6 +11,7 @@ using Npgsql;
 using NSubstitute;
 using RunCoach.Api.Infrastructure.Idempotency;
 using RunCoach.Api.Modules.Coaching;
+using RunCoach.Api.Modules.Coaching.Conversation;
 using RunCoach.Api.Modules.Coaching.Models;
 using RunCoach.Api.Modules.Coaching.Onboarding;
 using RunCoach.Api.Modules.Coaching.Onboarding.Models;
@@ -158,6 +159,49 @@ public sealed class OnboardingTurnConcurrencyIntegrationTests(RunCoachAppFactory
         }
     }
 
+    /// <summary>
+    /// Regression guard for the shared per-user event stream: onboarding and the interactive
+    /// conversation both materialize from the bare-user-id stream. A runner who chats before
+    /// onboarding creates that stream via the conversation handler; their first onboarding turn
+    /// must then APPEND <c>OnboardingStarted</c>, not <c>StartStream</c> — a <c>StartStream</c>
+    /// over the already-existing stream throws <see cref="ExistingStreamIdCollisionException"/>,
+    /// which <c>OnboardingController</c> does not catch, so it would surface as an unhandled 500
+    /// that permanently blocks the account from ever completing onboarding.
+    /// </summary>
+    [Fact]
+    public async Task FirstOnboardingTurn_WhenConversationStreamAlreadyExists_AppendsWithoutCollision()
+    {
+        // Arrange — a runner who has chatted (their per-user stream exists, tagged
+        // ConversationView) but has never onboarded (no OnboardingView document yet).
+        var userId = await SeedUserAsync();
+        await PreseedConversationStreamAsync(userId);
+
+        // Act — stage the first onboarding turn, then commit (standing in for Wolverine's
+        // transactional middleware). The commit must not throw a stream-collision.
+        var (scope, session) = await PrepareFirstTurnAsync(userId, idempotencyKey: Guid.NewGuid());
+        try
+        {
+            Func<Task> commit = () => session.SaveChangesAsync(TestContext.Current.CancellationToken);
+            await commit.Should().NotThrowAsync(
+                because: "the first onboarding turn appends OnboardingStarted to the existing shared per-user stream instead of StartStream, which would collide");
+        }
+        finally
+        {
+            await session.DisposeAsync();
+            scope.Dispose();
+        }
+
+        // Assert — the OnboardingView materialized from the appended OnboardingStarted, proving
+        // the projection's Create ran on the bootstrap event even though it was not the stream's
+        // first event.
+        using var readScope = Factory.Services.CreateScope();
+        var store = readScope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        await using var readSession = store.LightweightSession(userId.ToString());
+        var view = await readSession.LoadAsync<OnboardingView>(userId, TestContext.Current.CancellationToken);
+        view.Should().NotBeNull(
+            because: "OnboardingProjection.Create runs on the appended OnboardingStarted mid-stream");
+    }
+
     /// <inheritdoc/>
     public override async ValueTask DisposeAsync()
     {
@@ -224,6 +268,21 @@ public sealed class OnboardingTurnConcurrencyIntegrationTests(RunCoachAppFactory
         result.Succeeded.Should()
             .BeTrue(because: $"seed must succeed — got [{string.Join(", ", result.Errors.Select(e => e.Code))}]");
         return user.Id;
+    }
+
+    /// <summary>
+    /// Creates the runner's per-user event stream via a conversation turn (as if they chatted
+    /// before onboarding), tagging the physical stream <c>ConversationView</c> with no
+    /// onboarding events on it yet.
+    /// </summary>
+    private async Task PreseedConversationStreamAsync(Guid userId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        session.Events.StartStream<ConversationView>(
+            userId, new UserMessagePosted(userId, Guid.NewGuid(), "hey coach"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Slice 4C-onboarding **PR-A** (DU-5). What started as the "fix the `SeedActivePlanAsync` `ITenanted` seam + restore the on-plan card assertion" cleanup uncovered — and this PR fixes — a **latent production bug**, so it grew from test-only to a small production fix. Flagging that scope change for review.

> ⚠️ **Scope note:** the spec framed DU-5 as a tenancy fix. That premise was a **misdiagnosis** (details below). The real defect is a Marten stream-bootstrap bug reachable by any client, so this PR fixes production code (`PostUserConversationTurnHandler`, `OnboardingTurnHandler`) plus a shared helper, in addition to the test work.

## The bug

Onboarding and the interactive conversation both materialize from **one physical per-user Marten stream** — both single-stream projections (`RunnerOnboardingProfile`, `ConversationView`) are keyed by the bare `userId`, so both target the `userId` stream. Each handler decided *bootstrap-vs-append* on **its own projection document's** existence instead of **physical stream** existence, so a `StartStream` ran over an already-existing stream and threw `ExistingStreamIdCollisionException`:

| Ordering | Handler | Symptom |
|---|---|---|
| **onboard → chat** | `PostUserConversationTurnHandler` | first chat message after onboarding 500s |
| **chat → onboard** | `OnboardingTurnHandler` | first onboarding turn after a chat 500s — **uncaught**, and since the transaction commits nothing, `OnboardingView` stays null forever, permanently blocking the account from completing onboarding |

`POST /api/v1/conversation/messages` is only auth-gated (no onboarding gate — `GreenQuestion_WithNoActivePlan_StillStreamsAnAnswer` proves chat-before-onboard is a supported state), so **both orderings are reachable by any client**. No test exercised either path before — the second direction was caught by the adversarial review of this PR.

## The fix

- **New** `Infrastructure/MartenEventStreamExtensions.StartStreamOrAppendAsync<TAggregate>` — decides on physical stream existence via `FetchStreamStateAsync`. Both handlers use it, so the distinction can't silently regress on either side. The inline projection still runs its `Create` overload for the first event it recognizes (aggregate-existence, not stream position), so appending a bootstrap event mid-stream still materializes the view.

## DU-5 completion (the on-plan card assertion)

`WorkoutLog_ReturnsConfirmationCard_AndCommitsNothing` now asserts `CardPayload.Prescription` resolves end-to-end (previously read but never asserted).

The spec's tenancy diagnosis was wrong: the manually EF-seeded `UserProfile` row was **deleted outright** by the single-stream projection when the SSE `UserMessagePosted` started the stream (null snapshot → the projection's `default` branch returns null → Marten deletes the row) — not filtered by tenant. So `SeedActivePlanAsync` now seeds through the onboarding **event stream** (`OnboardingStarted` + `PlanLinkedToUser` + `OnboardingCompleted`) exactly as production does, and `CurrentPlanId` survives the reprojection. The run date is pinned to the plan's week-1/day-0 Sunday (was wall-clock `LocalToday()`, which never mapped to a prescribed day).

## Tests (both proven to fail with a collision if their fix is reverted)

- `PostMessage_AfterOnboardingCreatedTheStream_AppendsWithoutStreamCollision` (conversation side)
- `FirstOnboardingTurn_WhenConversationStreamAlreadyExists_AppendsWithoutCollision` (onboarding side)

## Verification

- Full backend suite **2051/2051** green in Replay (Colima/Testcontainers).
- Each handler fix independently verified: the guarding test fails with `ExistingStreamIdCollisionException` when the fix is reverted.
- The `OnboardingTurnConcurrencyIntegrationTests` Rich-mode guard still holds (concurrent first-turns all see no stream pre-commit → one `StartStream` wins).

## Review (adversarial sonnet pass)

The onboarding-side (`chat → onboard`) direction and both comment-accuracy fixes below came from the review; the challenger ruled out tenancy mismatch, reprojection drift, and clock-flake on the changed code.

## Follow-ups (intentionally out of scope)

1. **DEC-047 divergence** — DEC-047 specifies onboarding on a *separate* `DeterministicGuid(userId, "onboarding")` stream ("commingling would force both projections to event-filter" — exactly the footgun here). The shipped bare-`userId` sharing is an emergent divergence; re-separating needs a projection-identity migration. Decide whether to **ratify the merged stream** or **re-separate** — natural fit for 4C-onboarding.
2. **Sibling test seeds** (`ConfirmConversationalLogEndpointIntegrationTests`, `ConversationControllerIntegrationTests`) still EF-insert the profile — correct today (they don't reproject) per the FR-5.3 scope guard, but worth porting to the event-sourced seed as a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved onboarding and conversation handling so a user’s first message can be recorded even if their event stream already exists.
  * Added more consistent stream initialization behavior across onboarding and chat flows.

* **Bug Fixes**
  * Resolved stream-collision issues that could occur when onboarding and conversation actions happened in different orders.
  * Improved reliability of first-turn writes while keeping duplicate submissions safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->