### PR TITLE
feat(split-ui): Slice 1 — Shell & Navigation (tab bar, tab-shell, /coach)

### DIFF
--- a/frontend/e2e/conversation-streaming.spec.ts
+++ b/frontend/e2e/conversation-streaming.spec.ts
@@ -8,7 +8,8 @@ import { expect, test, type Page, type Route } from '@playwright/test'
 //      pair are seeded exactly as the runtime app expects (the hand-rolled SSE
 //      POST reads the `__Host-Xsrf-Request` cookie and sets `X-XSRF-TOKEN`).
 //   2. Onboarding state + plan/current are stubbed so the home page renders the
-//      plan view with the interactive coach chat mounted.
+//      plan view; the interactive coach chat lives on its own `/coach` route
+//      (SPLIT/Alpine Slice 1), reached via the shell's TabBar COACH tab.
 //   3. The conversation endpoints are stubbed at the wire: `GET /conversation/
 //      timeline`, the SSE `POST /conversation/messages`, and the JSON
 //      `POST /conversation/logs/confirm`.
@@ -222,6 +223,10 @@ test('register → ask a question → describe a workout → confirm the parsed 
   await page.getByLabel('Password').fill(VALID_PASSWORD)
   await page.getByRole('button', { name: /create account/i }).click()
   await expect(page).toHaveURL('/')
+
+  // Coach chat lives on its own /coach route — reach it via the TabBar.
+  await page.getByTestId('tab-coach').click()
+  await expect(page).toHaveURL('/coach')
   await expect(page.getByTestId('coach-chat')).toBeVisible()
 
   // 1. Ask a question → the streamed answer renders and persists in the timeline.

--- a/frontend/e2e/shell-navigation.spec.ts
+++ b/frontend/e2e/shell-navigation.spec.ts
@@ -1,0 +1,79 @@
+import { randomUUID } from 'node:crypto'
+import { expect, test, type Page, type Route } from '@playwright/test'
+
+// SPLIT/Alpine Slice 1 — TabBar presence/absence per spec § Quality
+// requirements: "add a spec asserting TabBar presence on a shell route and
+// absence on /login."
+
+// eslint-disable-next-line sonarjs/no-hardcoded-passwords -- static E2E fixture password (matches the sibling e2e specs), not a real credential
+const VALID_PASSWORD = 'Correct-Horse-9!'
+const uniqueEmail = (): string => `e2e-${randomUUID()}@runcoach.test`
+
+const OnboardingStatus = { Completed: 2 } as const
+const completedPlanId = '8a4b9b2a-1d3f-4f1c-9aab-5e2c1f0b7777'
+const userId = '00000000-0000-0000-0000-000000000099'
+
+const installNavigationStubs = async (page: Page): Promise<void> => {
+  await page.route('**/api/v1/onboarding/state', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        userId,
+        status: OnboardingStatus.Completed,
+        currentTopic: null,
+        completedTopics: 6,
+        totalTopics: 6,
+        isComplete: true,
+        outstandingClarifications: [],
+        primaryGoal: null,
+        targetEvent: null,
+        currentFitness: null,
+        weeklySchedule: null,
+        injuryHistory: null,
+        preferences: null,
+        currentPlanId: completedPlanId,
+      }),
+    })
+  })
+
+  // A 404 plan is enough for the shell/TabBar to render — the home page's
+  // "no plan yet" defensive state still mounts inside `ShellLayout`.
+  await page.route('**/api/v1/plan/current', async (route: Route) => {
+    await route.fulfill({
+      status: 404,
+      contentType: 'application/json',
+      body: JSON.stringify({ type: 'about:blank', title: 'Not Found', status: 404 }),
+    })
+  })
+}
+
+test('the TabBar renders on a shell route and is absent on /login', async ({ page }) => {
+  await installNavigationStubs(page)
+
+  await page.goto('/register')
+  await page.getByLabel('Email').fill(uniqueEmail())
+  await page.getByLabel('Password').fill(VALID_PASSWORD)
+  await page.getByRole('button', { name: /create account/i }).click()
+  await expect(page).toHaveURL('/')
+
+  const tabBar = page.getByTestId('tab-bar')
+  await expect(tabBar).toBeVisible()
+  await expect(page.getByTestId('tab-today')).toHaveAttribute('aria-current', 'page')
+  await expect(page.getByTestId('tab-coach')).toBeVisible()
+  await expect(page.getByTestId('tab-log')).toHaveAccessibleName('Log a workout')
+  await expect(page.getByTestId('tab-history')).toBeVisible()
+  await expect(page.getByTestId('tab-settings')).toBeVisible()
+
+  // Navigating within the shell keeps the bar mounted and moves the current tab.
+  await page.getByTestId('tab-settings').click()
+  await expect(page).toHaveURL('/settings')
+  await expect(tabBar).toBeVisible()
+  await expect(page.getByTestId('tab-settings')).toHaveAttribute('aria-current', 'page')
+
+  // Auth surfaces sit outside the shell entirely — no TabBar there.
+  await page.context().clearCookies()
+  await page.goto('/login')
+  await expect(page).toHaveURL('/login')
+  await expect(page.getByTestId('tab-bar')).not.toBeVisible()
+})

--- a/frontend/e2e/workout-logging.spec.ts
+++ b/frontend/e2e/workout-logging.spec.ts
@@ -12,8 +12,8 @@ import { expect, test, type Page, type Route } from '@playwright/test'
 //      guards on `/`, `/log`, and `/history` let the user through without
 //      walking the onboarding chat.
 //   3. `GET /api/v1/plan/current` is stubbed with a populated projection so the
-//      home page renders the plan view (and therefore the "Workout history"
-//      link the user clicks to reach the surface under test).
+//      home page renders the plan view (the shell's TabBar, from which the
+//      user reaches the history surface under test, is always present).
 //   4. The slice-2b units under test are NOT stubbed: `POST .../workouts/logs`
 //      (create) and `POST .../workouts/logs/query` (history) hit the real
 //      backend. The freshly-registered user has no real plan (onboarding/plan
@@ -25,6 +25,7 @@ import { expect, test, type Page, type Route } from '@playwright/test'
 // freeform note. The journey asserts both appear in the week-grouped history
 // surface and that the rich workout's note + metric render.
 
+// eslint-disable-next-line sonarjs/no-hardcoded-passwords -- static E2E fixture password (matches the sibling e2e specs), not a real credential
 const VALID_PASSWORD = 'Correct-Horse-9!'
 
 // Fresh email per run so the suite is re-runnable against a shared dev Postgres
@@ -207,8 +208,10 @@ test('register → log a minimum + a rich workout → both appear in week-groupe
     avgHr: '150',
   })
 
-  // 3. Navigate to the history surface via the home link (the real UI path).
-  await page.getByTestId('home-history-link').click()
+  // 3. Navigate to the history surface via the TabBar LOG BOOK tab (the real
+  //    UI path — Slice 1 replaced the home-page chrome link with the shared
+  //    bottom nav).
+  await page.getByTestId('tab-history').click()
   await expect(page).toHaveURL('/history')
   await expect(page.getByTestId('workout-history-page')).toBeVisible()
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <link rel="apple-touch-icon" href="/favicon.svg" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#10140F" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>SPLIT</title>
     <script>
       // No-flash theme script — must run before the module script below so

--- a/frontend/src/app/modules/app/app.component.spec.tsx
+++ b/frontend/src/app/modules/app/app.component.spec.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { toast } from 'sonner'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
@@ -55,8 +55,35 @@ vi.mock('~/error-boundary/report-client-error', () => ({
   reportClientError: vi.fn(),
 }))
 
+// Route-guard-asymmetry coverage (below) renders the real `App` route table
+// end-to-end rather than a hand-built harness, so it swaps in lightweight
+// stand-ins for every routed page — isolating the guard wiring under test
+// from each page's own data-fetching concerns (e.g. `SettingsPage`'s
+// `useGetCurrentPlanQuery`, which needs RTK Query middleware this spec's
+// bare `authSlice`-only store does not configure).
+vi.mock('~/modules/plan/pages/home.page', () => ({
+  HomePage: () => <div data-testid="home-page">home</div>,
+}))
+vi.mock('~/modules/coaching/pages/coach.page', () => ({
+  CoachPage: () => <div data-testid="coach-page">coach</div>,
+}))
+vi.mock('~/modules/logging/pages/log.page', () => ({
+  LogPage: () => <div data-testid="log-page">log</div>,
+}))
+vi.mock('~/modules/logging/pages/history.page', () => ({
+  HistoryPage: () => <div data-testid="history-page">history</div>,
+}))
+vi.mock('~/modules/settings/pages/settings.page', () => ({
+  SettingsPage: () => <div data-testid="settings-page">settings</div>,
+}))
+vi.mock('~/modules/onboarding/pages/onboarding.page', () => ({
+  OnboardingPage: () => <div data-testid="onboarding-page">onboarding</div>,
+}))
+
 import { App } from './app.component'
 import { OnboardingRedirectGuard } from './app.component'
+import { store as realAppStore } from './app.store'
+import { sessionVerified } from '~/modules/auth/store/auth.slice'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -317,5 +344,84 @@ describe('OnboardingRedirectGuard', () => {
     renderGuard({ expectComplete: true, redirectTo: '/', startAt: '/onboarding' })
     expect(screen.getByTestId('guarded-content')).toBeInTheDocument()
     expect(screen.queryByTestId('location')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Route-guard asymmetry at the composed route-table level
+//
+// `/`, `/coach`, `/log`, `/history` are each wrapped in
+// `OnboardingRedirectGuard(expectComplete=false)`; `/settings` is
+// deliberately left unguarded (see app.component.tsx's "No onboarding
+// guard" comment). The specs above exercise `OnboardingRedirectGuard` in
+// isolation via a hand-built two-route harness — none render the real,
+// composed `<App>` route tree, so nothing would catch a future refactor
+// that accidentally guards `/settings` or drops the guard from a shell
+// route. These specs render `<App>` end-to-end (real `BrowserRouter`,
+// navigated via `window.history.pushState`) under an incomplete-onboarding
+// state and assert the guard asymmetry holds.
+// ---------------------------------------------------------------------------
+
+describe('App route table — onboarding guard asymmetry', () => {
+  beforeEach(() => {
+    // `App` renders against its own real, module-singleton store (not the
+    // `makeStore()` harness used above) — dispatch straight to it so
+    // `RequireAuth` clears its 'unknown'-status loading fallback and the
+    // route table underneath actually mounts.
+    realAppStore.dispatch(sessionVerified({ userId: 'usr_1', email: 'runner@example.com' }))
+  })
+
+  afterEach(() => {
+    window.history.pushState({}, '', '/')
+  })
+
+  it('does not redirect away from /settings when onboarding is incomplete', () => {
+    getOnboardingStateMock.mockReturnValue({
+      data: { isComplete: false },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    })
+    window.history.pushState({}, '', '/settings')
+
+    render(<App />)
+
+    expect(screen.getByTestId('settings-page')).toBeInTheDocument()
+    expect(screen.queryByTestId('onboarding-page')).not.toBeInTheDocument()
+  })
+
+  it('redirects /coach to /onboarding when onboarding is incomplete', () => {
+    getOnboardingStateMock.mockReturnValue({
+      data: { isComplete: false },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    })
+    window.history.pushState({}, '', '/coach')
+
+    render(<App />)
+
+    expect(screen.getByTestId('onboarding-page')).toBeInTheDocument()
+    expect(screen.queryByTestId('coach-page')).not.toBeInTheDocument()
+  })
+
+  it('redirects /log and /history to /onboarding when onboarding is incomplete', () => {
+    getOnboardingStateMock.mockReturnValue({
+      data: { isComplete: false },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    })
+
+    window.history.pushState({}, '', '/log')
+    const { unmount } = render(<App />)
+    expect(screen.getByTestId('onboarding-page')).toBeInTheDocument()
+    expect(screen.queryByTestId('log-page')).not.toBeInTheDocument()
+    unmount()
+
+    window.history.pushState({}, '', '/history')
+    render(<App />)
+    expect(screen.getByTestId('onboarding-page')).toBeInTheDocument()
+    expect(screen.queryByTestId('history-page')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/app/modules/app/app.component.tsx
+++ b/frontend/src/app/modules/app/app.component.tsx
@@ -31,6 +31,15 @@ interface OnboardingRedirectGuardProps {
   expectComplete: boolean
   redirectTo: string
   children: ReactElement
+  /**
+   * Whether the loading/error fallback should center against the full
+   * viewport (`min-h-screen`) or the available space inside its parent
+   * (`min-h-full`). `/onboarding` renders outside `ShellLayout` with no
+   * ancestor providing height, so it needs the viewport-based fallback;
+   * the four shell routes render inside `ShellLayout`'s `Outlet` wrapper,
+   * where `min-h-screen` overflows past the tab-bar clearance padding.
+   */
+  fullScreen?: boolean
 }
 
 const isErrorStatus = (error: unknown, expected: number): boolean => {
@@ -66,15 +75,17 @@ export const OnboardingRedirectGuard = ({
   expectComplete,
   redirectTo,
   children,
+  fullScreen = true,
 }: OnboardingRedirectGuardProps): ReactElement => {
   const { data, isLoading, isError, error, refetch } = useGetOnboardingStateQuery(undefined)
+  const heightClass = fullScreen ? 'min-h-screen' : 'min-h-full'
 
   if (isLoading) {
     return (
       <div
         role="status"
         aria-live="polite"
-        className="flex min-h-screen items-center justify-center bg-background"
+        className={`flex ${heightClass} items-center justify-center bg-background`}
       >
         <span className="text-sm text-muted-foreground">Loading…</span>
       </div>
@@ -91,7 +102,7 @@ export const OnboardingRedirectGuard = ({
       <div
         role="alert"
         data-testid="onboarding-guard-error"
-        className="flex min-h-screen flex-col items-center justify-center gap-3 bg-background px-4 text-center"
+        className={`flex ${heightClass} flex-col items-center justify-center gap-3 bg-background px-4 text-center`}
       >
         <p className="text-sm text-muted-foreground">
           We couldn’t reach the onboarding service. Check your connection and try again.
@@ -162,7 +173,11 @@ const AppShell = () => {
           <Route
             path="/"
             element={
-              <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
+              <OnboardingRedirectGuard
+                expectComplete={false}
+                redirectTo="/onboarding"
+                fullScreen={false}
+              >
                 <HomePage />
               </OnboardingRedirectGuard>
             }
@@ -170,7 +185,11 @@ const AppShell = () => {
           <Route
             path="/coach"
             element={
-              <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
+              <OnboardingRedirectGuard
+                expectComplete={false}
+                redirectTo="/onboarding"
+                fullScreen={false}
+              >
                 <CoachPage />
               </OnboardingRedirectGuard>
             }
@@ -178,7 +197,11 @@ const AppShell = () => {
           <Route
             path="/log"
             element={
-              <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
+              <OnboardingRedirectGuard
+                expectComplete={false}
+                redirectTo="/onboarding"
+                fullScreen={false}
+              >
                 <LogPage />
               </OnboardingRedirectGuard>
             }
@@ -186,7 +209,11 @@ const AppShell = () => {
           <Route
             path="/history"
             element={
-              <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
+              <OnboardingRedirectGuard
+                expectComplete={false}
+                redirectTo="/onboarding"
+                fullScreen={false}
+              >
                 <HistoryPage />
               </OnboardingRedirectGuard>
             }

--- a/frontend/src/app/modules/app/app.component.tsx
+++ b/frontend/src/app/modules/app/app.component.tsx
@@ -10,6 +10,7 @@ import { useGlobalErrorReporter } from '~/error-boundary/use-global-error-report
 import { ShellLayout } from '~/modules/app/components/shell-layout/shell-layout.component'
 import { RequireAuth } from '~/modules/auth/components/require-auth.component'
 import { useAuthBootstrap, useAuthBroadcastListener } from '~/modules/auth/hooks/auth.hooks'
+import { CoachPage } from '~/modules/coaching/pages/coach.page'
 import { HistoryPage } from '~/modules/logging/pages/history.page'
 import { LogPage } from '~/modules/logging/pages/log.page'
 import { OnboardingPage } from '~/modules/onboarding/pages/onboarding.page'
@@ -163,6 +164,14 @@ const AppShell = () => {
             element={
               <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
                 <HomePage />
+              </OnboardingRedirectGuard>
+            }
+          />
+          <Route
+            path="/coach"
+            element={
+              <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
+                <CoachPage />
               </OnboardingRedirectGuard>
             }
           />

--- a/frontend/src/app/modules/app/app.component.tsx
+++ b/frontend/src/app/modules/app/app.component.tsx
@@ -7,6 +7,7 @@ import { store } from './app.store'
 import { useGetOnboardingStateQuery } from '~/api/onboarding.api'
 import { AppErrorBoundary } from '~/error-boundary/app-error-boundary'
 import { useGlobalErrorReporter } from '~/error-boundary/use-global-error-reporter'
+import { ShellLayout } from '~/modules/app/components/shell-layout/shell-layout.component'
 import { RequireAuth } from '~/modules/auth/components/require-auth.component'
 import { useAuthBootstrap, useAuthBroadcastListener } from '~/modules/auth/hooks/auth.hooks'
 import { HistoryPage } from '~/modules/logging/pages/history.page'
@@ -151,43 +152,39 @@ const AppShell = () => {
           }
         />
         <Route
-          path="/"
           element={
             <RequireAuth>
+              <ShellLayout />
+            </RequireAuth>
+          }
+        >
+          <Route
+            path="/"
+            element={
               <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
                 <HomePage />
               </OnboardingRedirectGuard>
-            </RequireAuth>
-          }
-        />
-        <Route
-          path="/log"
-          element={
-            <RequireAuth>
+            }
+          />
+          <Route
+            path="/log"
+            element={
               <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
                 <LogPage />
               </OnboardingRedirectGuard>
-            </RequireAuth>
-          }
-        />
-        <Route
-          path="/history"
-          element={
-            <RequireAuth>
+            }
+          />
+          <Route
+            path="/history"
+            element={
               <OnboardingRedirectGuard expectComplete={false} redirectTo="/onboarding">
                 <HistoryPage />
               </OnboardingRedirectGuard>
-            </RequireAuth>
-          }
-        />
-        <Route
-          path="/settings"
-          element={
-            <RequireAuth>
-              <SettingsPage />
-            </RequireAuth>
-          }
-        />
+            }
+          />
+          {/* No onboarding guard — matches today's behavior. */}
+          <Route path="/settings" element={<SettingsPage />} />
+        </Route>
         {/* Dev-only design-token inspector. `import.meta.env.DEV` is
             replaced with the literal `false` by Vite during `build`, so
             this <Route> is never registered and `ThemeDebugPage` is

--- a/frontend/src/app/modules/app/components/shell-layout/shell-layout.component.spec.tsx
+++ b/frontend/src/app/modules/app/components/shell-layout/shell-layout.component.spec.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { ShellLayout } from './shell-layout.component'
+
+const renderShellAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route element={<ShellLayout />}>
+          <Route path="/" element={<div data-testid="page-content">Home</div>} />
+          <Route path="/settings" element={<div data-testid="page-content">Settings</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  )
+
+describe('ShellLayout', () => {
+  it('renders the routed page content via Outlet', () => {
+    renderShellAt('/')
+    expect(screen.getByTestId('page-content')).toHaveTextContent('Home')
+  })
+
+  it('renders the TabBar alongside the page content', () => {
+    renderShellAt('/')
+    expect(screen.getByTestId('tab-bar')).toBeInTheDocument()
+  })
+
+  it('keeps the TabBar mounted and reflects the routed content on another shell route', () => {
+    renderShellAt('/settings')
+    expect(screen.getByTestId('tab-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('page-content')).toHaveTextContent('Settings')
+  })
+})

--- a/frontend/src/app/modules/app/components/shell-layout/shell-layout.component.tsx
+++ b/frontend/src/app/modules/app/components/shell-layout/shell-layout.component.tsx
@@ -11,7 +11,7 @@ import { TabBar, TAB_BAR_CLEARANCE } from '~/modules/app/components/tab-bar/tab-
  * render with no tab bar at all.
  */
 export const ShellLayout = (): ReactElement => (
-  <div className="min-h-screen bg-background">
+  <div className="min-h-dvh bg-background">
     <div style={{ paddingBottom: TAB_BAR_CLEARANCE }}>
       <Outlet />
     </div>

--- a/frontend/src/app/modules/app/components/shell-layout/shell-layout.component.tsx
+++ b/frontend/src/app/modules/app/components/shell-layout/shell-layout.component.tsx
@@ -1,0 +1,20 @@
+import type { ReactElement } from 'react'
+import { Outlet } from 'react-router-dom'
+import { TabBar, TAB_BAR_CLEARANCE } from '~/modules/app/components/tab-bar/tab-bar.component'
+
+/**
+ * Shared shell for every authenticated, onboarded route: a scrollable
+ * content region (the routed page via `<Outlet />`) plus the fixed
+ * `<TabBar />`. The content region is padded by `TAB_BAR_CLEARANCE` so no
+ * page content ever renders behind the bar (spec § AD2). `/login`,
+ * `/register`, and `/onboarding` are NOT nested under this layout — they
+ * render with no tab bar at all.
+ */
+export const ShellLayout = (): ReactElement => (
+  <div className="min-h-screen bg-background">
+    <div style={{ paddingBottom: TAB_BAR_CLEARANCE }}>
+      <Outlet />
+    </div>
+    <TabBar />
+  </div>
+)

--- a/frontend/src/app/modules/app/components/shell-layout/shell-layout.component.tsx
+++ b/frontend/src/app/modules/app/components/shell-layout/shell-layout.component.tsx
@@ -3,12 +3,13 @@ import { Outlet } from 'react-router-dom'
 import { TabBar, TAB_BAR_CLEARANCE } from '~/modules/app/components/tab-bar/tab-bar.component'
 
 /**
- * Shared shell for every authenticated, onboarded route: a scrollable
- * content region (the routed page via `<Outlet />`) plus the fixed
- * `<TabBar />`. The content region is padded by `TAB_BAR_CLEARANCE` so no
- * page content ever renders behind the bar (spec § AD2). `/login`,
- * `/register`, and `/onboarding` are NOT nested under this layout — they
- * render with no tab bar at all.
+ * Shared shell for every authenticated route: a scrollable content region
+ * (the routed page via `<Outlet />`) plus the fixed `<TabBar />`. The
+ * content region is padded by `TAB_BAR_CLEARANCE` so no page content ever
+ * renders behind the bar (spec § AD2). `/login`, `/register`, and
+ * `/onboarding` are NOT nested under this layout — they render with no tab
+ * bar at all. Not every nested route is onboarding-gated: `/settings` is
+ * deliberately left without an `OnboardingRedirectGuard`.
  */
 export const ShellLayout = (): ReactElement => (
   <div className="min-h-dvh bg-background">

--- a/frontend/src/app/modules/app/components/tab-bar/tab-bar.component.spec.tsx
+++ b/frontend/src/app/modules/app/components/tab-bar/tab-bar.component.spec.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { TabBar } from './tab-bar.component'
+
+// `NavLink` needs router context; wrap in a minimal route table so
+// `useLocation`-driven active-state matching behaves exactly as it would
+// nested under `ShellLayout` in the real app.
+const renderTabBarAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="*" element={<TabBar />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+
+describe('TabBar', () => {
+  it('renders a Primary nav landmark', () => {
+    renderTabBarAt('/')
+    expect(screen.getByRole('navigation', { name: 'Primary' })).toBeInTheDocument()
+  })
+
+  it('renders five interactive targets with accessible names', () => {
+    renderTabBarAt('/')
+    expect(screen.getByRole('link', { name: /today/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /coach/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Log a workout' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /log book/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument()
+  })
+
+  it('marks TODAY as the current page when on /', () => {
+    renderTabBarAt('/')
+    expect(screen.getByTestId('tab-today')).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByTestId('tab-settings')).not.toHaveAttribute('aria-current')
+  })
+
+  it('marks SETTINGS as the current page when on /settings', () => {
+    renderTabBarAt('/settings')
+    expect(screen.getByTestId('tab-settings')).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByTestId('tab-today')).not.toHaveAttribute('aria-current')
+  })
+
+  it('marks COACH as the current page when on /coach', () => {
+    renderTabBarAt('/coach')
+    expect(screen.getByTestId('tab-coach')).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('marks LOG BOOK as the current page when on /history', () => {
+    renderTabBarAt('/history')
+    expect(screen.getByTestId('tab-history')).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('does not mark TODAY current on unrelated shell routes (exact match on "/")', () => {
+    renderTabBarAt('/history')
+    expect(screen.getByTestId('tab-today')).not.toHaveAttribute('aria-current')
+  })
+
+  it('exposes the expected new data-testids', () => {
+    renderTabBarAt('/')
+    expect(screen.getByTestId('tab-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('tab-today')).toBeInTheDocument()
+    expect(screen.getByTestId('tab-coach')).toBeInTheDocument()
+    expect(screen.getByTestId('tab-log')).toBeInTheDocument()
+    expect(screen.getByTestId('tab-history')).toBeInTheDocument()
+    expect(screen.getByTestId('tab-settings')).toBeInTheDocument()
+  })
+
+  it('points each target at its route', () => {
+    renderTabBarAt('/')
+    expect(screen.getByTestId('tab-today')).toHaveAttribute('href', '/')
+    expect(screen.getByTestId('tab-coach')).toHaveAttribute('href', '/coach')
+    expect(screen.getByTestId('tab-log')).toHaveAttribute('href', '/log')
+    expect(screen.getByTestId('tab-history')).toHaveAttribute('href', '/history')
+    expect(screen.getByTestId('tab-settings')).toHaveAttribute('href', '/settings')
+  })
+})

--- a/frontend/src/app/modules/app/components/tab-bar/tab-bar.component.tsx
+++ b/frontend/src/app/modules/app/components/tab-bar/tab-bar.component.tsx
@@ -1,0 +1,73 @@
+import type { ComponentType, ReactElement } from 'react'
+import { Clock, Home, MessageCircle, Plus, SlidersHorizontal } from 'lucide-react'
+import { NavLink, type NavLinkRenderProps } from 'react-router-dom'
+import { cn } from '@/lib/utils'
+
+// Reserved vertical space the fixed bar occupies at the bottom of the
+// viewport, including the raised center action and the safe-area inset.
+// `ShellLayout` pads its content region by this amount and `CoachPage`
+// sizes its full-height flex column against it — single source of truth so
+// the two never drift out of sync.
+export const TAB_BAR_CLEARANCE = 'calc(84px + env(safe-area-inset-bottom))'
+
+interface TabBarLinkItem {
+  to: string
+  label: string
+  icon: ComponentType<{ className?: string; 'aria-hidden'?: boolean }>
+  testId: string
+}
+
+const LEADING_ITEMS: readonly TabBarLinkItem[] = [
+  { to: '/', label: 'Today', icon: Home, testId: 'tab-today' },
+  { to: '/coach', label: 'Coach', icon: MessageCircle, testId: 'tab-coach' },
+]
+
+const TRAILING_ITEMS: readonly TabBarLinkItem[] = [
+  { to: '/history', label: 'Log book', icon: Clock, testId: 'tab-history' },
+  { to: '/settings', label: 'Settings', icon: SlidersHorizontal, testId: 'tab-settings' },
+]
+
+const tabLinkClassName = ({ isActive }: NavLinkRenderProps): string =>
+  cn(
+    'flex min-h-11 flex-col items-center justify-center gap-1 transition-colors duration-200 ease-out motion-reduce:transition-none',
+    isActive ? 'text-clay-text' : 'text-muted-foreground',
+  )
+
+const TabLink = ({ to, label, icon: Icon, testId }: TabBarLinkItem): ReactElement => (
+  <NavLink to={to} end={to === '/'} data-testid={testId} className={tabLinkClassName}>
+    <Icon aria-hidden className="size-[21px]" />
+    <span className="font-condensed text-[10px] font-semibold tracking-[0.12em] uppercase">
+      {label}
+    </span>
+  </NavLink>
+)
+
+/**
+ * Fixed bottom primary navigation — the app's single navigation system
+ * (SPLIT/Alpine Slice 1). Five columns: TODAY, COACH, a raised center LOG
+ * action, LOG BOOK, and SETTINGS. Uses `NavLink` so `aria-current="page"`
+ * tracks the active route automatically; the center action always reads as
+ * the clay accent regardless of route (spec § Design contract).
+ */
+export const TabBar = (): ReactElement => (
+  <nav
+    aria-label="Primary"
+    data-testid="tab-bar"
+    className="fixed inset-x-0 bottom-0 grid grid-cols-5 items-center border-t border-border bg-card pt-2 pb-[calc(0.75rem+env(safe-area-inset-bottom))]"
+  >
+    <TabLink {...LEADING_ITEMS[0]} />
+    <TabLink {...LEADING_ITEMS[1]} />
+    <div className="flex justify-center">
+      <NavLink
+        to="/log"
+        aria-label="Log a workout"
+        data-testid="tab-log"
+        className="-mt-6.5 flex size-[54px] min-h-11 min-w-11 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-transform duration-200 ease-out active:scale-[0.98] motion-reduce:transition-none"
+      >
+        <Plus aria-hidden className="size-6" />
+      </NavLink>
+    </div>
+    <TabLink {...TRAILING_ITEMS[0]} />
+    <TabLink {...TRAILING_ITEMS[1]} />
+  </nav>
+)

--- a/frontend/src/app/modules/app/components/tab-bar/tab-bar.component.tsx
+++ b/frontend/src/app/modules/app/components/tab-bar/tab-bar.component.tsx
@@ -29,7 +29,8 @@ const TRAILING_ITEMS: readonly TabBarLinkItem[] = [
 
 const tabLinkClassName = ({ isActive }: NavLinkRenderProps): string =>
   cn(
-    'flex min-h-11 flex-col items-center justify-center gap-1 transition-colors duration-200 ease-out motion-reduce:transition-none',
+    'flex min-h-11 flex-col items-center justify-center gap-1 rounded-md transition-colors duration-200 ease-out motion-reduce:transition-none',
+    'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/[0.22] focus-visible:outline-none',
     isActive ? 'text-clay-text' : 'text-muted-foreground',
   )
 
@@ -62,7 +63,7 @@ export const TabBar = (): ReactElement => (
         to="/log"
         aria-label="Log a workout"
         data-testid="tab-log"
-        className="-mt-6.5 flex size-[54px] min-h-11 min-w-11 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-transform duration-200 ease-out active:scale-[0.98] motion-reduce:transition-none"
+        className="-mt-6.5 flex size-[54px] min-h-11 min-w-11 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-transform duration-200 ease-out focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/[0.22] focus-visible:outline-none active:scale-[0.98] motion-reduce:transition-none"
       >
         <Plus aria-hidden className="size-6" />
       </NavLink>

--- a/frontend/src/app/modules/coaching/components/coach-chat.component.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-chat.component.tsx
@@ -161,14 +161,14 @@ export const CoachChat = (): ReactElement => {
     <section
       aria-labelledby="coach-chat-heading"
       data-testid="coach-chat"
-      className="flex flex-col gap-3"
+      className="flex min-h-0 flex-1 flex-col gap-3"
     >
       <h2 id="coach-chat-heading" className="text-lg font-semibold text-foreground">
         Coach
       </h2>
       <TranscriptScroller
         turnCount={scrollKey}
-        className="max-h-[28rem] rounded-md border border-border bg-card p-4"
+        className="min-h-0 flex-1 rounded-md border border-border bg-card p-4"
       >
         {timeline.map((turn) => (
           <TimelineRow key={turn.turnId} turn={turn} units={units} />

--- a/frontend/src/app/modules/coaching/pages/coach.page.spec.tsx
+++ b/frontend/src/app/modules/coaching/pages/coach.page.spec.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PreferredUnits } from '~/api/generated'
+import type { UseCoachStreamReturn } from '~/modules/coaching/hooks/use-coach-stream.hooks'
+
+const { timelineMock, streamMock, preferredUnitsMock } = vi.hoisted(() => ({
+  timelineMock: vi.fn(),
+  streamMock: vi.fn(),
+  preferredUnitsMock: vi.fn<() => PreferredUnits>(),
+}))
+
+vi.mock('~/api/conversation.api', () => ({
+  useGetConversationTimelineQuery: () => timelineMock(),
+  useConfirmConversationalLogMutation: () => [vi.fn(), { isLoading: false }],
+}))
+vi.mock('~/modules/coaching/hooks/use-coach-stream.hooks', () => ({
+  useCoachStream: () => streamMock(),
+}))
+vi.mock('~/modules/settings/hooks/use-preferred-units.hooks', () => ({
+  usePreferredUnits: () => preferredUnitsMock(),
+}))
+
+import { CoachPage } from './coach.page'
+
+const idleStream = (): UseCoachStreamReturn => ({
+  pendingUserMessage: null,
+  streamingText: '',
+  isStreaming: false,
+  safety: null,
+  card: null,
+  error: null,
+  send: vi.fn(),
+  retry: vi.fn(),
+  dismissCard: vi.fn(),
+})
+
+const renderCoachPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/coach']}>
+      <CoachPage />
+    </MemoryRouter>,
+  )
+
+describe('CoachPage', () => {
+  beforeEach(() => {
+    timelineMock.mockReturnValue({ data: { turns: [] }, isLoading: false, isError: false })
+    streamMock.mockReturnValue(idleStream())
+    preferredUnitsMock.mockReturnValue(PreferredUnits.Kilometers)
+  })
+
+  it('mounts under the coach-page testid', () => {
+    renderCoachPage()
+    expect(screen.getByTestId('coach-page')).toBeInTheDocument()
+  })
+
+  it('mounts the full existing CoachChat experience — transcript + composer', () => {
+    renderCoachPage()
+    expect(screen.getByTestId('coach-chat')).toBeInTheDocument()
+    expect(screen.getByTestId('transcript-scroller')).toBeInTheDocument()
+    expect(screen.getByTestId('coach-composer')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/modules/coaching/pages/coach.page.tsx
+++ b/frontend/src/app/modules/coaching/pages/coach.page.tsx
@@ -6,8 +6,8 @@ import { CoachChat } from '~/modules/coaching/components/coach-chat.component'
  * The `/coach` route (spec § AD3). A mechanical relocation of the existing
  * `<CoachChat />` — previously mounted mid-page on home — into its own
  * full-height screen so the transcript scrolls and the composer pins
- * directly above the `TabBar`. No turn-kind restyling and no new header
- * chrome here; that is Slice 3's scope. `CoachChat`'s own behavior
+ * directly above the `TabBar`. No turn-kind restyling or header chrome
+ * is added here; `CoachChat`'s own behavior
  * contract (streaming, retry, confirm, Edit→`/log`) is untouched.
  */
 const CoachPage = (): ReactElement => (

--- a/frontend/src/app/modules/coaching/pages/coach.page.tsx
+++ b/frontend/src/app/modules/coaching/pages/coach.page.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement } from 'react'
+import { TAB_BAR_CLEARANCE } from '~/modules/app/components/tab-bar/tab-bar.component'
+import { CoachChat } from '~/modules/coaching/components/coach-chat.component'
+
+/**
+ * The `/coach` route (spec § AD3). A mechanical relocation of the existing
+ * `<CoachChat />` — previously mounted mid-page on home — into its own
+ * full-height screen so the transcript scrolls and the composer pins
+ * directly above the `TabBar`. No turn-kind restyling and no new header
+ * chrome here; that is Slice 3's scope. `CoachChat`'s own behavior
+ * contract (streaming, retry, confirm, Edit→`/log`) is untouched.
+ */
+const CoachPage = (): ReactElement => (
+  <div
+    className="flex flex-col px-4 py-4"
+    style={{ height: `calc(100dvh - ${TAB_BAR_CLEARANCE})` }}
+    data-testid="coach-page"
+  >
+    <CoachChat />
+  </div>
+)
+
+export default CoachPage
+export { CoachPage }

--- a/frontend/src/app/modules/logging/pages/history.page.spec.tsx
+++ b/frontend/src/app/modules/logging/pages/history.page.spec.tsx
@@ -145,12 +145,6 @@ describe('HistoryPage', () => {
     expect(screen.queryByTestId('workout-history-load-older')).toBeNull()
   })
 
-  it('renders a back link to the plan home', () => {
-    setQueryState({ data: dataOf(page([log('2026-06-07')])) })
-    renderPage()
-    expect(screen.getByRole('link', { name: /back to plan/i })).toHaveAttribute('href', '/')
-  })
-
   it('renders entries in miles when the unit preference is Miles', () => {
     preferredUnitsMock.mockReturnValueOnce(PreferredUnits.Miles)
     setQueryState({ data: dataOf(page([log('2026-06-07')])) })

--- a/frontend/src/app/modules/logging/pages/history.page.tsx
+++ b/frontend/src/app/modules/logging/pages/history.page.tsx
@@ -106,12 +106,9 @@ export const HistoryPage = (): ReactElement => {
   return (
     <main
       data-testid="workout-history-page"
-      className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-6 bg-background px-4 py-8"
+      className="mx-auto flex min-h-full w-full max-w-3xl flex-col gap-6 bg-background px-4 py-8"
     >
       <header className="flex flex-col gap-1">
-        <Link to="/" className="text-sm text-muted-foreground hover:text-foreground">
-          ← Back to plan
-        </Link>
         <h1 className="text-2xl font-semibold text-foreground">Workout history</h1>
       </header>
 

--- a/frontend/src/app/modules/logging/pages/log.page.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.tsx
@@ -190,7 +190,7 @@ const LogPage = () => {
 
   return (
     <main
-      className="mx-auto flex min-h-screen w-full max-w-md flex-col gap-6 bg-background px-4 py-8"
+      className="mx-auto flex min-h-full w-full max-w-md flex-col gap-6 bg-background px-4 py-8"
       data-testid="log-page"
     >
       <header className="flex flex-col gap-1">

--- a/frontend/src/app/modules/plan/pages/home.page.spec.tsx
+++ b/frontend/src/app/modules/plan/pages/home.page.spec.tsx
@@ -193,10 +193,6 @@ describe('HomePage', () => {
     expect(screen.getByTestId('macro-phase-strip')).toBeInTheDocument()
     expect(screen.getByTestId('today-card')).toBeInTheDocument()
     expect(screen.getByTestId('upcoming-list')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /workout history/i })).toHaveAttribute(
-      'href',
-      '/history',
-    )
   })
 
   it('renders the no-plan-yet state on a 404 response', () => {

--- a/frontend/src/app/modules/plan/pages/home.page.spec.tsx
+++ b/frontend/src/app/modules/plan/pages/home.page.spec.tsx
@@ -2,8 +2,6 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PreferredUnits } from '~/api/generated'
-import type { UseCoachStreamReturn } from '~/modules/coaching/hooks/use-coach-stream.hooks'
-import type { ConversationTimelineDto } from '~/modules/coaching/models/conversation.model'
 import { buildPlanFixture } from '~/modules/plan/components/plan-display.fixture'
 import type { PlanProjectionDto } from '~/modules/plan/models/plan.model'
 
@@ -15,31 +13,13 @@ interface QueryResult {
   refetch: () => void
 }
 
-interface TimelineQueryResult {
-  data?: ConversationTimelineDto
-  isLoading: boolean
-  isError: boolean
-}
-
-const { getCurrentPlanMock, getConversationTimelineMock, coachStreamMock, preferredUnitsMock } =
-  vi.hoisted(() => ({
-    getCurrentPlanMock: vi.fn<() => QueryResult>(),
-    getConversationTimelineMock: vi.fn<() => TimelineQueryResult>(),
-    coachStreamMock: vi.fn<() => UseCoachStreamReturn>(),
-    preferredUnitsMock: vi.fn<() => PreferredUnits>(),
-  }))
+const { getCurrentPlanMock, preferredUnitsMock } = vi.hoisted(() => ({
+  getCurrentPlanMock: vi.fn<() => QueryResult>(),
+  preferredUnitsMock: vi.fn<() => PreferredUnits>(),
+}))
 
 vi.mock('~/api/plan.api', () => ({
   useGetCurrentPlanQuery: () => getCurrentPlanMock(),
-}))
-
-vi.mock('~/api/conversation.api', () => ({
-  useGetConversationTimelineQuery: () => getConversationTimelineMock(),
-  useConfirmConversationalLogMutation: () => [vi.fn(), { isLoading: false }],
-}))
-
-vi.mock('~/modules/coaching/hooks/use-coach-stream.hooks', () => ({
-  useCoachStream: () => coachStreamMock(),
 }))
 
 // `HomePage` reads the unit preference via this hook, which wraps a real RTK
@@ -50,18 +30,6 @@ vi.mock('~/modules/coaching/hooks/use-coach-stream.hooks', () => ({
 vi.mock('~/modules/settings/hooks/use-preferred-units.hooks', () => ({
   usePreferredUnits: () => preferredUnitsMock(),
 }))
-
-const idleStream = (): UseCoachStreamReturn => ({
-  pendingUserMessage: null,
-  streamingText: '',
-  isStreaming: false,
-  safety: null,
-  card: null,
-  error: null,
-  send: vi.fn(),
-  retry: vi.fn(),
-  dismissCard: vi.fn(),
-})
 
 import { HomePage } from './home.page'
 
@@ -75,16 +43,6 @@ const renderHome = () =>
 describe('HomePage', () => {
   beforeEach(() => {
     getCurrentPlanMock.mockReset()
-    getConversationTimelineMock.mockReset()
-    coachStreamMock.mockReset()
-    // Default: an empty timeline + an idle stream — the chat renders its
-    // composer with no turns yet.
-    getConversationTimelineMock.mockReturnValue({
-      data: { turns: [] },
-      isLoading: false,
-      isError: false,
-    })
-    coachStreamMock.mockReturnValue(idleStream())
     preferredUnitsMock.mockReturnValue(PreferredUnits.Kilometers)
   })
 
@@ -223,7 +181,7 @@ describe('HomePage', () => {
     expect(screen.getByTestId('home-page-error')).toBeInTheDocument()
   })
 
-  it('renders the interactive coach chat between today-card and upcoming-list', () => {
+  it('no longer mounts the coach chat on home — it lives on its own /coach route', () => {
     getCurrentPlanMock.mockReturnValue({
       data: buildPlanFixture(),
       isLoading: false,
@@ -232,30 +190,7 @@ describe('HomePage', () => {
     })
     renderHome()
 
-    expect(screen.getByTestId('coach-chat')).toBeInTheDocument()
-    // Document order: the coach chat reads in today's context, before the
-    // forward-looking upcoming stack.
-    const home = screen.getByTestId('home-page')
-    const order = [...home.querySelectorAll('[data-testid]')].map((node) =>
-      node.getAttribute('data-testid'),
-    )
-    expect(order.indexOf('coach-chat')).toBeGreaterThan(order.indexOf('today-card'))
-    expect(order.indexOf('coach-chat')).toBeLessThan(order.indexOf('upcoming-list'))
-  })
-
-  it('still renders the coach chat (composer) when the timeline is empty', () => {
-    getCurrentPlanMock.mockReturnValue({
-      data: buildPlanFixture(),
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    })
-    renderHome()
-
-    expect(screen.getByTestId('coach-chat')).toBeInTheDocument()
-    expect(screen.getByTestId('coach-composer')).toBeInTheDocument()
-    expect(screen.getByTestId('today-card')).toBeInTheDocument()
-    expect(screen.getByTestId('upcoming-list')).toBeInTheDocument()
+    expect(screen.queryByTestId('coach-chat')).not.toBeInTheDocument()
   })
 
   it('omits the macro phase strip but still renders today-card and upcoming-list when plan.macro is null', () => {

--- a/frontend/src/app/modules/plan/pages/home.page.tsx
+++ b/frontend/src/app/modules/plan/pages/home.page.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
-import { CoachChat } from '~/modules/coaching/components/coach-chat.component'
 import { MacroPhaseStrip } from '~/modules/plan/components/macro-phase-strip.component'
 import { TodayCard } from '~/modules/plan/components/today-card.component'
 import { UpcomingList } from '~/modules/plan/components/upcoming-list.component'
@@ -18,7 +17,9 @@ import { usePreferredUnits } from '~/modules/settings/hooks/use-preferred-units.
  * Top-level container for the protected home route (`/`). Composes the
  * plan-render sections: the macro periodisation strip, today's prominent
  * workout (or rest-day variant), and the upcoming stack (rest-of-week +
- * meso summaries).
+ * meso summaries). The interactive coach chat now lives on its own
+ * `/coach` route (spec § AD3) — home is the plan-render surface only,
+ * navigated to and from via the `TabBar`.
  *
  * Behaviour:
  *   - On mount calls `getCurrentPlan` via the `usePlan` hook.
@@ -78,12 +79,6 @@ interface PlanLayoutProps {
  * The `targetEvent`-null / general-fitness path renders a plan whose macro
  * `goalDescription` reflects the absence of a named race — no special-casing
  * required at the page level.
- *
- * The interactive coach chat sits between today's workout and the
- * upcoming stack: the streamed conversation + composed timeline (interactive
- * turns plus the proactive adaptation/safety explanations) read in today's
- * context before the forward-looking sections. It owns its own queries and
- * never blocks the plan view.
  */
 const PlanLayout = ({ plan }: PlanLayoutProps): ReactElement => {
   const currentWeek = resolveCurrentWeek(plan)
@@ -103,8 +98,6 @@ const PlanLayout = ({ plan }: PlanLayoutProps): ReactElement => {
       {currentWeekTemplate === undefined ? null : (
         <TodayCard currentWeek={currentWeekTemplate} workouts={currentWeekWorkouts} units={units} />
       )}
-
-      <CoachChat />
 
       <UpcomingList
         currentWeekWorkouts={currentWeekWorkouts}

--- a/frontend/src/app/modules/plan/pages/home.page.tsx
+++ b/frontend/src/app/modules/plan/pages/home.page.tsx
@@ -93,27 +93,15 @@ const PlanLayout = ({ plan }: PlanLayoutProps): ReactElement => {
 
   return (
     <main
-      className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-8 bg-background px-4 py-8"
+      className="mx-auto flex min-h-full w-full max-w-3xl flex-col gap-8 bg-background px-4 py-8"
       data-testid="home-page"
     >
-      <div className="flex justify-end">
-        <Button asChild variant="ghost" size="sm">
-          <Link to="/history" data-testid="home-history-link">
-            Workout history
-          </Link>
-        </Button>
-      </div>
-
       {plan.macro === null ? null : (
         <MacroPhaseStrip macro={plan.macro} currentWeek={currentWeek} />
       )}
 
       {currentWeekTemplate === undefined ? null : (
-        <TodayCard
-          currentWeek={currentWeekTemplate}
-          workouts={currentWeekWorkouts}
-          units={units}
-        />
+        <TodayCard currentWeek={currentWeekTemplate} workouts={currentWeekWorkouts} units={units} />
       )}
 
       <CoachChat />

--- a/frontend/src/app/modules/plan/pages/home.page.tsx
+++ b/frontend/src/app/modules/plan/pages/home.page.tsx
@@ -40,7 +40,7 @@ export const HomePage = (): ReactElement => {
       <div
         role="status"
         aria-live="polite"
-        className="flex min-h-screen items-center justify-center bg-background"
+        className="flex min-h-full items-center justify-center bg-background"
       >
         <span className="text-sm text-muted-foreground">Loading…</span>
       </div>
@@ -54,7 +54,7 @@ export const HomePage = (): ReactElement => {
   if (isError || plan === undefined) {
     return (
       <main
-        className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background px-4"
+        className="flex min-h-full flex-col items-center justify-center gap-4 bg-background px-4"
         data-testid="home-page-error"
       >
         <h1 className="text-2xl font-semibold text-foreground">Something went wrong</h1>
@@ -118,7 +118,7 @@ const PlanLayout = ({ plan }: PlanLayoutProps): ReactElement => {
  */
 const NoPlanYetState = (): ReactElement => (
   <main
-    className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background px-4"
+    className="flex min-h-full flex-col items-center justify-center gap-4 bg-background px-4"
     data-testid="home-page-no-plan"
   >
     <h1 className="text-2xl font-semibold text-foreground">No plan yet</h1>

--- a/frontend/src/app/modules/settings/pages/settings.page.tsx
+++ b/frontend/src/app/modules/settings/pages/settings.page.tsx
@@ -1,5 +1,4 @@
 import { useState, type ReactElement } from 'react'
-import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { useGetCurrentPlanQuery } from '~/api/plan.api'
@@ -23,14 +22,11 @@ export const SettingsPage = (): ReactElement => {
 
   return (
     <main
-      className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-8 bg-background px-4 py-8"
+      className="mx-auto flex min-h-full w-full max-w-3xl flex-col gap-8 bg-background px-4 py-8"
       data-testid="settings-page"
     >
       <header className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold text-foreground">Settings</h1>
-        <Link to="/" className="text-sm font-medium text-muted-foreground hover:text-foreground">
-          Back to plan
-        </Link>
       </header>
 
       <Card className="gap-2 p-6" data-testid="settings-plan-section">


### PR DESCRIPTION
## SPLIT/Alpine Slice 1 — Shell & Navigation

Gives the app its single navigation system — a fixed bottom **TabBar** + a **tab-shell layout** — and carves **`/coach`** out of the home page. Frontend-only slice; no backend/wire delta. Requirements: `docs/plans/split-ui-cycle/slice-1-shell-navigation.md`; design: HANDOFF § 4.

### What changed
- **`TabBar`** (`app/components/tab-bar/`) — fixed bottom 5-col grid: `TODAY /` · `COACH /coach` · center raised clay **LOG** action → `/log` · `LOG BOOK /history` · `SETTINGS /settings`. `NavLink`-driven active state (`aria-current="page"`), `<nav aria-label="Primary">`, labels always visible, canonical Slice 0 focus-visible ring, ≥44px tap targets, `env(safe-area-inset-bottom)` padding. Active = clay, inactive = muted; center circle always clay with `aria-label="Log a workout"`.
- **`ShellLayout`** (`app/components/shell-layout/`) — `Outlet` + `TabBar`; content region padded by a shared `TAB_BAR_CLEARANCE` so nothing hides behind the bar. `min-h-dvh` for mobile-viewport consistency.
- **Router rewire** — `/`, `/coach`, `/log`, `/history`, `/settings` nested under a `RequireAuth` → `ShellLayout` layout route, each child keeping its **existing** guard (settings unchanged: no onboarding guard). `/login`, `/register`, `/onboarding` stay outside the shell. Guard semantics untouched.
- **`/coach` route + `CoachPage`** — mechanical relocation of `CoachChat` off home into a full-height screen with the composer pinned above the tab bar. No turn-kind restyling / no new header chrome (Slice 3 owns that). CoachChat behavior specs pass **unmodified** (only layout classNames changed).
- **Nav cleanup** — removed `CoachChat` from home + the scattered chrome nav (`home-history-link`, history/settings "Back to plan"). Kept contextual CTAs (empty-state log, no-plan onboarding, Edit→/log, post-submit redirect). Added `viewport-fit=cover`.
- **Tests** — new `TabBar`/`ShellLayout`/`CoachPage` specs (active-state-per-route, five targets, nav landmark, shell-vs-auth rendering); home spec flipped to assert no chat; Playwright realigned to navigate via the tab bar.

### Verification
- `npm run build` ✅ · `npm run test` ✅ (674/674) · `npx eslint` clean on changed files · `check-contrast` 38/38 (no new token pairs).
- Sonnet code review run; both findings (missing focus ring, `100vh`/`100dvh` mismatch) fixed in `9bfe634`.

### ⚠️ Pre-merge manual check
The **mobile-Safari keyboard × pinned composer × fixed tab-bar** interplay (spec's flagged fiddly area) could not be verified in this environment — it needs a real iOS Safari device (desktop Chrome/Playwright won't reproduce the keyboard behavior). Please eyeball `/coach` with the keyboard open on a phone before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent bottom tab bar for navigating between the main app sections.
  * Introduced a dedicated coach screen, with chat moved to its own `/coach` page.
  * Improved mobile viewport handling for better support on devices with safe areas and notches.

* **Bug Fixes**
  * Updated page layouts so content fits correctly with the fixed tab bar.
  * Refined navigation and accessibility behavior so the active tab is clearly indicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->