### PR TITLE
feat(slice-4c-onboarding): deterministic form-answer origination endpoint

### DIFF
--- a/backend/openapi/swagger.json
+++ b/backend/openapi/swagger.json
@@ -894,6 +894,122 @@
         ]
       }
     },
+    "/api/v1/onboarding/answers": {
+      "post": {
+        "tags": [
+          "Onboarding"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitStructuredAnswersRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitStructuredAnswersRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitStructuredAnswersRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/OnboardingStateDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OnboardingStateDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OnboardingStateDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": [ ]
+          },
+          {
+            "bearerAuth": [ ]
+          }
+        ]
+      }
+    },
     "/api/v1/plan/current": {
       "get": {
         "tags": [
@@ -1846,6 +1962,37 @@
         },
         "additionalProperties": false
       },
+      "CurrentFitnessInputDto": {
+        "required": [
+          "longestRecentRunKm",
+          "typicalWeeklyKm"
+        ],
+        "type": "object",
+        "properties": {
+          "typicalWeeklyKm": {
+            "type": "number",
+            "format": "double"
+          },
+          "longestRecentRunKm": {
+            "type": "number",
+            "format": "double"
+          },
+          "recentRaceDistanceKm": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "recentRaceTimeIso": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "DaySlotType": {
         "enum": [
           "Run",
@@ -1884,6 +2031,26 @@
           "pastInjurySummary": {
             "type": "string",
             "description": "Summary of past injuries or recurring issues that should inform the training plan. Empty string if none."
+          }
+        },
+        "additionalProperties": false
+      },
+      "InjuryHistoryInputDto": {
+        "required": [
+          "hasActiveInjury"
+        ],
+        "type": "object",
+        "properties": {
+          "hasActiveInjury": {
+            "type": "boolean"
+          },
+          "activeInjuryDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "pastInjurySummary": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -2420,6 +2587,30 @@
         },
         "additionalProperties": false
       },
+      "PreferencesInputDto": {
+        "required": [
+          "comfortableWithIntensity",
+          "preferredUnits",
+          "preferTrail"
+        ],
+        "type": "object",
+        "properties": {
+          "preferredUnits": {
+            "$ref": "#/components/schemas/PreferredUnits"
+          },
+          "preferTrail": {
+            "type": "boolean"
+          },
+          "comfortableWithIntensity": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "PreferredUnits": {
         "enum": [
           0,
@@ -2452,6 +2643,22 @@
           "description": {
             "type": "string",
             "description": "Runner-supplied free-text description that informed the categorical mapping."
+          }
+        },
+        "additionalProperties": false
+      },
+      "PrimaryGoalInputDto": {
+        "required": [
+          "goal"
+        ],
+        "type": "object",
+        "properties": {
+          "goal": {
+            "$ref": "#/components/schemas/PrimaryGoal"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -2687,6 +2894,43 @@
         },
         "additionalProperties": false
       },
+      "SubmitStructuredAnswersRequestDto": {
+        "required": [
+          "currentFitness",
+          "idempotencyKey",
+          "injuryHistory",
+          "preferences",
+          "primaryGoal",
+          "targetEvent",
+          "weeklySchedule"
+        ],
+        "type": "object",
+        "properties": {
+          "idempotencyKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "primaryGoal": {
+            "$ref": "#/components/schemas/PrimaryGoalInputDto"
+          },
+          "targetEvent": {
+            "$ref": "#/components/schemas/TargetEventInputDto"
+          },
+          "currentFitness": {
+            "$ref": "#/components/schemas/CurrentFitnessInputDto"
+          },
+          "weeklySchedule": {
+            "$ref": "#/components/schemas/WeeklyScheduleInputDto"
+          },
+          "injuryHistory": {
+            "$ref": "#/components/schemas/InjuryHistoryInputDto"
+          },
+          "preferences": {
+            "$ref": "#/components/schemas/PreferencesInputDto"
+          }
+        },
+        "additionalProperties": false
+      },
       "SuggestedInputType": {
         "enum": [
           0,
@@ -2723,6 +2967,31 @@
           "targetFinishTimeIso": {
             "type": "string",
             "description": "Optional target finishing time as ISO-8601 duration (e.g. PT1H45M30S). Null if the runner has no specific time goal.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TargetEventInputDto": {
+        "required": [
+          "distanceKm",
+          "eventDateIso",
+          "eventName"
+        ],
+        "type": "object",
+        "properties": {
+          "eventName": {
+            "type": "string"
+          },
+          "distanceKm": {
+            "type": "number",
+            "format": "double"
+          },
+          "eventDateIso": {
+            "type": "string"
+          },
+          "targetFinishTimeIso": {
+            "type": "string",
             "nullable": true
           }
         },
@@ -2835,6 +3104,56 @@
           "description": {
             "type": "string",
             "description": "Runner-supplied free-text description of constraints not captured by the day flags (e.g. 'no early mornings')."
+          }
+        },
+        "additionalProperties": false
+      },
+      "WeeklyScheduleInputDto": {
+        "required": [
+          "friday",
+          "maxRunDaysPerWeek",
+          "monday",
+          "saturday",
+          "sunday",
+          "thursday",
+          "tuesday",
+          "typicalSessionMinutes",
+          "wednesday"
+        ],
+        "type": "object",
+        "properties": {
+          "maxRunDaysPerWeek": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "typicalSessionMinutes": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "monday": {
+            "type": "boolean"
+          },
+          "tuesday": {
+            "type": "boolean"
+          },
+          "wednesday": {
+            "type": "boolean"
+          },
+          "thursday": {
+            "type": "boolean"
+          },
+          "friday": {
+            "type": "boolean"
+          },
+          "saturday": {
+            "type": "boolean"
+          },
+          "sunday": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/CurrentFitnessInputDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/CurrentFitnessInputDto.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+/// <summary>
+/// Wire-input shape for the CurrentFitness topic on POST /api/v1/onboarding/answers. A loosened,
+/// non-throwing counterpart to <see cref="CurrentFitnessAnswer"/> (see
+/// <see cref="PrimaryGoalInputDto"/> for the rationale). Distances are canonical kilometers; the
+/// form converts from the runner's chosen display unit before submitting (DEC-086).
+/// </summary>
+/// <param name="TypicalWeeklyKm">Typical weekly running distance in kilometers (validated &gt;= 0).</param>
+/// <param name="LongestRecentRunKm">Longest single run in the past four weeks, in kilometers (validated &gt;= 0).</param>
+/// <param name="RecentRaceDistanceKm">Optional recent race distance in kilometers (validated &gt;= 0 when present).</param>
+/// <param name="RecentRaceTimeIso">Optional recent race time as an ISO-8601 duration (e.g. PT0H45M30S).</param>
+/// <param name="Description">Optional runner-supplied free-text nuance for this topic.</param>
+public sealed record CurrentFitnessInputDto(
+    [property: JsonRequired] double TypicalWeeklyKm,
+    [property: JsonRequired] double LongestRecentRunKm,
+    double? RecentRaceDistanceKm,
+    string? RecentRaceTimeIso,
+    string? Description);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/CurrentFitnessInputDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/CurrentFitnessInputDto.cs
@@ -11,7 +11,7 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
 /// <param name="TypicalWeeklyKm">Typical weekly running distance in kilometers (validated &gt;= 0).</param>
 /// <param name="LongestRecentRunKm">Longest single run in the past four weeks, in kilometers (validated &gt;= 0).</param>
 /// <param name="RecentRaceDistanceKm">Optional recent race distance in kilometers (validated &gt;= 0 when present).</param>
-/// <param name="RecentRaceTimeIso">Optional recent race time as an ISO-8601 duration (e.g. PT0H45M30S).</param>
+/// <param name="RecentRaceTimeIso">Optional recent race time as an ISO-8601 duration (e.g. <c>PT0H45M30S</c>).</param>
 /// <param name="Description">Optional runner-supplied free-text nuance for this topic.</param>
 public sealed record CurrentFitnessInputDto(
     [property: JsonRequired] double TypicalWeeklyKm,

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/InjuryHistoryInputDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/InjuryHistoryInputDto.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+/// <summary>
+/// Wire-input shape for the InjuryHistory topic on POST /api/v1/onboarding/answers. A loosened,
+/// non-throwing counterpart to <see cref="InjuryHistoryAnswer"/> (see
+/// <see cref="PrimaryGoalInputDto"/> for the rationale). <see cref="PastInjurySummary"/> is this
+/// topic's free-text nuance field.
+/// </summary>
+/// <param name="HasActiveInjury">Whether the runner currently has an active injury or pain limiting training.</param>
+/// <param name="ActiveInjuryDescription">Optional description of the active injury or limitation.</param>
+/// <param name="PastInjurySummary">Optional summary of past injuries or recurring issues (the nuance field).</param>
+public sealed record InjuryHistoryInputDto(
+    [property: JsonRequired] bool HasActiveInjury,
+    string? ActiveInjuryDescription,
+    string? PastInjurySummary);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/PreferencesInputDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/PreferencesInputDto.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+/// <summary>
+/// Wire-input shape for the Preferences topic on POST /api/v1/onboarding/answers. A loosened,
+/// non-throwing counterpart to <see cref="PreferencesAnswer"/> (see
+/// <see cref="PrimaryGoalInputDto"/> for the rationale).
+/// </summary>
+/// <remarks>
+/// <see cref="PreferredUnits"/> is submitted so the required Preferences slot round-trips, but it
+/// is non-authoritative for display: the canonical unit preference lives in the 4C-units
+/// <c>UserSettings</c> store, written separately by the form via PUT /api/v1/settings/units
+/// (DEC-086 D4). This endpoint never converts units — the km-native prompt is unaffected.
+/// </remarks>
+/// <param name="PreferredUnits">Preferred distance units (validated against the closed enum server-side).</param>
+/// <param name="PreferTrail">Whether the runner prefers trail running where possible.</param>
+/// <param name="ComfortableWithIntensity">Whether the runner is comfortable with structured high-intensity workouts.</param>
+/// <param name="Description">Optional runner-supplied free-text nuance for this topic.</param>
+public sealed record PreferencesInputDto(
+    [property: JsonRequired] PreferredUnits PreferredUnits,
+    [property: JsonRequired] bool PreferTrail,
+    [property: JsonRequired] bool ComfortableWithIntensity,
+    string? Description);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/PreferencesInputDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/PreferencesInputDto.cs
@@ -10,7 +10,7 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
 /// <remarks>
 /// <see cref="PreferredUnits"/> is submitted so the required Preferences slot round-trips, but it
 /// is non-authoritative for display: the canonical unit preference lives in the 4C-units
-/// <c>UserSettings</c> store, written separately by the form via PUT /api/v1/settings/units
+/// <c>UserSettings</c> store, written separately by the form via <c>PUT /api/v1/settings/units</c>
 /// (DEC-086 D4). This endpoint never converts units — the km-native prompt is unaffected.
 /// </remarks>
 /// <param name="PreferredUnits">Preferred distance units (validated against the closed enum server-side).</param>

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/PrimaryGoalInputDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/PrimaryGoalInputDto.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+/// <summary>
+/// Wire-input shape for the PrimaryGoal topic on POST /api/v1/onboarding/answers.
+/// A loosened, non-throwing counterpart to <see cref="PrimaryGoalAnswer"/>: the form
+/// submits primitives, the controller validates them deterministically and constructs the
+/// canonical answer record. Kept separate from <see cref="PrimaryGoalAnswer"/> because that
+/// record self-validates in its <c>init</c> accessors — binding it directly would surface a
+/// hostile value as an uncatchable HTTP 500 instead of a clean 400.
+/// </summary>
+/// <param name="Goal">Categorical primary goal (validated against the closed enum server-side).</param>
+/// <param name="Description">Optional runner-supplied free-text nuance for this topic.</param>
+public sealed record PrimaryGoalInputDto(
+    [property: JsonRequired] PrimaryGoal Goal,
+    string? Description);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/SubmitStructuredAnswersRequestDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/SubmitStructuredAnswersRequestDto.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+/// <summary>
+/// Request payload for POST /api/v1/onboarding/answers — the deterministic, form-first onboarding
+/// intake (DEC-086). Carries a client-minted idempotency key plus a nullable, whole-record slot
+/// per topic; a present slot is that topic's complete answer. The single-page form submits every
+/// completed topic in one request. Each slot is a loosened, non-throwing input shape (see
+/// <see cref="PrimaryGoalInputDto"/>); the controller validates them deterministically and
+/// originates one <see cref="AnswerCaptured"/> event per submitted topic — no onboarding-time LLM
+/// call.
+/// </summary>
+/// <param name="IdempotencyKey">Client-generated idempotency key (typically a <c>crypto.randomUUID()</c>) re-sent on retry.</param>
+/// <param name="PrimaryGoal">PrimaryGoal answer, or null if not submitted this request.</param>
+/// <param name="TargetEvent">TargetEvent answer (only valid with a race-training PrimaryGoal), or null.</param>
+/// <param name="CurrentFitness">CurrentFitness answer, or null.</param>
+/// <param name="WeeklySchedule">WeeklySchedule answer, or null.</param>
+/// <param name="InjuryHistory">InjuryHistory answer, or null.</param>
+/// <param name="Preferences">Preferences answer, or null.</param>
+public sealed record SubmitStructuredAnswersRequestDto(
+    [property: JsonRequired] Guid IdempotencyKey,
+    PrimaryGoalInputDto? PrimaryGoal,
+    TargetEventInputDto? TargetEvent,
+    CurrentFitnessInputDto? CurrentFitness,
+    WeeklyScheduleInputDto? WeeklySchedule,
+    InjuryHistoryInputDto? InjuryHistory,
+    PreferencesInputDto? Preferences);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/TargetEventInputDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/TargetEventInputDto.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+/// <summary>
+/// Wire-input shape for the TargetEvent topic on POST /api/v1/onboarding/answers. A loosened,
+/// non-throwing counterpart to <see cref="TargetEventAnswer"/> (see
+/// <see cref="PrimaryGoalInputDto"/> for why the wire shape is separated from the self-validating
+/// answer record). Only submitted when the primary goal is race training.
+/// </summary>
+/// <param name="EventName">Name of the goal race or event.</param>
+/// <param name="DistanceKm">Target distance in kilometers (validated &gt; 0 server-side).</param>
+/// <param name="EventDateIso">Target event date in ISO-8601 calendar form (yyyy-MM-dd), validated server-side.</param>
+/// <param name="TargetFinishTimeIso">Optional target finishing time as an ISO-8601 duration (e.g. PT1H45M30S).</param>
+public sealed record TargetEventInputDto(
+    [property: JsonRequired] string EventName,
+    [property: JsonRequired] double DistanceKm,
+    [property: JsonRequired] string EventDateIso,
+    string? TargetFinishTimeIso);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/TargetEventInputDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/TargetEventInputDto.cs
@@ -10,8 +10,8 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
 /// </summary>
 /// <param name="EventName">Name of the goal race or event.</param>
 /// <param name="DistanceKm">Target distance in kilometers (validated &gt; 0 server-side).</param>
-/// <param name="EventDateIso">Target event date in ISO-8601 calendar form (yyyy-MM-dd), validated server-side.</param>
-/// <param name="TargetFinishTimeIso">Optional target finishing time as an ISO-8601 duration (e.g. PT1H45M30S).</param>
+/// <param name="EventDateIso">Target event date in ISO-8601 calendar form (<c>yyyy-MM-dd</c>), validated server-side.</param>
+/// <param name="TargetFinishTimeIso">Optional target finishing time as an ISO-8601 duration (e.g. <c>PT1H45M30S</c>).</param>
 public sealed record TargetEventInputDto(
     [property: JsonRequired] string EventName,
     [property: JsonRequired] double DistanceKm,

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/WeeklyScheduleInputDto.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/Models/WeeklyScheduleInputDto.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+
+namespace RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+/// <summary>
+/// Wire-input shape for the WeeklySchedule topic on POST /api/v1/onboarding/answers. A loosened,
+/// non-throwing counterpart to <see cref="WeeklyScheduleAnswer"/> (see
+/// <see cref="PrimaryGoalInputDto"/> for the rationale). Day availability is carried as seven
+/// named booleans, matching the answer record — the whole group is co-submitted, which is what
+/// structurally dissolves the turn-based slot-merge loop (DEC-086).
+/// </summary>
+/// <param name="MaxRunDaysPerWeek">Maximum run days per week (validated 1-7 server-side).</param>
+/// <param name="TypicalSessionMinutes">Typical session duration in minutes (validated &gt; 0).</param>
+/// <param name="Monday">Whether Monday is an available run day.</param>
+/// <param name="Tuesday">Whether Tuesday is an available run day.</param>
+/// <param name="Wednesday">Whether Wednesday is an available run day.</param>
+/// <param name="Thursday">Whether Thursday is an available run day.</param>
+/// <param name="Friday">Whether Friday is an available run day.</param>
+/// <param name="Saturday">Whether Saturday is an available run day.</param>
+/// <param name="Sunday">Whether Sunday is an available run day.</param>
+/// <param name="Description">Optional runner-supplied free-text nuance for this topic.</param>
+public sealed record WeeklyScheduleInputDto(
+    [property: JsonRequired] int MaxRunDaysPerWeek,
+    [property: JsonRequired] int TypicalSessionMinutes,
+    [property: JsonRequired] bool Monday,
+    [property: JsonRequired] bool Tuesday,
+    [property: JsonRequired] bool Wednesday,
+    [property: JsonRequired] bool Thursday,
+    [property: JsonRequired] bool Friday,
+    [property: JsonRequired] bool Saturday,
+    [property: JsonRequired] bool Sunday,
+    string? Description);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingController.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingController.cs
@@ -31,6 +31,9 @@ public sealed partial class OnboardingController(
     private const string AlreadyCompleteType = "https://runcoach.app/problems/onboarding-already-complete";
     private const string MissingUserType = "https://runcoach.app/problems/missing-user-claim";
     private const string InvalidTopicType = "https://runcoach.app/problems/invalid-onboarding-topic";
+    private const string InvalidAnswersType = "https://runcoach.app/problems/invalid-onboarding-answers";
+    private const string PlanGenerationFailedType = "https://runcoach.app/problems/onboarding-plan-generation-failed";
+    private const string StateUnavailableType = "https://runcoach.app/problems/onboarding-state-unavailable";
 
     /// <summary>POST /api/v1/onboarding/turns — submit a single onboarding turn.</summary>
     /// <remarks>
@@ -208,6 +211,88 @@ public sealed partial class OnboardingController(
         return Ok(BuildStateDto(view));
     }
 
+    /// <summary>POST /api/v1/onboarding/answers — submit structured onboarding answers (form-first intake).</summary>
+    /// <remarks>
+    /// The deterministic, form-first intake (DEC-086 D1). Validates the submitted topics, dispatches a
+    /// <see cref="SubmitStructuredAnswers"/> command to <see cref="SubmitStructuredAnswersHandler"/>
+    /// (one <see cref="AnswerCaptured"/> per topic, gate, inline plan generation — no LLM call), then
+    /// returns the reloaded onboarding view. When the completion gate is satisfied the response carries
+    /// the generated plan id and <c>isComplete = true</c>; otherwise it reflects partial progress and
+    /// the client stays on the form (<c>GET /state</c> remains the resume contract).
+    /// </remarks>
+    [HttpPost("answers")]
+    [Microsoft.AspNetCore.Antiforgery.RequireAntiforgeryToken]
+    [ProducesResponseType(typeof(OnboardingStateDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> SubmitAnswers(
+        [FromBody] SubmitStructuredAnswersRequestDto request,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryGetUserId(out var userId))
+        {
+            return MissingUserClaim();
+        }
+
+        // Deterministic validation of untrusted input before any transaction opens. The loosened wire
+        // DTOs bind without throwing, so an out-of-range numeric surfaces here as a 400 rather than an
+        // uncatchable 500 during model binding.
+        if (!SubmitStructuredAnswersRequestMapper.TryMap(request, userId, out var command, out var validationError))
+        {
+            return Problem(
+                type: InvalidAnswersType,
+                title: "The submitted onboarding answers are invalid.",
+                detail: validationError,
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        try
+        {
+            _ = await bus
+                .InvokeForTenantAsync<SubmitStructuredAnswersResult>(userId.ToString(), command!, ct)
+                .ConfigureAwait(false);
+        }
+        catch (OnboardingAlreadyCompleteException ex)
+        {
+            LogAlreadyComplete(logger, ex.UserId);
+            return Problem(
+                type: AlreadyCompleteType,
+                title: "Onboarding is already complete.",
+                detail: "Regenerate your plan via Settings → Plan instead of resubmitting the onboarding form.",
+                statusCode: StatusCodes.Status409Conflict);
+        }
+        catch (PlanGenerationRejectedException ex)
+        {
+            // The gate was satisfied but the generated plan failed validation (F3 / DEC-082). Wolverine
+            // aborted the transaction — nothing staged, the form is re-submittable. Surface a handled 422
+            // with a retry affordance rather than a 500 so monitoring sees no unhandled exception.
+            LogPlanGenerationRejected(logger, userId, ex.Violation);
+            return Problem(
+                type: PlanGenerationFailedType,
+                title: "We couldn't build a plan from your answers.",
+                detail: "Please submit again.",
+                statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+
+        // Reload the committed projection so the response reflects authoritative state (mirrors
+        // ReviseAnswer). The handler always bootstraps + appends, so the view must exist post-commit.
+        await using var session = store.LightweightSession(userId.ToString());
+        var view = await session.LoadAsync<OnboardingView>(userId, ct).ConfigureAwait(false);
+        if (view is null)
+        {
+            LogAnswersStateUnavailable(logger, userId);
+            return Problem(
+                type: StateUnavailableType,
+                title: "Onboarding state could not be read after submission.",
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+
+        return Ok(BuildStateDto(view));
+    }
+
     private static OnboardingStateDto BuildStateDto(OnboardingView view)
     {
         var (completed, total) = OnboardingCompletionGate.Progress(view);
@@ -239,6 +324,12 @@ public sealed partial class OnboardingController(
         Level = LogLevel.Warning,
         Message = "Plan generation rejected during onboarding completion: UserId={UserId} Violation={Violation}")]
     private static partial void LogPlanGenerationRejected(ILogger logger, Guid userId, MacroPlanOutputValidationViolation violation);
+
+    [LoggerMessage(
+        EventId = 3,
+        Level = LogLevel.Error,
+        Message = "Onboarding view was null after a successful structured-answers submission: UserId={UserId}")]
+    private static partial void LogAnswersStateUnavailable(ILogger logger, Guid userId);
 
     private bool TryGetUserId(out Guid userId)
     {

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingController.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/OnboardingController.cs
@@ -14,7 +14,8 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding;
 
 /// <summary>
 /// Slice 1 onboarding endpoints — submit a turn, read current state, revise an
-/// answer. Per Slice 1 § Unit 1 / DEC-055 every state-changing route is gated
+/// answer, and submit structured form answers. Per Slice 1 § Unit 1 / DEC-055
+/// every state-changing route is gated
 /// by both <see cref="AuthPolicies.CookieOrBearer"/> and
 /// <see cref="Microsoft.AspNetCore.Antiforgery.RequireAntiforgeryTokenAttribute"/>;
 /// the read endpoint requires auth but no antiforgery token (idempotent GETs

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitStructuredAnswers.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitStructuredAnswers.cs
@@ -1,0 +1,38 @@
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+namespace RunCoach.Api.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Wolverine command dispatched by <c>OnboardingController.SubmitAnswers</c> for the form-first
+/// onboarding intake (DEC-086 D1). Carries the authenticated user's id (the per-user onboarding
+/// stream identity), the client-supplied idempotency key, and the already-validated canonical
+/// answer records for each submitted topic. Per DP-2 the matching handler is
+/// <see cref="SubmitStructuredAnswersHandler"/> — a plain static Wolverine handler (no
+/// <c>[AggregateHandler]</c> attribute) that appends one whole-record <see cref="AnswerCaptured"/>
+/// per present slot, evaluates the deterministic completion gate, and runs the existing inline
+/// plan-generation terminal branch — all through a single Marten <c>IDocumentSession</c>, with no
+/// onboarding-time LLM call.
+/// </summary>
+/// <remarks>
+/// The slots carry the canonical <c>*Answer</c> records rather than the loosened wire input DTOs:
+/// the controller performs deterministic validation and constructs these records (whose <c>init</c>
+/// accessors enforce numeric ranges) before dispatch, so an invalid submission is rejected with a
+/// 400 before any transaction opens.
+/// </remarks>
+/// <param name="UserId">The authenticated runner's id; doubles as the onboarding stream id (DEC-047).</param>
+/// <param name="IdempotencyKey">Client-generated idempotency key; the handler short-circuits duplicates via <c>IIdempotencyStore.SeenAsync</c>.</param>
+/// <param name="PrimaryGoal">Validated PrimaryGoal answer, or null if not submitted.</param>
+/// <param name="TargetEvent">Validated TargetEvent answer, or null.</param>
+/// <param name="CurrentFitness">Validated CurrentFitness answer, or null.</param>
+/// <param name="WeeklySchedule">Validated WeeklySchedule answer, or null.</param>
+/// <param name="InjuryHistory">Validated InjuryHistory answer, or null.</param>
+/// <param name="Preferences">Validated Preferences answer, or null.</param>
+public sealed record SubmitStructuredAnswers(
+    Guid UserId,
+    Guid IdempotencyKey,
+    PrimaryGoalAnswer? PrimaryGoal,
+    TargetEventAnswer? TargetEvent,
+    CurrentFitnessAnswer? CurrentFitness,
+    WeeklyScheduleAnswer? WeeklySchedule,
+    InjuryHistoryAnswer? InjuryHistory,
+    PreferencesAnswer? Preferences);

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitStructuredAnswersHandler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitStructuredAnswersHandler.cs
@@ -1,0 +1,242 @@
+using System.Text.Json;
+using Marten;
+using RunCoach.Api.Infrastructure;
+using RunCoach.Api.Infrastructure.Idempotency;
+using RunCoach.Api.Modules.Training.Plan;
+
+namespace RunCoach.Api.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Wolverine static command handler for <see cref="SubmitStructuredAnswers"/> — the deterministic,
+/// form-first onboarding intake (DEC-086 D1 / DP-2). Like <see cref="OnboardingTurnHandler"/> it is
+/// dispatched via Wolverine's plain static-handler convention (no <c>[AggregateHandler]</c>
+/// attribute): it injects <see cref="IDocumentSession"/> directly, loads
+/// <see cref="OnboardingView"/> via <c>session.LoadAsync</c>, and stages every event on that one
+/// session, which Wolverine's transactional middleware commits atomically — no
+/// <c>SaveChangesAsync</c> in the handler body.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike the turn handler there is <b>no LLM call</b>. The already-validated answer records are
+/// appended straight to the stream as whole-record <see cref="AnswerCaptured"/> events
+/// (<c>Confidence = 1.0</c>), exactly as the deterministic <c>ReviseAnswer</c> escape hatch does.
+/// The completion gate is the sole plan-generation authority (there is no LLM <c>ReadyForPlan</c>
+/// signal to AND against).
+/// </para>
+/// <para>
+/// Flow: (1) idempotency short-circuit; (2) bootstrap the stream via
+/// <see cref="MartenEventStreamExtensions.StartStreamOrAppendAsync{TAggregate}"/> keyed on physical
+/// stream existence (onboarding and conversation share one per-user stream — a raw
+/// <c>StartStream</c> would collide); (3) append one <see cref="AnswerCaptured"/> per submitted
+/// topic and mirror each onto a working view; (4) if
+/// <see cref="OnboardingCompletionGate.IsSatisfied(OnboardingView)"/>, run the existing inline
+/// plan-generation terminal branch and append <see cref="PlanLinkedToUser"/> +
+/// <see cref="OnboardingCompleted"/>; (5) record the idempotency marker last. Any failure (e.g. a
+/// rejected generated plan) propagates so Wolverine aborts the transaction — nothing staged, the
+/// form is re-submittable.
+/// </para>
+/// </remarks>
+public sealed partial class SubmitStructuredAnswersHandler
+{
+    // The type is a stateless logical handler container: Wolverine codegen emits a non-static
+    // handler stub that calls the static Handle method, and ILogger<SubmitStructuredAnswersHandler>
+    // needs a non-static type argument. The private constructor prevents instantiation in test code.
+    private SubmitStructuredAnswersHandler()
+    {
+    }
+
+    /// <summary>
+    /// Wolverine command handler. Stages every event + idempotency marker on <paramref name="session"/>;
+    /// Wolverine's transactional middleware commits them atomically after the handler returns.
+    /// </summary>
+    /// <param name="cmd">The submit-structured-answers command (validated by the controller).</param>
+    /// <param name="session">Marten session bracketed by Wolverine's transactional middleware.</param>
+    /// <param name="idempotency">Idempotency store backed by the same <paramref name="session"/>.</param>
+    /// <param name="planGen">Plan generation orchestrator (six-call macro/meso/micro chain).</param>
+    /// <param name="time">Time provider for event timestamps.</param>
+    /// <param name="logger">Logger.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The handler's terminal decision (whether a plan was generated + its id), memoized for idempotent replay.</returns>
+    public static async Task<SubmitStructuredAnswersResult> Handle(
+        SubmitStructuredAnswers cmd,
+        IDocumentSession session,
+        IIdempotencyStore idempotency,
+        IPlanGenerationService planGen,
+        TimeProvider time,
+        ILogger<SubmitStructuredAnswersHandler> logger,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(cmd);
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(idempotency);
+        ArgumentNullException.ThrowIfNull(planGen);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        // (1) idempotency short-circuit: on hit return the byte-identical prior result, append nothing.
+        var prior = await idempotency
+            .SeenAsync<SubmitStructuredAnswersResult>(cmd.IdempotencyKey, ct)
+            .ConfigureAwait(false);
+        if (prior is not null)
+        {
+            LogIdempotentReplay(logger, cmd.IdempotencyKey, cmd.UserId);
+            return prior;
+        }
+
+        var streamId = cmd.UserId;
+        var now = time.GetUtcNow();
+
+        var view = await session
+            .LoadAsync<OnboardingView>(streamId, ct)
+            .ConfigureAwait(false);
+
+        if (view is null)
+        {
+            // Bootstrap on physical stream existence (a runner who chatted before onboarding already
+            // has the shared per-user stream, so a raw StartStream would collide).
+            await session
+                .StartStreamOrAppendAsync<OnboardingView>(streamId, new OnboardingStarted(streamId, now), ct)
+                .ConfigureAwait(false);
+        }
+        else if (view.Status == OnboardingStatus.Completed)
+        {
+            // Re-submitting the form after completion would generate a second plan. Reject it as a
+            // protocol violation the controller maps to a 409 (regeneration goes through Settings).
+            throw new OnboardingAlreadyCompleteException(cmd.UserId);
+        }
+
+        // Working copy so the completion gate sees the in-flight state without waiting for Marten to
+        // materialize the projection mid-handler.
+        var working = view ?? CreateBootstrapView(streamId, now);
+
+        var topicsCaptured = 0;
+
+        if (cmd.PrimaryGoal is not null)
+        {
+            AppendAnswer(session, streamId, OnboardingTopic.PrimaryGoal, cmd.PrimaryGoal, now);
+            working.PrimaryGoal = cmd.PrimaryGoal;
+
+            // Mirror both projections: a non-racing goal clears any stale target event so the working
+            // view and the materialized projections agree.
+            if (cmd.PrimaryGoal.Goal != Models.PrimaryGoal.RaceTraining)
+            {
+                working.TargetEvent = null;
+            }
+
+            ClearClarification(working, OnboardingTopic.PrimaryGoal);
+            topicsCaptured++;
+        }
+
+        if (cmd.TargetEvent is not null)
+        {
+            AppendAnswer(session, streamId, OnboardingTopic.TargetEvent, cmd.TargetEvent, now);
+            working.TargetEvent = cmd.TargetEvent;
+            ClearClarification(working, OnboardingTopic.TargetEvent);
+            topicsCaptured++;
+        }
+
+        if (cmd.CurrentFitness is not null)
+        {
+            AppendAnswer(session, streamId, OnboardingTopic.CurrentFitness, cmd.CurrentFitness, now);
+            working.CurrentFitness = cmd.CurrentFitness;
+            ClearClarification(working, OnboardingTopic.CurrentFitness);
+            topicsCaptured++;
+        }
+
+        if (cmd.WeeklySchedule is not null)
+        {
+            AppendAnswer(session, streamId, OnboardingTopic.WeeklySchedule, cmd.WeeklySchedule, now);
+            working.WeeklySchedule = cmd.WeeklySchedule;
+            ClearClarification(working, OnboardingTopic.WeeklySchedule);
+            topicsCaptured++;
+        }
+
+        if (cmd.InjuryHistory is not null)
+        {
+            AppendAnswer(session, streamId, OnboardingTopic.InjuryHistory, cmd.InjuryHistory, now);
+            working.InjuryHistory = cmd.InjuryHistory;
+            ClearClarification(working, OnboardingTopic.InjuryHistory);
+            topicsCaptured++;
+        }
+
+        if (cmd.Preferences is not null)
+        {
+            AppendAnswer(session, streamId, OnboardingTopic.Preferences, cmd.Preferences, now);
+            working.Preferences = cmd.Preferences;
+            ClearClarification(working, OnboardingTopic.Preferences);
+            topicsCaptured++;
+        }
+
+        // Terminal branch — the deterministic gate is the sole plan-generation authority (no LLM
+        // ReadyForPlan signal in the form flow). Plan generation runs INLINE on this same session.
+        Guid? planId = null;
+        if (OnboardingCompletionGate.IsSatisfied(working))
+        {
+            var newPlanId = Guid.NewGuid();
+            LogTerminalBranch(logger, cmd.UserId, newPlanId);
+
+            var planEvents = await planGen
+                .GeneratePlanAsync(working, cmd.UserId, newPlanId, intent: null, previousPlanId: null, ct)
+                .ConfigureAwait(false);
+
+            session.Events.StartStream<RunCoach.Api.Modules.Training.Plan.Models.PlanProjectionDto>(
+                newPlanId,
+                planEvents.ToEvents().ToArray());
+            session.Events.Append(streamId, new PlanLinkedToUser(cmd.UserId, newPlanId));
+            session.Events.Append(streamId, new OnboardingCompleted(newPlanId, now));
+            planId = newPlanId;
+        }
+
+        var result = new SubmitStructuredAnswersResult(planId is not null, planId, topicsCaptured);
+
+        // Record the idempotency marker LAST so the recorded result matches what the caller receives.
+        idempotency.Record(cmd.IdempotencyKey, result);
+
+        return result;
+    }
+
+    private static void AppendAnswer<T>(
+        IDocumentSession session, Guid streamId, OnboardingTopic topic, T record, DateTimeOffset now)
+        where T : class
+    {
+        // Captured-answer payloads stay default-cased (PascalCase) because both inline projections
+        // read them back via JsonDocument.Deserialize<T>() with the server-default casing; they never
+        // reach the wire. This is the same construction ReviseAnswer / ExtractAnswer use.
+        var payload = JsonSerializer.SerializeToDocument(record);
+        session.Events.Append(streamId, new AnswerCaptured(topic, payload, Confidence: 1.0, CapturedAt: now));
+    }
+
+    private static void ClearClarification(OnboardingView working, OnboardingTopic topic)
+    {
+        // Capturing an answer clears any outstanding clarification on that topic, mirroring the
+        // projection's AnswerCaptured apply so the working gate check agrees with the materialized view.
+        if (working.OutstandingClarifications.Contains(topic))
+        {
+            working.OutstandingClarifications = working.OutstandingClarifications
+                .Where(t => t != topic)
+                .ToArray();
+        }
+    }
+
+    private static OnboardingView CreateBootstrapView(Guid streamId, DateTimeOffset now) => new()
+    {
+        Id = streamId,
+        UserId = streamId,
+        Status = OnboardingStatus.InProgress,
+        OnboardingStartedAt = now,
+        OutstandingClarifications = Array.Empty<OnboardingTopic>(),
+        Version = 1,
+    };
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Information,
+        Message = "Structured onboarding answers idempotent replay key={IdempotencyKey} user={UserId}")]
+    private static partial void LogIdempotentReplay(ILogger logger, Guid idempotencyKey, Guid userId);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Information,
+        Message = "Structured onboarding answers terminal branch user={UserId} planId={PlanId}")]
+    private static partial void LogTerminalBranch(ILogger logger, Guid userId, Guid planId);
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitStructuredAnswersHandler.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitStructuredAnswersHandler.cs
@@ -39,7 +39,7 @@ namespace RunCoach.Api.Modules.Coaching.Onboarding;
 public sealed partial class SubmitStructuredAnswersHandler
 {
     // The type is a stateless logical handler container: Wolverine codegen emits a non-static
-    // handler stub that calls the static Handle method, and ILogger<SubmitStructuredAnswersHandler>
+    // handler stub that calls the static Handle method, and `ILogger<SubmitStructuredAnswersHandler>`
     // needs a non-static type argument. The private constructor prevents instantiation in test code.
     private SubmitStructuredAnswersHandler()
     {
@@ -200,7 +200,7 @@ public sealed partial class SubmitStructuredAnswersHandler
         where T : class
     {
         // Captured-answer payloads stay default-cased (PascalCase) because both inline projections
-        // read them back via JsonDocument.Deserialize<T>() with the server-default casing; they never
+        // read them back via `JsonDocument.Deserialize<T>()` with the server-default casing; they never
         // reach the wire. This is the same construction ReviseAnswer / ExtractAnswer use.
         var payload = JsonSerializer.SerializeToDocument(record);
         session.Events.Append(streamId, new AnswerCaptured(topic, payload, Confidence: 1.0, CapturedAt: now));

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitStructuredAnswersRequestMapper.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitStructuredAnswersRequestMapper.cs
@@ -1,0 +1,317 @@
+using System.Globalization;
+using System.Xml;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+namespace RunCoach.Api.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Deterministic validator/mapper from the loosened wire request
+/// (<see cref="SubmitStructuredAnswersRequestDto"/>) to the validated
+/// <see cref="SubmitStructuredAnswers"/> command (DU-1 FR-1.8). This is the deterministic
+/// replacement for the retired LLM <c>OnboardingTurnOutputValidator</c>.
+/// </summary>
+/// <remarks>
+/// The loosened input DTOs bind without throwing, so numeric-range violations do not surface as an
+/// uncatchable HTTP 500 during model binding. Validation is layered: explicit guards for the rules
+/// the answer records cannot express (enum definedness, ISO date/duration parseability, the
+/// TargetEvent ⇒ RaceTraining cross-field rule), then construction of the canonical answer records
+/// whose <c>init</c> accessors enforce the numeric ranges — an <see cref="ArgumentException"/> from
+/// any of those is caught and reported as a validation failure. The controller maps a
+/// <see langword="false"/> result to a 400 <c>ProblemDetails</c>.
+/// </remarks>
+public static class SubmitStructuredAnswersRequestMapper
+{
+    // Distances above this are physically implausible. Combined with double.IsFinite this closes the
+    // hole where a JSON literal overflowing double range (e.g. 1e400) deserializes to
+    // double.PositiveInfinity, slips past the answer records' one-sided lower-bound guards, and then
+    // crashes JsonSerializer.SerializeToDocument in the handler as an uncatchable 500 (the exact
+    // failure mode FR-1.8 exists to prevent).
+    private const double MaxDistanceKm = 100_000;
+
+    // A finish/race time longer than this is garbage; the longest multi-day ultras are well under it.
+    private static readonly TimeSpan MaxDuration = TimeSpan.FromDays(60);
+
+    /// <summary>
+    /// Validates <paramref name="request"/> and, on success, builds the
+    /// <see cref="SubmitStructuredAnswers"/> command carrying the canonical answer records.
+    /// </summary>
+    /// <param name="request">The client request payload.</param>
+    /// <param name="userId">The authenticated runner's id.</param>
+    /// <param name="command">The built command when validation succeeds; otherwise <see langword="null"/>.</param>
+    /// <param name="error">A human-readable validation error when validation fails; otherwise <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> when the request is valid and <paramref name="command"/> is populated.</returns>
+    public static bool TryMap(
+        SubmitStructuredAnswersRequestDto request,
+        Guid userId,
+        out SubmitStructuredAnswers? command,
+        out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        command = null;
+        error = null;
+
+        if (request.IdempotencyKey == Guid.Empty)
+        {
+            error = "IdempotencyKey must be a non-empty GUID.";
+            return false;
+        }
+
+        var anyTopic = request.PrimaryGoal is not null
+            || request.TargetEvent is not null
+            || request.CurrentFitness is not null
+            || request.WeeklySchedule is not null
+            || request.InjuryHistory is not null
+            || request.Preferences is not null;
+        if (!anyTopic)
+        {
+            error = "At least one topic answer must be provided.";
+            return false;
+        }
+
+        try
+        {
+            if (!TryMapPrimaryGoal(request.PrimaryGoal, out var primaryGoal, out error))
+            {
+                return false;
+            }
+
+            // A target event is only meaningful for a race-training primary goal submitted alongside
+            // it. Checked AFTER the goal enum is validated so an undefined goal reports the accurate
+            // "not a recognized goal" error rather than this cross-field message. Enforcing
+            // co-submission keeps this a pure, stateless check and prevents stale race metadata
+            // surviving on the projection (the single-page form always co-submits both).
+            if (request.TargetEvent is not null
+                && (primaryGoal is null || primaryGoal.Goal != PrimaryGoal.RaceTraining))
+            {
+                error = "TargetEvent is only valid when PrimaryGoal is RaceTraining in the same submission.";
+                return false;
+            }
+
+            if (!TryMapTargetEvent(request.TargetEvent, out var targetEvent, out error)
+                || !TryMapCurrentFitness(request.CurrentFitness, out var currentFitness, out error)
+                || !TryMapPreferences(request.Preferences, out var preferences, out error))
+            {
+                return false;
+            }
+
+            var weeklySchedule = MapWeeklySchedule(request.WeeklySchedule);
+            var injuryHistory = MapInjuryHistory(request.InjuryHistory);
+
+            command = new SubmitStructuredAnswers(
+                userId,
+                request.IdempotencyKey,
+                primaryGoal,
+                targetEvent,
+                currentFitness,
+                weeklySchedule,
+                injuryHistory,
+                preferences);
+            return true;
+        }
+        catch (ArgumentException ex)
+        {
+            // A canonical answer record's init accessor rejected an out-of-range numeric value
+            // (e.g. DistanceKm <= 0, MaxRunDaysPerWeek outside 1-7). Report as a validation failure
+            // rather than letting it propagate as a 500.
+            command = null;
+            error = ex.Message;
+            return false;
+        }
+    }
+
+    private static bool TryMapPrimaryGoal(PrimaryGoalInputDto? input, out PrimaryGoalAnswer? answer, out string? error)
+    {
+        answer = null;
+        error = null;
+        if (input is null)
+        {
+            return true;
+        }
+
+        if (!Enum.IsDefined(input.Goal))
+        {
+            error = $"PrimaryGoal.Goal value '{(int)input.Goal}' is not a recognized goal.";
+            return false;
+        }
+
+        answer = new PrimaryGoalAnswer
+        {
+            Goal = input.Goal,
+            Description = input.Description ?? string.Empty,
+        };
+        return true;
+    }
+
+    private static bool TryMapTargetEvent(TargetEventInputDto? input, out TargetEventAnswer? answer, out string? error)
+    {
+        answer = null;
+        error = null;
+        if (input is null)
+        {
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(input.EventName))
+        {
+            error = "TargetEvent.EventName is required.";
+            return false;
+        }
+
+        if (!IsSaneDistanceKm(input.DistanceKm))
+        {
+            error = "TargetEvent.DistanceKm must be a finite distance in kilometers within a sane range.";
+            return false;
+        }
+
+        if (!DateOnly.TryParseExact(input.EventDateIso, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
+        {
+            error = "TargetEvent.EventDateIso must be an ISO-8601 calendar date (yyyy-MM-dd).";
+            return false;
+        }
+
+        if (!TryNormalizeOptionalDuration(input.TargetFinishTimeIso, out var targetFinish))
+        {
+            error = "TargetEvent.TargetFinishTimeIso must be an ISO-8601 duration (e.g. PT1H45M30S).";
+            return false;
+        }
+
+        answer = new TargetEventAnswer
+        {
+            EventName = input.EventName,
+            DistanceKm = input.DistanceKm,
+            EventDateIso = input.EventDateIso,
+            TargetFinishTimeIso = targetFinish,
+        };
+        return true;
+    }
+
+    private static bool TryMapCurrentFitness(CurrentFitnessInputDto? input, out CurrentFitnessAnswer? answer, out string? error)
+    {
+        answer = null;
+        error = null;
+        if (input is null)
+        {
+            return true;
+        }
+
+        if (!IsSaneDistanceKm(input.TypicalWeeklyKm)
+            || !IsSaneDistanceKm(input.LongestRecentRunKm)
+            || (input.RecentRaceDistanceKm is { } recentRaceDistance && !IsSaneDistanceKm(recentRaceDistance)))
+        {
+            error = "CurrentFitness distances must be finite values in kilometers within a sane range.";
+            return false;
+        }
+
+        if (!TryNormalizeOptionalDuration(input.RecentRaceTimeIso, out var recentRaceTime))
+        {
+            error = "CurrentFitness.RecentRaceTimeIso must be an ISO-8601 duration (e.g. PT0H45M30S).";
+            return false;
+        }
+
+        answer = new CurrentFitnessAnswer
+        {
+            TypicalWeeklyKm = input.TypicalWeeklyKm,
+            LongestRecentRunKm = input.LongestRecentRunKm,
+            RecentRaceDistanceKm = input.RecentRaceDistanceKm,
+            RecentRaceTimeIso = recentRaceTime,
+            Description = input.Description ?? string.Empty,
+        };
+        return true;
+    }
+
+    private static bool TryMapPreferences(PreferencesInputDto? input, out PreferencesAnswer? answer, out string? error)
+    {
+        answer = null;
+        error = null;
+        if (input is null)
+        {
+            return true;
+        }
+
+        if (!Enum.IsDefined(input.PreferredUnits))
+        {
+            error = $"Preferences.PreferredUnits value '{(int)input.PreferredUnits}' is not a recognized unit.";
+            return false;
+        }
+
+        answer = new PreferencesAnswer
+        {
+            PreferredUnits = input.PreferredUnits,
+            PreferTrail = input.PreferTrail,
+            ComfortableWithIntensity = input.ComfortableWithIntensity,
+            Description = input.Description ?? string.Empty,
+        };
+        return true;
+    }
+
+    private static WeeklyScheduleAnswer? MapWeeklySchedule(WeeklyScheduleInputDto? input)
+    {
+        // Numeric ranges (MaxRunDaysPerWeek 1-7, TypicalSessionMinutes > 0) are enforced by the
+        // record's init accessors; a violation throws ArgumentException, caught by TryMap.
+        if (input is null)
+        {
+            return null;
+        }
+
+        return new WeeklyScheduleAnswer
+        {
+            MaxRunDaysPerWeek = input.MaxRunDaysPerWeek,
+            TypicalSessionMinutes = input.TypicalSessionMinutes,
+            Monday = input.Monday,
+            Tuesday = input.Tuesday,
+            Wednesday = input.Wednesday,
+            Thursday = input.Thursday,
+            Friday = input.Friday,
+            Saturday = input.Saturday,
+            Sunday = input.Sunday,
+            Description = input.Description ?? string.Empty,
+        };
+    }
+
+    private static InjuryHistoryAnswer? MapInjuryHistory(InjuryHistoryInputDto? input)
+    {
+        if (input is null)
+        {
+            return null;
+        }
+
+        return new InjuryHistoryAnswer
+        {
+            HasActiveInjury = input.HasActiveInjury,
+            ActiveInjuryDescription = input.ActiveInjuryDescription ?? string.Empty,
+            PastInjurySummary = input.PastInjurySummary ?? string.Empty,
+        };
+    }
+
+    private static bool TryNormalizeOptionalDuration(string? value, out string? normalized)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            normalized = null;
+            return true;
+        }
+
+        try
+        {
+            // XmlConvert.ToTimeSpan (xsd:duration) permissively accepts a leading '-' and arbitrarily
+            // large components, so a negative or absurd duration parses without throwing. Reject those:
+            // a race/finish time must be non-negative and within a sane bound.
+            var duration = XmlConvert.ToTimeSpan(value);
+            if (duration < TimeSpan.Zero || duration > MaxDuration)
+            {
+                normalized = null;
+                return false;
+            }
+
+            normalized = value;
+            return true;
+        }
+        catch (FormatException)
+        {
+            normalized = null;
+            return false;
+        }
+    }
+
+    private static bool IsSaneDistanceKm(double value) => double.IsFinite(value) && value <= MaxDistanceKm;
+}

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitStructuredAnswersRequestMapper.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitStructuredAnswersRequestMapper.cs
@@ -306,8 +306,11 @@ public static class SubmitStructuredAnswersRequestMapper
             normalized = value;
             return true;
         }
-        catch (FormatException)
+        catch (Exception ex) when (ex is FormatException or OverflowException)
         {
+            // OverflowException: XmlConvert.ToTimeSpan does checked arithmetic and throws for a
+            // syntactically valid but numerically huge xsd:duration (e.g. "P1000000000D") — the
+            // duration twin of the 1e400→Infinity distance hole. Reject cleanly instead of bubbling a 500.
             normalized = null;
             return false;
         }

--- a/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitStructuredAnswersResult.cs
+++ b/backend/src/RunCoach.Api/Modules/Coaching/Onboarding/SubmitStructuredAnswersResult.cs
@@ -1,0 +1,17 @@
+namespace RunCoach.Api.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Result returned by <see cref="SubmitStructuredAnswersHandler"/> to
+/// <c>OnboardingController.SubmitAnswers</c> and memoized by
+/// <see cref="Infrastructure.Idempotency.IIdempotencyStore"/> so a duplicate submission replays
+/// the same outcome without re-appending events or generating a second plan. The controller reads
+/// the authoritative onboarding state from a post-commit projection reload; this result carries
+/// only the handler's terminal decision for logging and idempotent replay.
+/// </summary>
+/// <param name="PlanGenerated">True when the completion gate was satisfied and a plan was generated this submission (or on the memoized original submission).</param>
+/// <param name="PlanId">The generated plan id when <paramref name="PlanGenerated"/> is true; otherwise null.</param>
+/// <param name="TopicsCaptured">The number of topic answers appended in this submission.</param>
+public sealed record SubmitStructuredAnswersResult(
+    bool PlanGenerated,
+    Guid? PlanId,
+    int TopicsCaptured);

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingAnswersEndpointIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingAnswersEndpointIntegrationTests.cs
@@ -1,0 +1,557 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using FluentAssertions;
+using Marten;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using RunCoach.Api.Infrastructure;
+using RunCoach.Api.Modules.Coaching.Conversation;
+using RunCoach.Api.Modules.Coaching.Onboarding.Entities;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+using RunCoach.Api.Modules.Identity.Contracts;
+using RunCoach.Api.Modules.Training.Plan;
+using RunCoach.Api.Tests.Infrastructure;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Integration coverage for the deterministic form-answer origination endpoint
+/// POST /api/v1/onboarding/answers (DU-1). Drives the LIVE HTTP + Wolverine pipeline through the
+/// real <see cref="SubmitStructuredAnswersHandler"/>: the endpoint appends one whole-record
+/// <c>AnswerCaptured</c> per submitted topic, evaluates the deterministic completion gate, and runs
+/// the existing inline plan-generation terminal branch — with no onboarding-time LLM call. The
+/// assembly-swapped <see cref="StubPlanGenerationService"/> supplies the deterministic plan events,
+/// so both the Marten <c>OnboardingView</c> and the EF <see cref="RunnerOnboardingProfile"/>
+/// projections materialize end-to-end (DEC-047 / DEC-060).
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public sealed class OnboardingAnswersEndpointIntegrationTests : DbBackedIntegrationTestBase
+{
+    private const string StrongPassword = "Str0ngTestPassw0rd!";
+    private const string AntiforgeryCookieName = AuthCookieNames.Antiforgery;
+    private const string AntiforgeryRequestCookieName = AuthCookieNames.AntiforgeryRequest;
+    private const string AntiforgeryHeaderName = AuthCookieNames.AntiforgeryHeader;
+    private const string AnswersPath = "/api/v1/onboarding/answers";
+    private const string StatePath = "/api/v1/onboarding/state";
+
+    private static readonly Uri BaseUri = new("https://localhost");
+
+    public OnboardingAnswersEndpointIntegrationTests(RunCoachAppFactory factory)
+        : base(factory)
+    {
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_AllSixTopics_RaceTraining_GeneratesPlan_MaterializesBothProjections()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        var userId = await RegisterAsync(client, container, email);
+        await LoginAsync(client, container, email);
+        var request = RaceTrainingRequest(Guid.NewGuid());
+
+        // Act
+        var token = await PrimeAntiforgeryAsync(client, container);
+        var response = await PostAnswersAsync(client, token, request, ct);
+
+        // Assert — HTTP contract: completed onboarding with a linked plan.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var state = await response.Content.ReadFromJsonAsync<OnboardingStateDto>(cancellationToken: ct);
+        state.Should().NotBeNull();
+        state!.IsComplete.Should().BeTrue(because: "all required topics were submitted, satisfying the deterministic gate");
+        state.CurrentPlanId.Should().NotBeNull().And.NotBe(Guid.Empty);
+
+        // Assert — OnboardingView (Marten projection) slots equal the submitted records.
+        state.PrimaryGoal.Should().Be(new PrimaryGoalAnswer { Goal = PrimaryGoal.RaceTraining, Description = "Sub-4 marathon" });
+        state.TargetEvent!.EventName.Should().Be("Berlin Marathon");
+        state.TargetEvent.DistanceKm.Should().Be(42.2);
+        state.TargetEvent.EventDateIso.Should().Be("2026-09-27");
+        state.WeeklySchedule!.MaxRunDaysPerWeek.Should().Be(5);
+        state.WeeklySchedule.Saturday.Should().BeTrue();
+        state.Preferences!.PreferredUnits.Should().Be(PreferredUnits.Miles);
+        state.InjuryHistory!.PastInjurySummary.Should().Be("Rolled ankle 2024");
+
+        // Assert — RunnerOnboardingProfile (EF projection) materialized identically (DEC-060).
+        var profile = await LoadProfileAsync(Factory, userId, ct);
+        profile.Should().NotBeNull();
+        profile!.PrimaryGoal.Should().Be(PrimaryGoal.RaceTraining);
+        profile.TargetEvent!.EventName.Should().Be("Berlin Marathon");
+        profile.WeeklySchedule!.MaxRunDaysPerWeek.Should().Be(5);
+        profile.CurrentPlanId.Should().Be(state.CurrentPlanId);
+        profile.OnboardingCompletedAt.Should().NotBeNull();
+
+        // Assert — a plan stream was actually created at the linked id.
+        (await PlanStreamExistsAsync(Factory, userId, state.CurrentPlanId!.Value, ct))
+            .Should().BeTrue(because: "the terminal branch starts a plan stream at the linked plan id");
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_FitnessProfile_NoTargetEvent_GeneratesPlan()
+    {
+        // Arrange — general fitness needs no TargetEvent to satisfy the gate.
+        var ct = TestContext.Current.CancellationToken;
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        await RegisterAsync(client, container, email);
+        await LoginAsync(client, container, email);
+        var request = FitnessRequest(Guid.NewGuid());
+
+        // Act
+        var token = await PrimeAntiforgeryAsync(client, container);
+        var response = await PostAnswersAsync(client, token, request, ct);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var state = await response.Content.ReadFromJsonAsync<OnboardingStateDto>(cancellationToken: ct);
+        state!.IsComplete.Should().BeTrue();
+        state.CurrentPlanId.Should().NotBeNull();
+        state.TargetEvent.Should().BeNull(because: "no target event is required or submitted for general fitness");
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_IncompleteSet_GateNotSatisfied_NoPlan_StateReflectsPartial()
+    {
+        // Arrange — only two of the five required topics.
+        var ct = TestContext.Current.CancellationToken;
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        await RegisterAsync(client, container, email);
+        await LoginAsync(client, container, email);
+        var request = new SubmitStructuredAnswersRequestDto(
+            Guid.NewGuid(),
+            new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, "Stay healthy"),
+            TargetEvent: null,
+            new CurrentFitnessInputDto(30, 12, null, null, "Moderate"),
+            WeeklySchedule: null,
+            InjuryHistory: null,
+            Preferences: null);
+
+        // Act
+        var token = await PrimeAntiforgeryAsync(client, container);
+        var response = await PostAnswersAsync(client, token, request, ct);
+
+        // Assert — 200 with partial progress; no plan generated.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var state = await response.Content.ReadFromJsonAsync<OnboardingStateDto>(cancellationToken: ct);
+        state!.IsComplete.Should().BeFalse();
+        state.CurrentPlanId.Should().BeNull();
+        state.PrimaryGoal.Should().NotBeNull();
+        state.CurrentFitness.Should().NotBeNull();
+        state.WeeklySchedule.Should().BeNull();
+
+        // Assert — GET /state reflects the same partial progress (the resume contract).
+        var resumed = await GetStateAsync(client, ct);
+        resumed.IsComplete.Should().BeFalse();
+        resumed.WeeklySchedule.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_DuplicateIdempotencyKey_SinglePlan_NoDoubleAppend()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        var userId = await RegisterAsync(client, container, email);
+        await LoginAsync(client, container, email);
+        var key = Guid.NewGuid();
+        var request = RaceTrainingRequest(key);
+
+        // Act — submit twice with the SAME idempotency key.
+        var token1 = await PrimeAntiforgeryAsync(client, container);
+        var first = await PostAnswersAsync(client, token1, request, ct);
+        var firstState = await first.Content.ReadFromJsonAsync<OnboardingStateDto>(cancellationToken: ct);
+        var eventCountAfterFirst = await OnboardingStreamEventCountAsync(Factory, userId, ct);
+
+        var token2 = await PrimeAntiforgeryAsync(client, container);
+        var second = await PostAnswersAsync(client, token2, request, ct);
+        var secondState = await second.Content.ReadFromJsonAsync<OnboardingStateDto>(cancellationToken: ct);
+
+        // Assert — same plan, no new events appended on replay.
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        secondState!.CurrentPlanId.Should().Be(firstState!.CurrentPlanId, because: "a duplicate key must not generate a second plan");
+        var eventCountAfterSecond = await OnboardingStreamEventCountAsync(Factory, userId, ct);
+        eventCountAfterSecond.Should().Be(eventCountAfterFirst, because: "the idempotent replay appends nothing");
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_AlreadyComplete_Returns409()
+    {
+        // Arrange — complete onboarding first.
+        var ct = TestContext.Current.CancellationToken;
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        await RegisterAsync(client, container, email);
+        await LoginAsync(client, container, email);
+        var token1 = await PrimeAntiforgeryAsync(client, container);
+        var first = await PostAnswersAsync(client, token1, RaceTrainingRequest(Guid.NewGuid()), ct);
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Act — submit again (new key) against a completed stream.
+        var token2 = await PrimeAntiforgeryAsync(client, container);
+        var second = await PostAnswersAsync(client, token2, RaceTrainingRequest(Guid.NewGuid()), ct);
+
+        // Assert — 409, no second plan.
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_OutOfRangeNumeric_Returns400_WithoutStagingEvents()
+    {
+        // Arrange — a hostile weekly-schedule value that would trip the answer record's init validator.
+        var ct = TestContext.Current.CancellationToken;
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        var userId = await RegisterAsync(client, container, email);
+        await LoginAsync(client, container, email);
+        var request = new SubmitStructuredAnswersRequestDto(
+            Guid.NewGuid(),
+            new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, "Stay healthy"),
+            TargetEvent: null,
+            CurrentFitness: null,
+            new WeeklyScheduleInputDto(99, 45, true, false, true, false, true, false, true, "Evenings"),
+            InjuryHistory: null,
+            Preferences: null);
+
+        // Act
+        var token = await PrimeAntiforgeryAsync(client, container);
+        var response = await PostAnswersAsync(client, token, request, ct);
+
+        // Assert — clean 400 ProblemDetails, not a 500, and nothing was appended.
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await OnboardingStreamEventCountAsync(Factory, userId, ct)).Should().Be(0, because: "an invalid request is rejected before any event is appended");
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_TargetEventWithoutRaceTraining_Returns400()
+    {
+        // Arrange — a target event paired with a non-racing goal is a cross-field violation.
+        var ct = TestContext.Current.CancellationToken;
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        await RegisterAsync(client, container, email);
+        await LoginAsync(client, container, email);
+        var request = new SubmitStructuredAnswersRequestDto(
+            Guid.NewGuid(),
+            new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, "Stay healthy"),
+            new TargetEventInputDto("Berlin Marathon", 42.2, "2026-09-27", null),
+            CurrentFitness: null,
+            WeeklySchedule: null,
+            InjuryHistory: null,
+            Preferences: null);
+
+        // Act
+        var token = await PrimeAntiforgeryAsync(client, container);
+        var response = await PostAnswersAsync(client, token, request, ct);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_PresentTopicMissingRequiredField_Returns400()
+    {
+        // Arrange — a raw body with a weeklySchedule object missing its required fields. The loosened
+        // input DTO's [JsonRequired] presence enforcement must surface this as a clean 400 at model
+        // binding, never a 500.
+        var ct = TestContext.Current.CancellationToken;
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        await RegisterAsync(client, container, email);
+        await LoginAsync(client, container, email);
+        var rawBody = $"{{\"idempotencyKey\":\"{Guid.NewGuid()}\",\"weeklySchedule\":{{\"maxRunDaysPerWeek\":5}}}}";
+
+        // Act
+        var token = await PrimeAntiforgeryAsync(client, container);
+        using var request = BuildRequest(HttpMethod.Post, AnswersPath, token);
+        request.Content = new StringContent(rawBody, Encoding.UTF8, "application/json");
+        var response = await client.SendAsync(request, ct);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_PlanGenerationRejected_Returns422_NothingStaged_ThenResubmitSucceeds()
+    {
+        // Arrange — a per-test factory whose plan generation rejects the first call then succeeds.
+        var ct = TestContext.Current.CancellationToken;
+        using var rejectingFactory = Factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IPlanGenerationService>();
+                services.AddSingleton<IPlanGenerationService>(
+                    new RejectOnceThenSucceedPlanGenerationService(new StubPlanGenerationService()));
+            }));
+        var (client, container) = CreateCookieClient(rejectingFactory);
+        var email = GenerateEmail();
+        var userId = await RegisterAsync(client, container, email);
+        await LoginAsync(client, container, email);
+
+        // Act 1 — submit all six; the gate is satisfied and plan generation rejects the first call.
+        var token1 = await PrimeAntiforgeryAsync(client, container);
+        var first = await PostAnswersAsync(client, token1, RaceTrainingRequest(Guid.NewGuid()), ct);
+
+        // Assert 1 — a handled 422 (not a 500), and the whole single-submit transaction rolled back:
+        // nothing staged means no onboarding stream exists at all (DEC-080 posture).
+        first.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        (await OnboardingStreamEventCountAsync(Factory, userId, ct))
+            .Should().Be(0, because: "a terminal plan-generation rejection aborts the transaction with nothing staged");
+
+        // Act 2 — re-submit with a NEW key; plan generation now succeeds.
+        var token2 = await PrimeAntiforgeryAsync(client, container);
+        var second = await PostAnswersAsync(client, token2, RaceTrainingRequest(Guid.NewGuid()), ct);
+
+        // Assert 2 — the form is re-submittable; onboarding completes with a plan.
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        var secondState = await second.Content.ReadFromJsonAsync<OnboardingStateDto>(cancellationToken: ct);
+        secondState!.IsComplete.Should().BeTrue();
+        secondState.CurrentPlanId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_WhenConversationStreamAlreadyExists_AppendsWithoutCollision()
+    {
+        // Arrange — a runner who chatted before onboarding already has the shared per-user Marten stream
+        // (tagged ConversationView). The handler must APPEND OnboardingStarted to it, not StartStream
+        // (which would throw ExistingStreamIdCollisionException) — the PR-A #259 bootstrap fix.
+        var ct = TestContext.Current.CancellationToken;
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        var userId = await RegisterAsync(client, container, email);
+        await LoginAsync(client, container, email);
+        await PreseedConversationStreamAsync(Factory, userId, ct);
+
+        // Act
+        var token = await PrimeAntiforgeryAsync(client, container);
+        var response = await PostAnswersAsync(client, token, RaceTrainingRequest(Guid.NewGuid()), ct);
+
+        // Assert — no collision; onboarding completes over the pre-existing shared stream.
+        response.StatusCode.Should().Be(
+            HttpStatusCode.OK,
+            because: "the handler appends OnboardingStarted to the existing shared stream instead of colliding on StartStream");
+        var state = await response.Content.ReadFromJsonAsync<OnboardingStateDto>(cancellationToken: ct);
+        state!.IsComplete.Should().BeTrue();
+        state.CurrentPlanId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_PartialThenCompleting_MergesPriorTopics_AndGeneratesPlan()
+    {
+        // Arrange
+        var ct = TestContext.Current.CancellationToken;
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        await RegisterAsync(client, container, email);
+        await LoginAsync(client, container, email);
+
+        // Act 1 — submit a subset (goal + fitness + weekly schedule); the gate is not yet satisfied.
+        var token1 = await PrimeAntiforgeryAsync(client, container);
+        var partial = new SubmitStructuredAnswersRequestDto(
+            Guid.NewGuid(),
+            new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, "Stay healthy"),
+            TargetEvent: null,
+            new CurrentFitnessInputDto(30, 12, null, null, "Moderate"),
+            new WeeklyScheduleInputDto(4, 45, true, false, true, false, true, false, true, "Evenings"),
+            InjuryHistory: null,
+            Preferences: null);
+        var first = await PostAnswersAsync(client, token1, partial, ct);
+        var firstState = await first.Content.ReadFromJsonAsync<OnboardingStateDto>(cancellationToken: ct);
+        firstState!.IsComplete.Should().BeFalse();
+        firstState.CurrentPlanId.Should().BeNull();
+
+        // Act 2 — submit the REMAINING topics with a NEW key; the merge completes onboarding.
+        var token2 = await PrimeAntiforgeryAsync(client, container);
+        var rest = new SubmitStructuredAnswersRequestDto(
+            Guid.NewGuid(),
+            PrimaryGoal: null,
+            TargetEvent: null,
+            CurrentFitness: null,
+            WeeklySchedule: null,
+            new InjuryHistoryInputDto(false, string.Empty, "none"),
+            new PreferencesInputDto(PreferredUnits.Kilometers, false, true, string.Empty));
+        var second = await PostAnswersAsync(client, token2, rest, ct);
+
+        // Assert — the first submission's topics survived onto the merged view; onboarding completes.
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        var secondState = await second.Content.ReadFromJsonAsync<OnboardingStateDto>(cancellationToken: ct);
+        secondState!.IsComplete.Should().BeTrue();
+        secondState.CurrentPlanId.Should().NotBeNull();
+        secondState.PrimaryGoal.Should().NotBeNull(because: "the earlier submission's topics survived the merge");
+        secondState.CurrentFitness.Should().NotBeNull();
+        secondState.WeeklySchedule.Should().NotBeNull();
+        secondState.InjuryHistory.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_OverflowingDistanceLiteral_Returns400_NotServerError()
+    {
+        // Arrange — a JSON numeric literal that overflows double range deserializes to +Infinity, which
+        // slips past the answer record's one-sided guard. The mapper must reject it as a clean 400, never
+        // crash serialization as a 500 (the FR-1.8 failure mode).
+        var ct = TestContext.Current.CancellationToken;
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        await RegisterAsync(client, container, email);
+        await LoginAsync(client, container, email);
+        var rawBody =
+            $"{{\"idempotencyKey\":\"{Guid.NewGuid()}\",\"currentFitness\":{{\"typicalWeeklyKm\":1e400,\"longestRecentRunKm\":12,\"recentRaceDistanceKm\":null,\"recentRaceTimeIso\":null,\"description\":\"x\"}}}}";
+
+        // Act
+        var token = await PrimeAntiforgeryAsync(client, container);
+        using var request = BuildRequest(HttpMethod.Post, AnswersPath, token);
+        request.Content = new StringContent(rawBody, Encoding.UTF8, "application/json");
+        var response = await client.SendAsync(request, ct);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    /// <inheritdoc/>
+    public override async ValueTask DisposeAsync()
+    {
+        // Onboarding + plan streams live in Marten's runcoach_events schema, which Respawn skips.
+        await Factory.Services.ResetAllMartenDataAsync();
+        await base.DisposeAsync();
+    }
+
+    private static SubmitStructuredAnswersRequestDto RaceTrainingRequest(Guid key) => new(
+        key,
+        new PrimaryGoalInputDto(PrimaryGoal.RaceTraining, "Sub-4 marathon"),
+        new TargetEventInputDto("Berlin Marathon", 42.2, "2026-09-27", "PT3H55M0S"),
+        new CurrentFitnessInputDto(45, 20, 21.1, "PT1H45M0S", "Feeling strong"),
+        new WeeklyScheduleInputDto(5, 60, true, false, true, false, true, true, false, "Evenings only"),
+        new InjuryHistoryInputDto(false, string.Empty, "Rolled ankle 2024"),
+        new PreferencesInputDto(PreferredUnits.Miles, true, true, "Prefer mornings"));
+
+    private static SubmitStructuredAnswersRequestDto FitnessRequest(Guid key) => new(
+        key,
+        new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, "Stay healthy"),
+        TargetEvent: null,
+        new CurrentFitnessInputDto(30, 12, null, null, "Moderate"),
+        new WeeklyScheduleInputDto(4, 45, true, false, true, false, true, false, true, "Evenings"),
+        new InjuryHistoryInputDto(false, string.Empty, string.Empty),
+        new PreferencesInputDto(PreferredUnits.Kilometers, false, true, string.Empty));
+
+    private static async Task<RunnerOnboardingProfile?> LoadProfileAsync(RunCoachAppFactory factory, Guid userId, CancellationToken ct)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<RunCoachDbContext>();
+        var query = db.RunnerOnboardingProfiles.AsNoTracking().Where(p => p.UserId == userId);
+        return await EntityFrameworkQueryableExtensions.FirstOrDefaultAsync(query, ct);
+    }
+
+    private static async Task PreseedConversationStreamAsync(RunCoachAppFactory factory, Guid userId, CancellationToken ct)
+    {
+        // Create the runner's per-user event stream via a conversation turn (as if they chatted before
+        // onboarding), tagging the physical stream ConversationView with no onboarding events on it yet.
+        var store = factory.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        session.Events.StartStream<ConversationView>(userId, new UserMessagePosted(userId, Guid.NewGuid(), "hey coach"));
+        await session.SaveChangesAsync(ct);
+    }
+
+    private static async Task<bool> PlanStreamExistsAsync(RunCoachAppFactory factory, Guid userId, Guid planId, CancellationToken ct)
+    {
+        var store = factory.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        var state = await session.Events.FetchStreamStateAsync(planId, ct);
+        return state is not null;
+    }
+
+    private static async Task<int> OnboardingStreamEventCountAsync(RunCoachAppFactory factory, Guid userId, CancellationToken ct)
+    {
+        var store = factory.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession(userId.ToString());
+        var events = await session.Events.FetchStreamAsync(userId, token: ct);
+        return events.Count;
+    }
+
+    private static (HttpClient Client, CookieContainer Container) CreateCookieClient(
+        Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program> factory)
+    {
+        var container = new CookieContainer();
+        var client = factory.CreateDefaultClient(new CookieContainerHandler(container));
+        client.BaseAddress = BaseUri;
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        return (client, container);
+    }
+
+    private static async Task<HttpResponseMessage> PostAnswersAsync(
+        HttpClient client, string antiforgeryToken, SubmitStructuredAnswersRequestDto dto, CancellationToken ct)
+    {
+        using var request = BuildRequest(HttpMethod.Post, AnswersPath, antiforgeryToken);
+        request.Content = JsonContent.Create(dto);
+        return await client.SendAsync(request, ct);
+    }
+
+    private static async Task<OnboardingStateDto> GetStateAsync(HttpClient client, CancellationToken ct)
+    {
+        using var response = await client.GetAsync(StatePath, ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<OnboardingStateDto>(cancellationToken: ct);
+        dto.Should().NotBeNull();
+        return dto!;
+    }
+
+    private static HttpRequestMessage BuildRequest(HttpMethod method, string path, string antiforgeryToken)
+    {
+        var request = new HttpRequestMessage(method, path);
+        request.Headers.Add(AntiforgeryHeaderName, antiforgeryToken);
+        return request;
+    }
+
+    private static async Task<string> PrimeAntiforgeryAsync(HttpClient client, CookieContainer container)
+    {
+        using var response = await client.GetAsync("/api/v1/auth/xsrf", TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        var requestCookie = GetCookie(container, AntiforgeryRequestCookieName);
+        requestCookie.Should().NotBeNull("/xsrf must issue the SPA-readable request token cookie");
+        GetCookie(container, AntiforgeryCookieName).Should().NotBeNull("the framework antiforgery cookie must also be set");
+        return requestCookie!.Value;
+    }
+
+    private static async Task<Guid> RegisterAsync(HttpClient client, CookieContainer container, string email)
+    {
+        var token = await PrimeAntiforgeryAsync(client, container);
+        using var request = BuildRequest(HttpMethod.Post, "/api/v1/auth/register", token);
+        request.Content = JsonContent.Create(new RegisterRequestDto(email, StrongPassword));
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Created, because: $"register helper must succeed — got {(int)response.StatusCode}");
+        var body = await response.Content.ReadFromJsonAsync<AuthResponseDto>(cancellationToken: TestContext.Current.CancellationToken);
+        body.Should().NotBeNull();
+        return body!.UserId;
+    }
+
+    private static async Task LoginAsync(HttpClient client, CookieContainer container, string email)
+    {
+        var token = await PrimeAntiforgeryAsync(client, container);
+        using var request = BuildRequest(HttpMethod.Post, "/api/v1/auth/login", token);
+        request.Content = JsonContent.Create(new LoginRequestDto(email, StrongPassword));
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK, because: $"login helper must succeed — got {(int)response.StatusCode}");
+    }
+
+    private static Cookie? GetCookie(CookieContainer container, string name)
+    {
+        foreach (Cookie c in container.GetCookies(BaseUri))
+        {
+            if (string.Equals(c.Name, name, StringComparison.Ordinal))
+            {
+                return c;
+            }
+        }
+
+        return null;
+    }
+
+    private static string GenerateEmail() => $"onboarding-answers-{Guid.NewGuid():N}@example.test";
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingAnswersEndpointIntegrationTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/OnboardingAnswersEndpointIntegrationTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using RunCoach.Api.Infrastructure;
 using RunCoach.Api.Modules.Coaching.Conversation;
+using RunCoach.Api.Modules.Coaching.Onboarding;
 using RunCoach.Api.Modules.Coaching.Onboarding.Entities;
 using RunCoach.Api.Modules.Coaching.Onboarding.Models;
 using RunCoach.Api.Modules.Identity.Contracts;
@@ -61,22 +62,67 @@ public sealed class OnboardingAnswersEndpointIntegrationTests : DbBackedIntegrat
         var token = await PrimeAntiforgeryAsync(client, container);
         var response = await PostAnswersAsync(client, token, request, ct);
 
-        // Assert — HTTP contract: completed onboarding with a linked plan.
+        // Assert — HTTP contract: full deep equality of the response against the expected contract
+        // (CurrentPlanId is server-generated and asserted separately below).
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var state = await response.Content.ReadFromJsonAsync<OnboardingStateDto>(cancellationToken: ct);
         state.Should().NotBeNull();
-        state!.IsComplete.Should().BeTrue(because: "all required topics were submitted, satisfying the deterministic gate");
-        state.CurrentPlanId.Should().NotBeNull().And.NotBe(Guid.Empty);
-
-        // Assert — OnboardingView (Marten projection) slots equal the submitted records.
-        state.PrimaryGoal.Should().Be(new PrimaryGoalAnswer { Goal = PrimaryGoal.RaceTraining, Description = "Sub-4 marathon" });
-        state.TargetEvent!.EventName.Should().Be("Berlin Marathon");
-        state.TargetEvent.DistanceKm.Should().Be(42.2);
-        state.TargetEvent.EventDateIso.Should().Be("2026-09-27");
-        state.WeeklySchedule!.MaxRunDaysPerWeek.Should().Be(5);
-        state.WeeklySchedule.Saturday.Should().BeTrue();
-        state.Preferences!.PreferredUnits.Should().Be(PreferredUnits.Miles);
-        state.InjuryHistory!.PastInjurySummary.Should().Be("Rolled ankle 2024");
+        var expectedState = new OnboardingStateDto(
+            UserId: userId,
+            Status: OnboardingStatus.Completed,
+            CurrentTopic: null,
+            CompletedTopics: 6,
+            TotalTopics: 6,
+            IsComplete: true,
+            OutstandingClarifications: Array.Empty<OnboardingTopic>(),
+            PrimaryGoal: new PrimaryGoalAnswer { Goal = PrimaryGoal.RaceTraining, Description = "Sub-4 marathon" },
+            TargetEvent: new TargetEventAnswer
+            {
+                EventName = "Berlin Marathon",
+                DistanceKm = 42.2,
+                EventDateIso = "2026-09-27",
+                TargetFinishTimeIso = "PT3H55M0S",
+            },
+            CurrentFitness: new CurrentFitnessAnswer
+            {
+                TypicalWeeklyKm = 45,
+                LongestRecentRunKm = 20,
+                RecentRaceDistanceKm = 21.1,
+                RecentRaceTimeIso = "PT1H45M0S",
+                Description = "Feeling strong",
+            },
+            WeeklySchedule: new WeeklyScheduleAnswer
+            {
+                MaxRunDaysPerWeek = 5,
+                TypicalSessionMinutes = 60,
+                Monday = true,
+                Tuesday = false,
+                Wednesday = true,
+                Thursday = false,
+                Friday = true,
+                Saturday = true,
+                Sunday = false,
+                Description = "Evenings only",
+            },
+            InjuryHistory: new InjuryHistoryAnswer
+            {
+                HasActiveInjury = false,
+                ActiveInjuryDescription = string.Empty,
+                PastInjurySummary = "Rolled ankle 2024",
+            },
+            Preferences: new PreferencesAnswer
+            {
+                PreferredUnits = PreferredUnits.Miles,
+                PreferTrail = true,
+                ComfortableWithIntensity = true,
+                Description = "Prefer mornings",
+            },
+            CurrentPlanId: null);
+        state.Should().BeEquivalentTo(
+            expectedState,
+            options => options.Excluding(x => x.CurrentPlanId),
+            because: "the full response contract must match the submitted answers and the deterministic gate verdict");
+        state!.CurrentPlanId.Should().NotBeNull().And.NotBe(Guid.Empty);
 
         // Assert — RunnerOnboardingProfile (EF projection) materialized identically (DEC-060).
         var profile = await LoadProfileAsync(Factory, userId, ct);
@@ -99,7 +145,7 @@ public sealed class OnboardingAnswersEndpointIntegrationTests : DbBackedIntegrat
         var ct = TestContext.Current.CancellationToken;
         var (client, container) = CreateCookieClient(Factory);
         var email = GenerateEmail();
-        await RegisterAsync(client, container, email);
+        var userId = await RegisterAsync(client, container, email);
         await LoginAsync(client, container, email);
         var request = FitnessRequest(Guid.NewGuid());
 
@@ -107,12 +153,60 @@ public sealed class OnboardingAnswersEndpointIntegrationTests : DbBackedIntegrat
         var token = await PrimeAntiforgeryAsync(client, container);
         var response = await PostAnswersAsync(client, token, request, ct);
 
-        // Assert
+        // Assert — full deep equality of the response against the expected contract (CurrentPlanId is
+        // server-generated and asserted separately below).
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var state = await response.Content.ReadFromJsonAsync<OnboardingStateDto>(cancellationToken: ct);
-        state!.IsComplete.Should().BeTrue();
-        state.CurrentPlanId.Should().NotBeNull();
-        state.TargetEvent.Should().BeNull(because: "no target event is required or submitted for general fitness");
+        var expectedState = new OnboardingStateDto(
+            UserId: userId,
+            Status: OnboardingStatus.Completed,
+            CurrentTopic: null,
+            CompletedTopics: 5,
+            TotalTopics: 5,
+            IsComplete: true,
+            OutstandingClarifications: Array.Empty<OnboardingTopic>(),
+            PrimaryGoal: new PrimaryGoalAnswer { Goal = PrimaryGoal.GeneralFitness, Description = "Stay healthy" },
+            TargetEvent: null,
+            CurrentFitness: new CurrentFitnessAnswer
+            {
+                TypicalWeeklyKm = 30,
+                LongestRecentRunKm = 12,
+                RecentRaceDistanceKm = null,
+                RecentRaceTimeIso = null,
+                Description = "Moderate",
+            },
+            WeeklySchedule: new WeeklyScheduleAnswer
+            {
+                MaxRunDaysPerWeek = 4,
+                TypicalSessionMinutes = 45,
+                Monday = true,
+                Tuesday = false,
+                Wednesday = true,
+                Thursday = false,
+                Friday = true,
+                Saturday = false,
+                Sunday = true,
+                Description = "Evenings",
+            },
+            InjuryHistory: new InjuryHistoryAnswer
+            {
+                HasActiveInjury = false,
+                ActiveInjuryDescription = string.Empty,
+                PastInjurySummary = string.Empty,
+            },
+            Preferences: new PreferencesAnswer
+            {
+                PreferredUnits = PreferredUnits.Kilometers,
+                PreferTrail = false,
+                ComfortableWithIntensity = true,
+                Description = string.Empty,
+            },
+            CurrentPlanId: null);
+        state.Should().BeEquivalentTo(
+            expectedState,
+            options => options.Excluding(x => x.CurrentPlanId),
+            because: "the full response contract must match the submitted answers and the deterministic gate verdict");
+        state!.CurrentPlanId.Should().NotBeNull(because: "general fitness satisfies the gate without a TargetEvent slot");
     }
 
     [Fact]
@@ -122,7 +216,7 @@ public sealed class OnboardingAnswersEndpointIntegrationTests : DbBackedIntegrat
         var ct = TestContext.Current.CancellationToken;
         var (client, container) = CreateCookieClient(Factory);
         var email = GenerateEmail();
-        await RegisterAsync(client, container, email);
+        var userId = await RegisterAsync(client, container, email);
         await LoginAsync(client, container, email);
         var request = new SubmitStructuredAnswersRequestDto(
             Guid.NewGuid(),
@@ -137,14 +231,35 @@ public sealed class OnboardingAnswersEndpointIntegrationTests : DbBackedIntegrat
         var token = await PrimeAntiforgeryAsync(client, container);
         var response = await PostAnswersAsync(client, token, request, ct);
 
-        // Assert — 200 with partial progress; no plan generated.
+        // Assert — 200 with partial progress; no plan generated. Full deep equality against the
+        // expected contract.
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var state = await response.Content.ReadFromJsonAsync<OnboardingStateDto>(cancellationToken: ct);
-        state!.IsComplete.Should().BeFalse();
-        state.CurrentPlanId.Should().BeNull();
-        state.PrimaryGoal.Should().NotBeNull();
-        state.CurrentFitness.Should().NotBeNull();
-        state.WeeklySchedule.Should().BeNull();
+        var expectedState = new OnboardingStateDto(
+            UserId: userId,
+            Status: OnboardingStatus.InProgress,
+            CurrentTopic: null,
+            CompletedTopics: 2,
+            TotalTopics: 5,
+            IsComplete: false,
+            OutstandingClarifications: Array.Empty<OnboardingTopic>(),
+            PrimaryGoal: new PrimaryGoalAnswer { Goal = PrimaryGoal.GeneralFitness, Description = "Stay healthy" },
+            TargetEvent: null,
+            CurrentFitness: new CurrentFitnessAnswer
+            {
+                TypicalWeeklyKm = 30,
+                LongestRecentRunKm = 12,
+                RecentRaceDistanceKm = null,
+                RecentRaceTimeIso = null,
+                Description = "Moderate",
+            },
+            WeeklySchedule: null,
+            InjuryHistory: null,
+            Preferences: null,
+            CurrentPlanId: null);
+        state.Should().BeEquivalentTo(
+            expectedState,
+            because: "the full response contract must match the partial submission and the deterministic gate verdict");
 
         // Assert — GET /state reflects the same partial progress (the resume contract).
         var resumed = await GetStateAsync(client, ct);
@@ -189,18 +304,21 @@ public sealed class OnboardingAnswersEndpointIntegrationTests : DbBackedIntegrat
         var ct = TestContext.Current.CancellationToken;
         var (client, container) = CreateCookieClient(Factory);
         var email = GenerateEmail();
-        await RegisterAsync(client, container, email);
+        var userId = await RegisterAsync(client, container, email);
         await LoginAsync(client, container, email);
         var token1 = await PrimeAntiforgeryAsync(client, container);
         var first = await PostAnswersAsync(client, token1, RaceTrainingRequest(Guid.NewGuid()), ct);
         first.StatusCode.Should().Be(HttpStatusCode.OK);
+        var eventCountAfterFirst = await OnboardingStreamEventCountAsync(Factory, userId, ct);
 
         // Act — submit again (new key) against a completed stream.
         var token2 = await PrimeAntiforgeryAsync(client, container);
         var second = await PostAnswersAsync(client, token2, RaceTrainingRequest(Guid.NewGuid()), ct);
 
-        // Assert — 409, no second plan.
+        // Assert — 409, no second plan or onboarding event was appended.
         second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var eventCountAfterSecond = await OnboardingStreamEventCountAsync(Factory, userId, ct);
+        eventCountAfterSecond.Should().Be(eventCountAfterFirst, because: "a rejected resubmission against a completed stream must not append or generate a second plan");
     }
 
     [Fact]
@@ -228,6 +346,35 @@ public sealed class OnboardingAnswersEndpointIntegrationTests : DbBackedIntegrat
         // Assert — clean 400 ProblemDetails, not a 500, and nothing was appended.
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         (await OnboardingStreamEventCountAsync(Factory, userId, ct)).Should().Be(0, because: "an invalid request is rejected before any event is appended");
+    }
+
+    [Fact]
+    public async Task SubmitAnswers_OverflowDuration_Returns400_WithoutStagingEvents()
+    {
+        // Arrange — a syntactically valid xsd:duration ("P1000000000D", 1e9 days) whose magnitude
+        // overflows XmlConvert.ToTimeSpan. The mapper must reject it as a clean 400, never crash with
+        // an unhandled OverflowException surfacing as a 500.
+        var ct = TestContext.Current.CancellationToken;
+        var (client, container) = CreateCookieClient(Factory);
+        var email = GenerateEmail();
+        var userId = await RegisterAsync(client, container, email);
+        await LoginAsync(client, container, email);
+        var request = new SubmitStructuredAnswersRequestDto(
+            Guid.NewGuid(),
+            new PrimaryGoalInputDto(PrimaryGoal.RaceTraining, "Sub-4 marathon"),
+            new TargetEventInputDto("Berlin Marathon", 42.2, "2026-09-27", "P1000000000D"),
+            CurrentFitness: null,
+            WeeklySchedule: null,
+            InjuryHistory: null,
+            Preferences: null);
+
+        // Act
+        var token = await PrimeAntiforgeryAsync(client, container);
+        var response = await PostAnswersAsync(client, token, request, ct);
+
+        // Assert — clean 400 ProblemDetails, not a 500, and nothing was appended.
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await OnboardingStreamEventCountAsync(Factory, userId, ct)).Should().Be(0, because: "an overflowing duration is rejected before any event is appended");
     }
 
     [Fact]
@@ -260,7 +407,7 @@ public sealed class OnboardingAnswersEndpointIntegrationTests : DbBackedIntegrat
     public async Task SubmitAnswers_PresentTopicMissingRequiredField_Returns400()
     {
         // Arrange — a raw body with a weeklySchedule object missing its required fields. The loosened
-        // input DTO's [JsonRequired] presence enforcement must surface this as a clean 400 at model
+        // input DTO's `[JsonRequired]` presence enforcement must surface this as a clean 400 at model
         // binding, never a 500.
         var ct = TestContext.Current.CancellationToken;
         var (client, container) = CreateCookieClient(Factory);
@@ -321,8 +468,8 @@ public sealed class OnboardingAnswersEndpointIntegrationTests : DbBackedIntegrat
     public async Task SubmitAnswers_WhenConversationStreamAlreadyExists_AppendsWithoutCollision()
     {
         // Arrange — a runner who chatted before onboarding already has the shared per-user Marten stream
-        // (tagged ConversationView). The handler must APPEND OnboardingStarted to it, not StartStream
-        // (which would throw ExistingStreamIdCollisionException) — the PR-A #259 bootstrap fix.
+        // (tagged `ConversationView`). The handler must APPEND `OnboardingStarted` to it, not `StartStream`
+        // (which would throw `ExistingStreamIdCollisionException`) — the bootstrap fix (PR-A `#259`).
         var ct = TestContext.Current.CancellationToken;
         var (client, container) = CreateCookieClient(Factory);
         var email = GenerateEmail();
@@ -394,7 +541,7 @@ public sealed class OnboardingAnswersEndpointIntegrationTests : DbBackedIntegrat
     [Fact]
     public async Task SubmitAnswers_OverflowingDistanceLiteral_Returns400_NotServerError()
     {
-        // Arrange — a JSON numeric literal that overflows double range deserializes to +Infinity, which
+        // Arrange — a JSON numeric literal that overflows `double` range deserializes to +Infinity, which
         // slips past the answer record's one-sided guard. The mapper must reject it as a clean 400, never
         // crash serialization as a 500 (the FR-1.8 failure mode).
         var ct = TestContext.Current.CancellationToken;
@@ -418,7 +565,7 @@ public sealed class OnboardingAnswersEndpointIntegrationTests : DbBackedIntegrat
     /// <inheritdoc/>
     public override async ValueTask DisposeAsync()
     {
-        // Onboarding + plan streams live in Marten's runcoach_events schema, which Respawn skips.
+        // Onboarding + plan streams live in Marten's `runcoach_events` schema, which Respawn skips.
         await Factory.Services.ResetAllMartenDataAsync();
         await base.DisposeAsync();
     }

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/SubmitStructuredAnswersRequestMapperTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/SubmitStructuredAnswersRequestMapperTests.cs
@@ -1,0 +1,480 @@
+using FluentAssertions;
+using RunCoach.Api.Modules.Coaching.Onboarding;
+using RunCoach.Api.Modules.Coaching.Onboarding.Models;
+
+namespace RunCoach.Api.Tests.Modules.Coaching.Onboarding;
+
+/// <summary>
+/// Unit coverage for the deterministic request validator/mapper behind
+/// POST /api/v1/onboarding/answers (DU-1 FR-1.8). This is the deterministic replacement for the
+/// retired LLM <c>OnboardingTurnOutputValidator</c>: it must reject hostile/malformed client input
+/// with a descriptive error (mapped to a 400 by the controller) rather than letting a self-validating
+/// answer record throw an uncatchable exception during model binding.
+/// </summary>
+public sealed class SubmitStructuredAnswersRequestMapperTests
+{
+    private static readonly Guid UserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Key = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void TryMap_AllSixTopics_RaceTraining_MapsEveryValidatedRecord()
+    {
+        // Arrange
+        var request = new SubmitStructuredAnswersRequestDto(
+            Key,
+            new PrimaryGoalInputDto(PrimaryGoal.RaceTraining, "Sub-4 marathon"),
+            new TargetEventInputDto("Berlin Marathon", 42.2, "2026-09-27", "PT3H55M0S"),
+            new CurrentFitnessInputDto(45, 20, 21.1, "PT1H45M0S", "Feeling strong"),
+            ValidWeeklySchedule(),
+            new InjuryHistoryInputDto(false, string.Empty, "Rolled ankle 2024"),
+            new PreferencesInputDto(PreferredUnits.Miles, true, true, "Prefer mornings"));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeTrue();
+        error.Should().BeNull();
+        command.Should().NotBeNull();
+        command!.UserId.Should().Be(UserId);
+        command.IdempotencyKey.Should().Be(Key);
+        command.PrimaryGoal.Should().Be(new PrimaryGoalAnswer { Goal = PrimaryGoal.RaceTraining, Description = "Sub-4 marathon" });
+        command.TargetEvent.Should().Be(new TargetEventAnswer
+        {
+            EventName = "Berlin Marathon",
+            DistanceKm = 42.2,
+            EventDateIso = "2026-09-27",
+            TargetFinishTimeIso = "PT3H55M0S",
+        });
+        command.CurrentFitness.Should().Be(new CurrentFitnessAnswer
+        {
+            TypicalWeeklyKm = 45,
+            LongestRecentRunKm = 20,
+            RecentRaceDistanceKm = 21.1,
+            RecentRaceTimeIso = "PT1H45M0S",
+            Description = "Feeling strong",
+        });
+        command.WeeklySchedule.Should().Be(new WeeklyScheduleAnswer
+        {
+            MaxRunDaysPerWeek = 5,
+            TypicalSessionMinutes = 60,
+            Monday = true,
+            Tuesday = false,
+            Wednesday = true,
+            Thursday = false,
+            Friday = true,
+            Saturday = true,
+            Sunday = false,
+            Description = "Evenings only",
+        });
+        command.InjuryHistory.Should().Be(new InjuryHistoryAnswer
+        {
+            HasActiveInjury = false,
+            ActiveInjuryDescription = string.Empty,
+            PastInjurySummary = "Rolled ankle 2024",
+        });
+        command.Preferences.Should().Be(new PreferencesAnswer
+        {
+            PreferredUnits = PreferredUnits.Miles,
+            PreferTrail = true,
+            ComfortableWithIntensity = true,
+            Description = "Prefer mornings",
+        });
+    }
+
+    [Fact]
+    public void TryMap_FitnessProfile_NoTargetEvent_MapsFiveTopics()
+    {
+        // Arrange — general fitness, no target event submitted.
+        var request = new SubmitStructuredAnswersRequestDto(
+            Key,
+            new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, "Stay healthy"),
+            TargetEvent: null,
+            new CurrentFitnessInputDto(30, 12, null, null, "Moderate"),
+            ValidWeeklySchedule(),
+            new InjuryHistoryInputDto(false, string.Empty, string.Empty),
+            new PreferencesInputDto(PreferredUnits.Kilometers, false, true, string.Empty));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeTrue();
+        error.Should().BeNull();
+        command!.TargetEvent.Should().BeNull();
+        command.PrimaryGoal!.Goal.Should().Be(PrimaryGoal.GeneralFitness);
+        command.CurrentFitness!.RecentRaceDistanceKm.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryMap_PartialSubmission_SingleTopic_Succeeds()
+    {
+        // Arrange — a single topic is a valid (incomplete) submission; the gate decides completion.
+        var request = WithTopics(primaryGoal: new PrimaryGoalInputDto(PrimaryGoal.BuildVolume, string.Empty));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeTrue();
+        error.Should().BeNull();
+        command!.PrimaryGoal.Should().NotBeNull();
+        command.WeeklySchedule.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryMap_NullDescription_MapsToEmptyString()
+    {
+        // Arrange — a null nuance box must become the record's empty-string default, not throw.
+        var request = WithTopics(primaryGoal: new PrimaryGoalInputDto(PrimaryGoal.BuildSpeed, Description: null));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeTrue();
+        error.Should().BeNull();
+        command!.PrimaryGoal!.Description.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void TryMap_NoTopicsProvided_Fails()
+    {
+        // Arrange
+        var request = new SubmitStructuredAnswersRequestDto(Key, null, null, null, null, null, null);
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void TryMap_EmptyIdempotencyKey_Fails()
+    {
+        // Arrange
+        var request = new SubmitStructuredAnswersRequestDto(
+            Guid.Empty,
+            new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, string.Empty),
+            TargetEvent: null,
+            CurrentFitness: null,
+            WeeklySchedule: null,
+            InjuryHistory: null,
+            Preferences: null);
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void TryMap_UndefinedPrimaryGoalEnum_Fails()
+    {
+        // Arrange — an out-of-range int-backed enum deserializes without throwing; the mapper must catch it.
+        var request = WithTopics(primaryGoal: new PrimaryGoalInputDto((PrimaryGoal)99, "x"));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void TryMap_UndefinedPreferredUnitsEnum_Fails()
+    {
+        // Arrange
+        var request = WithTopics(
+            primaryGoal: new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, string.Empty),
+            preferences: new PreferencesInputDto((PreferredUnits)7, false, false, string.Empty));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void TryMap_TargetEventWithoutPrimaryGoal_Fails()
+    {
+        // Arrange — a target event with no primary goal in the submission cannot establish race training.
+        var request = WithTopics(targetEvent: ValidTargetEvent());
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void TryMap_TargetEventWithNonRacingPrimaryGoal_Fails()
+    {
+        // Arrange
+        var request = WithTopics(
+            primaryGoal: new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, string.Empty),
+            targetEvent: ValidTargetEvent());
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void TryMap_NonPositiveTargetDistance_Fails(double distanceKm)
+    {
+        // Arrange — the TargetEventAnswer record enforces DistanceKm > 0 in its init accessor.
+        var request = WithTopics(
+            primaryGoal: RacingGoal(),
+            targetEvent: new TargetEventInputDto("Race", distanceKm, "2026-09-27", null));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryMap_BlankEventName_Fails(string eventName)
+    {
+        // Arrange
+        var request = WithTopics(
+            primaryGoal: RacingGoal(),
+            targetEvent: new TargetEventInputDto(eventName, 10, "2026-09-27", null));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData("not-a-date")]
+    [InlineData("2026-13-40")]
+    [InlineData("2026/09/27")]
+    [InlineData("27-09-2026")]
+    public void TryMap_InvalidEventDate_Fails(string eventDateIso)
+    {
+        // Arrange
+        var request = WithTopics(
+            primaryGoal: RacingGoal(),
+            targetEvent: new TargetEventInputDto("Race", 10, eventDateIso, null));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void TryMap_InvalidTargetFinishDuration_Fails()
+    {
+        // Arrange — a present-but-unparseable ISO-8601 duration is rejected.
+        var request = WithTopics(
+            primaryGoal: RacingGoal(),
+            targetEvent: new TargetEventInputDto("Race", 10, "2026-09-27", "3 hours 55"));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData(-1, 12)]
+    [InlineData(30, -1)]
+    public void TryMap_NegativeFitnessDistance_Fails(double typicalWeeklyKm, double longestRecentRunKm)
+    {
+        // Arrange — CurrentFitnessAnswer enforces >= 0 on both distances.
+        var request = WithTopics(
+            primaryGoal: new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, string.Empty),
+            currentFitness: new CurrentFitnessInputDto(typicalWeeklyKm, longestRecentRunKm, null, null, string.Empty));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void TryMap_NegativeRecentRaceDistance_Fails()
+    {
+        // Arrange
+        var request = WithTopics(
+            primaryGoal: new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, string.Empty),
+            currentFitness: new CurrentFitnessInputDto(30, 12, -3, null, string.Empty));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(8)]
+    public void TryMap_OutOfRangeRunDays_Fails(int maxRunDaysPerWeek)
+    {
+        // Arrange — WeeklyScheduleAnswer enforces 1..7.
+        var request = WithTopics(
+            primaryGoal: new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, string.Empty),
+            weeklySchedule: ValidWeeklySchedule() with { MaxRunDaysPerWeek = maxRunDaysPerWeek });
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void TryMap_NonPositiveSessionMinutes_Fails()
+    {
+        // Arrange — WeeklyScheduleAnswer enforces TypicalSessionMinutes > 0.
+        var request = WithTopics(
+            primaryGoal: new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, string.Empty),
+            weeklySchedule: ValidWeeklySchedule() with { TypicalSessionMinutes = 0 });
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void TryMap_NonFiniteTargetDistance_Fails()
+    {
+        // Arrange — a JSON literal overflowing double range deserializes to +Infinity, which slips past
+        // the record's `<= 0` guard and would later crash serialization as a 500. The mapper must reject it.
+        var request = WithTopics(
+            primaryGoal: RacingGoal(),
+            targetEvent: new TargetEventInputDto("Race", double.PositiveInfinity, "2026-09-27", null));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NaN)]
+    [InlineData(500_000)]
+    public void TryMap_NonFiniteOrAbsurdFitnessDistance_Fails(double typicalWeeklyKm)
+    {
+        // Arrange
+        var request = WithTopics(
+            primaryGoal: new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, string.Empty),
+            currentFitness: new CurrentFitnessInputDto(typicalWeeklyKm, 12, null, null, string.Empty));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData("-PT1H45M0S")]
+    [InlineData("P100Y")]
+    public void TryMap_NegativeOrAbsurdDuration_Fails(string durationIso)
+    {
+        // Arrange — XmlConvert.ToTimeSpan accepts negative and arbitrarily large durations without
+        // throwing; the mapper must range-check them.
+        var request = WithTopics(
+            primaryGoal: RacingGoal(),
+            targetEvent: new TargetEventInputDto("Race", 10, "2026-09-27", durationIso));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void TryMap_UndefinedGoalWithTargetEvent_ReportsGoalError_NotCrossFieldError()
+    {
+        // Arrange — an undefined goal submitted with a target event must report the goal problem, not the
+        // cross-field message (the enum is validated before the cross-field check).
+        var request = WithTopics(
+            primaryGoal: new PrimaryGoalInputDto((PrimaryGoal)99, "x"),
+            targetEvent: ValidTargetEvent());
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().Contain("recognized goal");
+    }
+
+    private static PrimaryGoalInputDto RacingGoal() => new(PrimaryGoal.RaceTraining, "Goal race");
+
+    private static TargetEventInputDto ValidTargetEvent() => new("Local 10K", 10, "2026-09-27", null);
+
+    private static WeeklyScheduleInputDto ValidWeeklySchedule() =>
+        new(5, 60, Monday: true, Tuesday: false, Wednesday: true, Thursday: false, Friday: true, Saturday: true, Sunday: false, "Evenings only");
+
+    private static SubmitStructuredAnswersRequestDto WithTopics(
+        PrimaryGoalInputDto? primaryGoal = null,
+        TargetEventInputDto? targetEvent = null,
+        CurrentFitnessInputDto? currentFitness = null,
+        WeeklyScheduleInputDto? weeklySchedule = null,
+        InjuryHistoryInputDto? injuryHistory = null,
+        PreferencesInputDto? preferences = null) =>
+        new(Key, primaryGoal, targetEvent, currentFitness, weeklySchedule, injuryHistory, preferences);
+}

--- a/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/SubmitStructuredAnswersRequestMapperTests.cs
+++ b/backend/tests/RunCoach.Api.Tests/Modules/Coaching/Onboarding/SubmitStructuredAnswersRequestMapperTests.cs
@@ -33,28 +33,23 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeTrue();
-        error.Should().BeNull();
-        command.Should().NotBeNull();
-        command!.UserId.Should().Be(UserId);
-        command.IdempotencyKey.Should().Be(Key);
-        command.PrimaryGoal.Should().Be(new PrimaryGoalAnswer { Goal = PrimaryGoal.RaceTraining, Description = "Sub-4 marathon" });
-        command.TargetEvent.Should().Be(new TargetEventAnswer
+        var expectedPrimaryGoal = new PrimaryGoalAnswer { Goal = PrimaryGoal.RaceTraining, Description = "Sub-4 marathon" };
+        var expectedTargetEvent = new TargetEventAnswer
         {
             EventName = "Berlin Marathon",
             DistanceKm = 42.2,
             EventDateIso = "2026-09-27",
             TargetFinishTimeIso = "PT3H55M0S",
-        });
-        command.CurrentFitness.Should().Be(new CurrentFitnessAnswer
+        };
+        var expectedCurrentFitness = new CurrentFitnessAnswer
         {
             TypicalWeeklyKm = 45,
             LongestRecentRunKm = 20,
             RecentRaceDistanceKm = 21.1,
             RecentRaceTimeIso = "PT1H45M0S",
             Description = "Feeling strong",
-        });
-        command.WeeklySchedule.Should().Be(new WeeklyScheduleAnswer
+        };
+        var expectedWeeklySchedule = new WeeklyScheduleAnswer
         {
             MaxRunDaysPerWeek = 5,
             TypicalSessionMinutes = 60,
@@ -66,20 +61,32 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
             Saturday = true,
             Sunday = false,
             Description = "Evenings only",
-        });
-        command.InjuryHistory.Should().Be(new InjuryHistoryAnswer
+        };
+        var expectedInjuryHistory = new InjuryHistoryAnswer
         {
             HasActiveInjury = false,
             ActiveInjuryDescription = string.Empty,
             PastInjurySummary = "Rolled ankle 2024",
-        });
-        command.Preferences.Should().Be(new PreferencesAnswer
+        };
+        var expectedPreferences = new PreferencesAnswer
         {
             PreferredUnits = PreferredUnits.Miles,
             PreferTrail = true,
             ComfortableWithIntensity = true,
             Description = "Prefer mornings",
-        });
+        };
+
+        actual.Should().BeTrue();
+        error.Should().BeNull();
+        command.Should().NotBeNull();
+        command!.UserId.Should().Be(UserId);
+        command.IdempotencyKey.Should().Be(Key);
+        command.PrimaryGoal.Should().Be(expectedPrimaryGoal);
+        command.TargetEvent.Should().Be(expectedTargetEvent);
+        command.CurrentFitness.Should().Be(expectedCurrentFitness);
+        command.WeeklySchedule.Should().Be(expectedWeeklySchedule);
+        command.InjuryHistory.Should().Be(expectedInjuryHistory);
+        command.Preferences.Should().Be(expectedPreferences);
     }
 
     [Fact]
@@ -147,9 +154,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Fact]
@@ -169,9 +174,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Fact]
@@ -184,9 +187,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Fact]
@@ -201,9 +202,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Fact]
@@ -216,9 +215,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Fact]
@@ -233,9 +230,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Theory]
@@ -243,7 +238,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
     [InlineData(-5)]
     public void TryMap_NonPositiveTargetDistance_Fails(double distanceKm)
     {
-        // Arrange — the TargetEventAnswer record enforces DistanceKm > 0 in its init accessor.
+        // Arrange — the `TargetEventAnswer` record enforces `DistanceKm > 0` in its init accessor.
         var request = WithTopics(
             primaryGoal: RacingGoal(),
             targetEvent: new TargetEventInputDto("Race", distanceKm, "2026-09-27", null));
@@ -252,9 +247,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Theory]
@@ -271,9 +264,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Theory]
@@ -292,9 +283,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Fact]
@@ -309,9 +298,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Theory]
@@ -319,7 +306,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
     [InlineData(30, -1)]
     public void TryMap_NegativeFitnessDistance_Fails(double typicalWeeklyKm, double longestRecentRunKm)
     {
-        // Arrange — CurrentFitnessAnswer enforces >= 0 on both distances.
+        // Arrange — `CurrentFitnessAnswer` enforces `>= 0` on both distances.
         var request = WithTopics(
             primaryGoal: new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, string.Empty),
             currentFitness: new CurrentFitnessInputDto(typicalWeeklyKm, longestRecentRunKm, null, null, string.Empty));
@@ -328,9 +315,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Fact]
@@ -345,9 +330,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Theory]
@@ -355,7 +338,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
     [InlineData(8)]
     public void TryMap_OutOfRangeRunDays_Fails(int maxRunDaysPerWeek)
     {
-        // Arrange — WeeklyScheduleAnswer enforces 1..7.
+        // Arrange — `WeeklyScheduleAnswer` enforces `1..7`.
         var request = WithTopics(
             primaryGoal: new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, string.Empty),
             weeklySchedule: ValidWeeklySchedule() with { MaxRunDaysPerWeek = maxRunDaysPerWeek });
@@ -364,26 +347,24 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
-    [Fact]
-    public void TryMap_NonPositiveSessionMinutes_Fails()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-15)]
+    public void TryMap_NonPositiveSessionMinutes_Fails(int typicalSessionMinutes)
     {
-        // Arrange — WeeklyScheduleAnswer enforces TypicalSessionMinutes > 0.
+        // Arrange — `WeeklyScheduleAnswer` enforces `TypicalSessionMinutes > 0`.
         var request = WithTopics(
             primaryGoal: new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, string.Empty),
-            weeklySchedule: ValidWeeklySchedule() with { TypicalSessionMinutes = 0 });
+            weeklySchedule: ValidWeeklySchedule() with { TypicalSessionMinutes = typicalSessionMinutes });
 
         // Act
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Fact]
@@ -399,9 +380,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Theory]
@@ -419,9 +398,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
     }
 
     [Theory]
@@ -429,7 +406,7 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
     [InlineData("P100Y")]
     public void TryMap_NegativeOrAbsurdDuration_Fails(string durationIso)
     {
-        // Arrange — XmlConvert.ToTimeSpan accepts negative and arbitrarily large durations without
+        // Arrange — `XmlConvert.ToTimeSpan` accepts negative and arbitrarily large durations without
         // throwing; the mapper must range-check them.
         var request = WithTopics(
             primaryGoal: RacingGoal(),
@@ -439,9 +416,24 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
 
         // Assert
-        actual.Should().BeFalse();
-        command.Should().BeNull();
-        error.Should().NotBeNullOrWhiteSpace();
+        AssertMapFailed(actual, command, error);
+    }
+
+    [Fact]
+    public void TryMap_OverflowDuration_Fails()
+    {
+        // Arrange — "P1000000000D" is syntactically valid ISO-8601 but numerically huge; `XmlConvert.ToTimeSpan`
+        // throws `OverflowException` (not `FormatException`) for it. The mapper must catch both, the duration
+        // twin of the 1e400→Infinity distance hole.
+        var request = WithTopics(
+            primaryGoal: new PrimaryGoalInputDto(PrimaryGoal.GeneralFitness, string.Empty),
+            currentFitness: new CurrentFitnessInputDto(30, 12, null, "P1000000000D", string.Empty));
+
+        // Act
+        var actual = SubmitStructuredAnswersRequestMapper.TryMap(request, UserId, out var command, out var error);
+
+        // Assert
+        AssertMapFailed(actual, command, error);
     }
 
     [Fact]
@@ -460,6 +452,13 @@ public sealed class SubmitStructuredAnswersRequestMapperTests
         actual.Should().BeFalse();
         command.Should().BeNull();
         error.Should().Contain("recognized goal");
+    }
+
+    private static void AssertMapFailed(bool actual, SubmitStructuredAnswers? command, string? error)
+    {
+        actual.Should().BeFalse();
+        command.Should().BeNull();
+        error.Should().NotBeNullOrWhiteSpace();
     }
 
     private static PrimaryGoalInputDto RacingGoal() => new(PrimaryGoal.RaceTraining, "Goal race");

--- a/frontend/src/app/api/generated/rtk/api.ts
+++ b/frontend/src/app/api/generated/rtk/api.ts
@@ -104,6 +104,16 @@ const injectedRtkApi = api.injectEndpoints({
         body: queryArg.reviseAnswerRequestDto,
       }),
     }),
+    postApiV1OnboardingAnswers: build.mutation<
+      PostApiV1OnboardingAnswersApiResponse,
+      PostApiV1OnboardingAnswersApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/v1/onboarding/answers`,
+        method: 'POST',
+        body: queryArg.submitStructuredAnswersRequestDto,
+      }),
+    }),
     getApiV1PlanCurrent: build.query<GetApiV1PlanCurrentApiResponse, GetApiV1PlanCurrentApiArg>({
       query: () => ({ url: `/api/v1/plan/current` }),
     }),
@@ -197,6 +207,10 @@ export type GetApiV1OnboardingStateApiArg = void
 export type PostApiV1OnboardingAnswersReviseApiResponse = /** status 200 OK */ OnboardingStateDto
 export type PostApiV1OnboardingAnswersReviseApiArg = {
   reviseAnswerRequestDto: ReviseAnswerRequestDto
+}
+export type PostApiV1OnboardingAnswersApiResponse = /** status 200 OK */ OnboardingStateDto
+export type PostApiV1OnboardingAnswersApiArg = {
+  submitStructuredAnswersRequestDto: SubmitStructuredAnswersRequestDto
 }
 export type GetApiV1PlanCurrentApiResponse = /** status 200 OK */ PlanProjectionDto
 export type GetApiV1PlanCurrentApiArg = void
@@ -500,6 +514,55 @@ export type ReviseAnswerRequestDto = {
   topic: OnboardingTopic
   normalizedValue: any
 }
+export type PrimaryGoalInputDto = {
+  goal: PrimaryGoal
+  description?: string | null
+}
+export type TargetEventInputDto = {
+  eventName: string
+  distanceKm: number
+  eventDateIso: string
+  targetFinishTimeIso?: string | null
+}
+export type CurrentFitnessInputDto = {
+  typicalWeeklyKm: number
+  longestRecentRunKm: number
+  recentRaceDistanceKm?: number | null
+  recentRaceTimeIso?: string | null
+  description?: string | null
+}
+export type WeeklyScheduleInputDto = {
+  maxRunDaysPerWeek: number
+  typicalSessionMinutes: number
+  monday: boolean
+  tuesday: boolean
+  wednesday: boolean
+  thursday: boolean
+  friday: boolean
+  saturday: boolean
+  sunday: boolean
+  description?: string | null
+}
+export type InjuryHistoryInputDto = {
+  hasActiveInjury: boolean
+  activeInjuryDescription?: string | null
+  pastInjurySummary?: string | null
+}
+export type PreferencesInputDto = {
+  preferredUnits: PreferredUnits
+  preferTrail: boolean
+  comfortableWithIntensity: boolean
+  description?: string | null
+}
+export type SubmitStructuredAnswersRequestDto = {
+  idempotencyKey: string
+  primaryGoal: PrimaryGoalInputDto
+  targetEvent: TargetEventInputDto
+  currentFitness: CurrentFitnessInputDto
+  weeklySchedule: WeeklyScheduleInputDto
+  injuryHistory: InjuryHistoryInputDto
+  preferences: PreferencesInputDto
+}
 export type PhaseType = 'Base' | 'Build' | 'Peak' | 'Taper' | 'Recovery'
 export type PlanPhaseOutput = {
   phaseType: PhaseType
@@ -648,6 +711,7 @@ export const {
   usePostApiV1OnboardingTurnsMutation,
   useGetApiV1OnboardingStateQuery,
   usePostApiV1OnboardingAnswersReviseMutation,
+  usePostApiV1OnboardingAnswersMutation,
   useGetApiV1PlanCurrentQuery,
   usePostApiV1PlanRegenerateMutation,
   useGetApiV1SettingsUnitsQuery,

--- a/frontend/src/app/api/generated/zod/onboarding/onboarding.ts
+++ b/frontend/src/app/api/generated/zod/onboarding/onboarding.ts
@@ -300,3 +300,179 @@ export const PostApiV1OnboardingAnswersReviseResponse = zod.strictObject({
   }),
   currentPlanId: zod.uuid().nullish(),
 })
+
+export const PostApiV1OnboardingAnswersBody = zod.strictObject({
+  idempotencyKey: zod.uuid(),
+  primaryGoal: zod.strictObject({
+    goal: zod.union([
+      zod.literal(0),
+      zod.literal(1),
+      zod.literal(2),
+      zod.literal(3),
+      zod.literal(4),
+    ]),
+    description: zod.string().nullish(),
+  }),
+  targetEvent: zod.strictObject({
+    eventName: zod.string(),
+    distanceKm: zod.number(),
+    eventDateIso: zod.string(),
+    targetFinishTimeIso: zod.string().nullish(),
+  }),
+  currentFitness: zod.strictObject({
+    typicalWeeklyKm: zod.number(),
+    longestRecentRunKm: zod.number(),
+    recentRaceDistanceKm: zod.number().nullish(),
+    recentRaceTimeIso: zod.string().nullish(),
+    description: zod.string().nullish(),
+  }),
+  weeklySchedule: zod.strictObject({
+    maxRunDaysPerWeek: zod.number(),
+    typicalSessionMinutes: zod.number(),
+    monday: zod.boolean(),
+    tuesday: zod.boolean(),
+    wednesday: zod.boolean(),
+    thursday: zod.boolean(),
+    friday: zod.boolean(),
+    saturday: zod.boolean(),
+    sunday: zod.boolean(),
+    description: zod.string().nullish(),
+  }),
+  injuryHistory: zod.strictObject({
+    hasActiveInjury: zod.boolean(),
+    activeInjuryDescription: zod.string().nullish(),
+    pastInjurySummary: zod.string().nullish(),
+  }),
+  preferences: zod.strictObject({
+    preferredUnits: zod.union([zod.literal(0), zod.literal(1)]),
+    preferTrail: zod.boolean(),
+    comfortableWithIntensity: zod.boolean(),
+    description: zod.string().nullish(),
+  }),
+})
+
+export const PostApiV1OnboardingAnswersResponse = zod.strictObject({
+  userId: zod.uuid(),
+  status: zod.union([zod.literal(0), zod.literal(1), zod.literal(2)]),
+  currentTopic: zod.union([
+    zod.literal(0),
+    zod.literal(1),
+    zod.literal(2),
+    zod.literal(3),
+    zod.literal(4),
+    zod.literal(5),
+  ]),
+  completedTopics: zod.number(),
+  totalTopics: zod.number(),
+  isComplete: zod.boolean(),
+  outstandingClarifications: zod.array(
+    zod.union([
+      zod.literal(0),
+      zod.literal(1),
+      zod.literal(2),
+      zod.literal(3),
+      zod.literal(4),
+      zod.literal(5),
+    ]),
+  ),
+  primaryGoal: zod.strictObject({
+    goal: zod.union([
+      zod.literal(0),
+      zod.literal(1),
+      zod.literal(2),
+      zod.literal(3),
+      zod.literal(4),
+    ]),
+    description: zod
+      .string()
+      .describe('Runner-supplied free-text description that informed the categorical mapping.'),
+  }),
+  targetEvent: zod.strictObject({
+    eventName: zod
+      .string()
+      .describe("Name of the goal race or event, such as 'Berlin Marathon' or 'Local 10K'."),
+    distanceKm: zod.number().describe('Target distance in kilometers for the event.'),
+    eventDateIso: zod
+      .string()
+      .describe('Target event date in ISO-8601 calendar form (yyyy-MM-dd).'),
+    targetFinishTimeIso: zod
+      .string()
+      .nullable()
+      .describe(
+        'Optional target finishing time as ISO-8601 duration (e.g. PT1H45M30S). Null if the runner has no specific time goal.',
+      ),
+  }),
+  currentFitness: zod.strictObject({
+    typicalWeeklyKm: zod
+      .number()
+      .describe('Typical weekly running distance in kilometers over the past four weeks.'),
+    longestRecentRunKm: zod
+      .number()
+      .describe('Longest single run completed in the past four weeks, in kilometers.'),
+    recentRaceDistanceKm: zod
+      .number()
+      .nullable()
+      .describe(
+        'Optional recent race distance in kilometers. Null if the runner has no recent race result.',
+      ),
+    recentRaceTimeIso: zod
+      .string()
+      .nullable()
+      .describe(
+        'Optional recent race time as ISO-8601 duration (e.g. PT0H45M30S). Null if the runner has no recent race result.',
+      ),
+    description: zod.string().describe("Self-reported fitness summary in the runner's own words."),
+  }),
+  weeklySchedule: zod.strictObject({
+    maxRunDaysPerWeek: zod
+      .number()
+      .describe(
+        'Maximum number of run days per week the runner can commit to. Valid range 1 through 7.',
+      ),
+    typicalSessionMinutes: zod
+      .number()
+      .describe('Typical session duration in minutes the runner has available per training day.'),
+    monday: zod.boolean().describe('Whether Monday is an available run day.'),
+    tuesday: zod.boolean().describe('Whether Tuesday is an available run day.'),
+    wednesday: zod.boolean().describe('Whether Wednesday is an available run day.'),
+    thursday: zod.boolean().describe('Whether Thursday is an available run day.'),
+    friday: zod.boolean().describe('Whether Friday is an available run day.'),
+    saturday: zod.boolean().describe('Whether Saturday is an available run day.'),
+    sunday: zod.boolean().describe('Whether Sunday is an available run day.'),
+    description: zod
+      .string()
+      .describe(
+        "Runner-supplied free-text description of constraints not captured by the day flags (e.g. 'no early mornings').",
+      ),
+  }),
+  injuryHistory: zod.strictObject({
+    hasActiveInjury: zod
+      .boolean()
+      .describe('Whether the runner currently has an active injury or pain that limits training.'),
+    activeInjuryDescription: zod
+      .string()
+      .describe(
+        'Description of the active injury or limitation. Empty string when there is no active injury.',
+      ),
+    pastInjurySummary: zod
+      .string()
+      .describe(
+        'Summary of past injuries or recurring issues that should inform the training plan. Empty string if none.',
+      ),
+  }),
+  preferences: zod.strictObject({
+    preferredUnits: zod.union([zod.literal(0), zod.literal(1)]),
+    preferTrail: zod.boolean().describe('Whether the runner prefers trail running where possible.'),
+    comfortableWithIntensity: zod
+      .boolean()
+      .describe(
+        'Whether the runner is comfortable with structured high-intensity workouts (intervals, threshold).',
+      ),
+    description: zod
+      .string()
+      .describe(
+        'Runner-supplied free-text description of any other preferences not captured above.',
+      ),
+  }),
+  currentPlanId: zod.uuid().nullish(),
+})


### PR DESCRIPTION
## Slice 4C-onboarding · PR-C (DU-1) — deterministic form-answer origination endpoint

Net-new **additive** `POST /api/v1/onboarding/answers`: a deterministic, form-first onboarding intake (DEC-086 D1) that originates the **existing** `AnswerCaptured` event per submitted topic with **no LLM call**, reusing the event-sourced spine — both projections, the completion gate, and the inline plan-generation terminal branch — byte-for-byte unchanged (DEC-047/DEC-060 hold). It **coexists** with the legacy conversational `/turns` path (retired later in PR-E).

### What's here

- **Command + plain static Wolverine handler** (`SubmitStructuredAnswers` / `SubmitStructuredAnswersHandler`, DP-2 — mirrors `OnboardingTurnHandler`, not `[AggregateHandler]`): idempotency short-circuit → `StartStreamOrAppendAsync` bootstrap (the shared per-user stream, PR-A #259) → one whole-record `AnswerCaptured` per topic (`Confidence 1.0`, **default PascalCase** for projection round-trip parity) → completion gate as the **sole** plan-gen authority (no LLM `ReadyForPlan`) → inline `GeneratePlanAsync` + `PlanLinkedToUser` + `OnboardingCompleted`. No `SaveChangesAsync` — Wolverine brackets the transaction.
- **6 loosened wire-input DTOs + `SubmitStructuredAnswersRequestMapper`** (FR-1.8, the deterministic replacement for the retired LLM validator). Rationale: the canonical `*Answer` records self-validate in their `init` accessors and throw `TargetInvocationException` if bound directly (→ uncatchable **500**). So the wire DTOs are loosened primitives that bind without throwing; the mapper validates deterministically (enum definedness, ISO-8601 date/duration, **finite + ranged** distances, the `TargetEvent ⇒ RaceTraining` cross-field rule) and constructs the canonical records in `try/catch (ArgumentException)` → clean **400** — the repo idiom (`WorkoutLogsController`).
- **Controller `SubmitAnswers`**: validate → dispatch → reload committed view (mirrors `ReviseAnswer`) → `200` / `400` / `409` (already complete) / `422` (plan-gen rejected — nothing staged, re-submittable).
- **Regenerated OpenAPI + rtk/zod** for PR-D.

### Verification

- 32 mapper unit tests + 12 integration tests (both projections materialize from the form-originated event; fitness/partial/partial-then-complete merge; duplicate-key no-double-append; shared-stream bootstrap collision; 409/422; every FR-1.8 hostile-input path → 400, incl. an overflow numeric literal `1e400` → **400 not 500**).
- Full backend suite **green in Replay**. Release build passes the SonarAnalyzer/StyleCop gate. Frontend build + 627 tests green.

### Review (adversarial, blind-challenge verified) — 9 findings confirmed, all addressed

| # | Sev | Finding | Resolution |
|---|-----|---------|-----------|
| 3 | **critical** | `1e400` → `+Infinity` slips past the records' one-sided guards, then crashes `SerializeToDocument` as a 500 | **Fixed** — mapper rejects non-finite / absurd distances; end-to-end test asserts 400 |
| 4/5 | med/nit | `XmlConvert.ToTimeSpan` accepts negative / absurd durations | **Fixed** — reject `< 0` / `> 60d` |
| 2/6 | low/nit | cross-field check read the enum before `Enum.IsDefined` → misleading (still 400) message | **Fixed** — validate goal enum first |
| 7 | high | no shared-stream bootstrap-collision test | **Added** |
| 8 | high | no partial-then-complete (save-and-resume) test | **Added** |
| 9 | med | all-six mapper test spot-checked 3 topics | **Fixed** — full-record equality for all 6 |
| 1 | med | **double-submit with *different* idempotency keys** can double-generate a plan + leave `CurrentPlanId` nondeterministic | **Deferred + tracked** (see below) |

### Deferred, tracked follow-ups (builder decision)

- **Finding #1 (concurrency).** The plain static handler has no Marten optimistic-concurrency gate, so two concurrent submissions with *different* keys both pass the gate and both generate a plan. This is **inherited verbatim from `OnboardingTurnHandler`** (DP-2 deliberately mirrored that unprotected convention over `[AggregateHandler]`/`FetchForWriting`). Fixing only the new handler would diverge from DP-2 and from the shipped turn handler → this needs a **cross-cutting decision applied to both onboarding handlers** (add expected-version optimistic concurrency + `ConcurrencyException → 409`), tracked for the builder. Practical mitigation lands in PR-D (disable the submit button on click); MVP-0 audience is self+family.
- **Generated request DTO marks all topic slots `required`** despite being C#-nullable — the known repo-wide `RequireNonNullablePropertiesSchemaFilter` `$ref` artifact (deferred structural fix, PR #163). Runtime binding correctly treats topics as optional; PR-D hand-writes accurate optional-topic models like `plan.model.ts`.

Pre-existing frontend lint noise (8 `sonarjs/no-hardcoded-passwords` on password/e2e fixtures) is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new structured onboarding answers API that accepts standardized inputs for current fitness, injury history, preferences, primary goal, target event, and weekly schedule.
  * Submissions now support idempotent handling and return deterministic outcomes, including whether a plan was generated.
* **Bug Fixes**
  * Strengthened request validation (required fields, numeric/date/duration formats, and cross-field consistency) with clean 400/409/422 responses.
  * Prevents duplicate staging and additional plans on repeated submissions with the same idempotency key.
* **Tests**
  * Added end-to-end integration coverage and extensive request-mapper unit tests for valid and hostile inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->