### PR TITLE
feat(split-ui): Slice 3 PR-B — Coach transcript turn kinds, timestamps, dividers, composer restyle

### DIFF
--- a/frontend/src/app/modules/coaching/components/coach-chat.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-chat.component.spec.tsx
@@ -92,6 +92,37 @@ const coachTurn = (content: string): ConversationTimelineTurnDto => ({
   proactive: null,
 })
 
+const erroredCoachTurn = (): ConversationTimelineTurnDto => ({
+  kind: 1,
+  turnId: 'ce1',
+  createdAt: '2026-06-29T10:00:01Z',
+  interactive: { content: '', isErrored: true, loggedRun: null },
+  proactive: null,
+})
+
+/**
+ * A raw interactive (user/coach) timeline turn with a caller-controlled
+ * `turnId`/`createdAt` — used by the date-divider test, which needs several
+ * turns spanning two distinct local calendar days without colliding on the
+ * fixed `turnId`s the `userTurn`/`coachTurn` helpers above hardcode.
+ * `createdAt` is round-tripped through `new Date(y, m, d, h).toISOString()`
+ * by callers so the local-day grouping under test is TZ-invariant — the
+ * ISO string always re-parses back to the SAME local calendar day under
+ * whatever timezone the test process itself runs in.
+ */
+const turnAt = (
+  kind: 0 | 1,
+  turnId: string,
+  createdAt: string,
+  content: string,
+): ConversationTimelineTurnDto => ({
+  kind,
+  turnId,
+  createdAt,
+  interactive: { content, isErrored: false, loggedRun: null },
+  proactive: null,
+})
+
 const restructureTurn = (
   diff: PlanAdaptationDiffDto = { workoutChanges: [], weeklyTargetChanges: [] },
 ): ConversationTimelineTurnDto => ({
@@ -183,8 +214,10 @@ describe('CoachChat', () => {
 
     renderChat()
 
-    expect(screen.getByText('how was my run?')).toBeInTheDocument()
-    expect(screen.getByText('You ran well.')).toBeInTheDocument()
+    expect(within(screen.getByTestId('user-turn')).getByText('how was my run?')).toBeInTheDocument()
+    expect(
+      within(screen.getByTestId('coach-text-turn')).getByText('You ran well.'),
+    ).toBeInTheDocument()
     expect(
       within(screen.getByTestId('restructure-turn')).getByText('I cut this week to recover.'),
     ).toBeInTheDocument()
@@ -236,6 +269,81 @@ describe('CoachChat', () => {
 
     expect(screen.getByText('tell me about tempo runs')).toBeInTheDocument()
     expect(screen.getByText('A tempo run is')).toBeInTheDocument()
+  })
+
+  it('captures one shared client-side HH:MM for the live pending user turn and streaming coach turn', () => {
+    setTimeline([])
+    streamMock.mockReturnValue(idleStream())
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <CoachChat />
+      </MemoryRouter>,
+    )
+
+    // Transition pendingUserMessage null -> non-null across a rerender —
+    // this is what actually drives the live-time capture in the component
+    // (a fresh mount that is ALREADY mid-exchange never exercises the
+    // transition at all).
+    streamMock.mockReturnValue(
+      idleStream({
+        pendingUserMessage: 'tell me about tempo runs',
+        streamingText: 'A tempo run is',
+        isStreaming: true,
+      }),
+    )
+    rerender(
+      <MemoryRouter>
+        <CoachChat />
+      </MemoryRouter>,
+    )
+
+    const timePattern = /\d{2}:\d{2}/
+    const userTime = screen.getByTestId('turn-meta').textContent?.match(timePattern)?.[0]
+    const coachTime = screen.getByTestId('coach-text-turn').textContent?.match(timePattern)?.[0]
+    // The exact clock value is non-deterministic (a live `new Date()` read) —
+    // only that both live rows share the SAME captured value is asserted.
+    expect(userTime).toBeDefined()
+    expect(coachTime).toBeDefined()
+    expect(userTime).toBe(coachTime)
+  })
+
+  it('renders a date divider before each new local-calendar-day group of persisted turns', () => {
+    const dayOneIso = new Date(2026, 5, 28, 9, 0).toISOString()
+    const dayTwoIso = new Date(2026, 5, 29, 9, 0).toISOString()
+    setTimeline([
+      turnAt(0, 'u1', dayOneIso, 'day one message'),
+      turnAt(1, 'c1', dayOneIso, 'day one reply'),
+      turnAt(0, 'u2', dayTwoIso, 'day two message'),
+    ])
+    streamMock.mockReturnValue(idleStream())
+
+    renderChat()
+
+    const dividers = screen.getAllByTestId('date-divider')
+    expect(dividers).toHaveLength(2)
+    expect(dividers[0]).toHaveTextContent('JUN 28')
+    expect(dividers[1]).toHaveTextContent('JUN 29')
+  })
+
+  it('renders no date divider for an empty timeline', () => {
+    setTimeline([])
+    streamMock.mockReturnValue(idleStream())
+
+    renderChat()
+
+    expect(screen.queryByTestId('date-divider')).not.toBeInTheDocument()
+  })
+
+  it('renders a persisted errored coach turn with its copy and no RETRY control', () => {
+    setTimeline([userTurn('how was my run?'), erroredCoachTurn()])
+    streamMock.mockReturnValue(idleStream())
+
+    renderChat()
+
+    const erroredNote = screen.getByTestId('coach-errored-turn')
+    expect(within(erroredNote).getByText("That reply didn't go through.")).toBeInTheDocument()
+    expect(within(erroredNote).queryByRole('button')).not.toBeInTheDocument()
   })
 
   it('wires the composer send to the stream', async () => {
@@ -320,9 +428,24 @@ describe('CoachChat', () => {
 
     renderChat()
     expect(screen.getByText('My end broke.')).toBeInTheDocument()
+    expect(screen.getByTestId('coach-error')).toHaveClass('border-l-destructive')
     await user.click(screen.getByRole('button', { name: /retry/i }))
 
     expect(retry).toHaveBeenCalledOnce()
+  })
+
+  it('hides the RETRY control on the live error surface when the error is not retryable', () => {
+    setTimeline([])
+    streamMock.mockReturnValue(
+      idleStream({
+        error: { message: 'Cannot retry this one.', retryable: false, retryAfterSeconds: 0 },
+      }),
+    )
+
+    renderChat()
+
+    expect(screen.getByTestId('coach-error')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument()
   })
 
   it('renders the deterministic safety notice during an exchange', () => {

--- a/frontend/src/app/modules/coaching/components/coach-chat.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-chat.component.spec.tsx
@@ -201,6 +201,7 @@ describe('CoachChat', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+    vi.useRealTimers()
   })
 
   it('renders interactive turns as chat bubbles and proactive turns via the existing components', () => {
@@ -306,6 +307,146 @@ describe('CoachChat', () => {
     expect(userTime).toBeDefined()
     expect(coachTime).toBeDefined()
     expect(userTime).toBe(coachTime)
+  })
+
+  it('refreshes liveTime on a retry that resends identical text, not just on a message-text change', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 29, 10, 0))
+    setTimeline([])
+    streamMock.mockReturnValue(idleStream())
+
+    // Mount idle, THEN transition into streaming — a fresh mount that is
+    // already mid-exchange never exercises the false -> true transition.
+    const { rerender } = render(
+      <MemoryRouter>
+        <CoachChat />
+      </MemoryRouter>,
+    )
+    streamMock.mockReturnValue(
+      idleStream({ pendingUserMessage: 'flaky message', isStreaming: true }),
+    )
+    rerender(
+      <MemoryRouter>
+        <CoachChat />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('turn-meta')).toHaveTextContent('10:00')
+
+    // The `error` reducer branch leaves `pendingUserMessage` unchanged — the
+    // bubble stays beside the retry affordance — while `isStreaming` flips
+    // to false.
+    streamMock.mockReturnValue(
+      idleStream({
+        pendingUserMessage: 'flaky message',
+        isStreaming: false,
+        error: { message: 'boom', retryable: true, retryAfterSeconds: null },
+      }),
+    )
+    rerender(
+      <MemoryRouter>
+        <CoachChat />
+      </MemoryRouter>,
+    )
+
+    // RETRY re-sends `lastMessageRef.current` — the identical text — so
+    // `pendingUserMessage` goes X -> X while `isStreaming` flips back to
+    // true. A fix keyed on message-text equality would miss this transition
+    // and leave the original attempt's stale 10:00 timestamp.
+    vi.setSystemTime(new Date(2026, 5, 29, 10, 5))
+    streamMock.mockReturnValue(
+      idleStream({ pendingUserMessage: 'flaky message', isStreaming: true }),
+    )
+    rerender(
+      <MemoryRouter>
+        <CoachChat />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByTestId('turn-meta')).toHaveTextContent('10:05')
+    vi.useRealTimers()
+  })
+
+  it('refreshes liveTime on a direct non-null -> different-non-null pendingUserMessage transition', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 29, 10, 0))
+    setTimeline([])
+    streamMock.mockReturnValue(idleStream())
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <CoachChat />
+      </MemoryRouter>,
+    )
+    streamMock.mockReturnValue(
+      idleStream({ pendingUserMessage: 'first message', isStreaming: true }),
+    )
+    rerender(
+      <MemoryRouter>
+        <CoachChat />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('turn-meta')).toHaveTextContent('10:00')
+
+    streamMock.mockReturnValue(
+      idleStream({
+        pendingUserMessage: 'first message',
+        isStreaming: false,
+        error: { message: 'boom', retryable: true, retryAfterSeconds: null },
+      }),
+    )
+    rerender(
+      <MemoryRouter>
+        <CoachChat />
+      </MemoryRouter>,
+    )
+
+    // A NEW message, sent right after the prior error without going through
+    // null.
+    vi.setSystemTime(new Date(2026, 5, 29, 10, 5))
+    streamMock.mockReturnValue(
+      idleStream({ pendingUserMessage: 'a different message', isStreaming: true }),
+    )
+    rerender(
+      <MemoryRouter>
+        <CoachChat />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByTestId('turn-meta')).toHaveTextContent('10:05')
+    vi.useRealTimers()
+  })
+
+  it('groups a proactive turn into the same local-day bucket as neighbouring interactive turns across a day boundary', () => {
+    const dayOneIso = new Date(2026, 5, 28, 9, 0).toISOString()
+    const dayTwoIso = new Date(2026, 5, 29, 9, 0).toISOString()
+    setTimeline([
+      turnAt(0, 'u1', dayOneIso, 'day one message'),
+      { ...restructureTurn(), turnId: 'a1', createdAt: dayTwoIso },
+      turnAt(0, 'u2', dayTwoIso, 'day two message'),
+    ])
+    streamMock.mockReturnValue(idleStream())
+
+    renderChat()
+
+    const dividers = screen.getAllByTestId('date-divider')
+    expect(dividers).toHaveLength(2)
+    expect(dividers[0]).toHaveTextContent('JUN 28')
+    expect(dividers[1]).toHaveTextContent('JUN 29')
+
+    // `Fragment` renders no wrapping DOM node, so bucketing is verified by
+    // DOM order rather than a parent-container query: the proactive turn
+    // must sit AFTER the second (JUN 29) divider, not the first — i.e. it
+    // buckets alongside `turnAt`'s day-two interactive turn, not day one.
+    const orderedTestIds = within(screen.getByTestId('transcript-scroller'))
+      .getAllByTestId(/^(date-divider|restructure-turn|user-turn)$/)
+      .map((el) => el.getAttribute('data-testid'))
+    expect(orderedTestIds).toEqual([
+      'date-divider',
+      'user-turn',
+      'date-divider',
+      'restructure-turn',
+      'user-turn',
+    ])
   })
 
   it('renders a date divider before each new local-calendar-day group of persisted turns', () => {

--- a/frontend/src/app/modules/coaching/components/coach-chat.component.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-chat.component.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type ReactElement } from 'react'
+import { Fragment, useCallback, useState, type ReactElement } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
@@ -23,17 +23,21 @@ import {
 import { usePreferredUnits } from '~/modules/settings/hooks/use-preferred-units.hooks'
 import { AdaptationTurn } from './adaptation-turn.component'
 import { CoachComposer } from './coach-composer.component'
+import { CoachTextTurn } from './coach-text-turn.component'
+import { DateDivider } from './date-divider.component'
 import { LogConfirmationCard } from './log-confirmation-card.component'
-import { MessageBubble, type MessageRole } from './message-bubble.component'
 import { SafetyTurn } from './safety-turn.component'
+import { formatTurnTime, groupTurnsByLocalDay } from './transcript-time.helpers'
 import { TranscriptScroller } from './transcript-scroller.component'
+import { UserTurn } from './user-turn.component'
 
-// The interactive streaming-conversation panel. It unions the composed timeline
-// (interactive chat bubbles + the proactive adaptation/safety turns, reusing the
-// existing components) with the live in-flight exchange from `useCoachStream`,
-// the confirmation card, and the composer. The streamed coach reply renders as
-// plain text via the shared `MessageBubble` (`whitespace-pre-wrap`) — no
-// markdown, no raw HTML.
+// The interactive streaming-conversation panel. It unions the composed
+// timeline (turn-kind components + the proactive adaptation/safety turns,
+// reusing the existing components) with the live in-flight exchange from
+// `useCoachStream`, the confirmation card, and the composer. Persisted
+// user/coach turns render via `UserTurn`/`CoachTextTurn` (Slice 3 PR-B) —
+// both are plain-text (`whitespace-pre-wrap`), never markdown, never raw
+// HTML.
 
 const NO_TURNS: readonly ConversationTimelineTurnDto[] = []
 
@@ -60,22 +64,19 @@ const isCoachChatLocationState = (value: unknown): value is CoachChatLocationSta
   (!('focusComposer' in value) ||
     typeof (value as { focusComposer?: unknown }).focusComposer === 'boolean')
 
-interface ChatBubbleProps {
-  role: MessageRole
-  text: string
-  pending?: boolean
-}
-
-const ChatBubble = ({ role, text, pending }: ChatBubbleProps): ReactElement => (
-  <div className="flex w-full">
-    <MessageBubble role={role} content={[{ type: 'text', text }]} pending={pending} />
-  </div>
-)
-
+// A persisted historical errored turn has no live `retry()` to call — RETRY
+// belongs only to the live-stream `RetryAffordance` below. Restyled as a
+// `CoachTextTurn`-shaped block (mono `COACH` label, plain body) so it reads
+// as part of the transcript rather than a bare disconnected line.
 const ErroredCoachNote = (): ReactElement => (
-  <p data-testid="coach-errored-turn" className="px-1 text-sm text-muted-foreground">
-    That reply didn&apos;t go through.
-  </p>
+  <div data-testid="coach-errored-turn" className="flex flex-col gap-1">
+    <span className="font-mono text-[10px] font-semibold tracking-[0.1em] text-clay-text">
+      COACH
+    </span>
+    <p className="font-body text-[14.5px] leading-[1.55] text-muted-foreground">
+      That reply didn&apos;t go through.
+    </p>
+  </div>
 )
 
 const SafetyNotice = ({ notice }: { notice: CoachSafetyNotice }): ReactElement => (
@@ -99,11 +100,18 @@ const RetryAffordance = ({ error, onRetry }: RetryAffordanceProps): ReactElement
   <div
     role="alert"
     data-testid="coach-error"
-    className="flex items-center justify-between gap-3 rounded-md border border-border bg-secondary px-3 py-2 text-sm"
+    // Failure-surface token bg-danger-surface lands in PR-C (spec §3 PR-C); using bg-secondary here until then.
+    className="flex items-center justify-between gap-3 rounded-md border-l-[3px] border-l-destructive bg-secondary px-3 py-2"
   >
-    <span className="text-destructive">{error.message}</span>
+    <span className="font-mono text-[12px] text-foreground">{error.message}</span>
     {error.retryable && (
-      <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onRetry}
+        className="font-condensed text-[11px] font-semibold tracking-[0.08em] uppercase"
+      >
         Retry
       </Button>
     )}
@@ -120,9 +128,18 @@ const TimelineRow = ({
   // Narrow on the payload null-ness — exactly one of interactive/proactive is set.
   if (turn.interactive !== null) {
     if (turn.interactive.isErrored) return <ErroredCoachNote />
-    const role: MessageRole =
-      turn.kind === CONVERSATION_TIMELINE_TURN_KIND.user ? 'user' : 'assistant'
-    return <ChatBubble role={role} text={turn.interactive.content} />
+    const time = formatTurnTime(turn.createdAt)
+    if (turn.kind === CONVERSATION_TIMELINE_TURN_KIND.user) {
+      return <UserTurn content={turn.interactive.content} time={time} />
+    }
+    return (
+      <CoachTextTurn
+        content={turn.interactive.content}
+        time={time}
+        loggedRun={turn.interactive.loggedRun}
+        units={units}
+      />
+    )
   }
   return turn.proactive.role === CONVERSATION_ROLE.systemSafety ? (
     <SafetyTurn turn={turn.proactive} />
@@ -150,6 +167,27 @@ export const CoachChat = (): ReactElement => {
   } = useCoachStream()
   const [confirmLog, { isLoading: isConfirming }] = useConfirmConversationalLogMutation()
   const navigate = useNavigate()
+
+  // Both live rows (the optimistic user bubble, the streaming coach block)
+  // share one client-captured `HH:MM` so the pair doesn't visibly disagree
+  // as tokens arrive. Captured once per exchange via React's blessed
+  // "adjust state during render" pattern (comparing against a snapshot of
+  // the previous render's `pendingUserMessage`, tracked in state rather
+  // than a ref — `react-hooks/refs` forbids reading `ref.current` during
+  // render): on ANY transition of `pendingUserMessage` to a new value,
+  // `liveTime` is recomputed — non-null yields a fresh `new Date()` capture,
+  // null clears it. This covers not just null -> non-null but also a direct
+  // non-null -> different-non-null transition (e.g. sending a new message
+  // after a prior exchange errored without going through null), which would
+  // otherwise leave a stale timestamp on the new optimistic bubble. This
+  // `new Date()` read is the ONE sanctioned live wall-clock read — every
+  // persisted turn always uses its server `createdAt` instead.
+  const [prevPendingUserMessage, setPrevPendingUserMessage] = useState(pendingUserMessage)
+  const [liveTime, setLiveTime] = useState('')
+  if (pendingUserMessage !== prevPendingUserMessage) {
+    setPrevPendingUserMessage(pendingUserMessage)
+    setLiveTime(pendingUserMessage !== null ? formatTurnTime(new Date().toISOString()) : '')
+  }
 
   const handleConfirm = useCallback(async (): Promise<void> => {
     if (card === null) return
@@ -182,6 +220,11 @@ export const CoachChat = (): ReactElement => {
   // streaming text length in keeps the live partial pinned to the bottom.
   const scrollKey = timeline.length + (pendingUserMessage !== null ? 1 : 0) + streamingText.length
 
+  // Date dividers are computed over the persisted timeline turns only — the
+  // live pending/streaming exchange belongs to "today" and renders after
+  // the last group with no live-introduced divider (§4.1/§6).
+  const dayGroups = groupTurnsByLocalDay(timeline)
+
   return (
     <section
       aria-labelledby="coach-chat-heading"
@@ -195,11 +238,18 @@ export const CoachChat = (): ReactElement => {
         turnCount={scrollKey}
         className="min-h-0 flex-1 rounded-md border border-border bg-card p-4"
       >
-        {timeline.map((turn) => (
-          <TimelineRow key={turn.turnId} turn={turn} units={units} />
+        {dayGroups.map((group) => (
+          <Fragment key={`day-${group.turns[0]?.turnId ?? group.label}`}>
+            <DateDivider label={group.label} />
+            {group.turns.map((turn) => (
+              <TimelineRow key={turn.turnId} turn={turn} units={units} />
+            ))}
+          </Fragment>
         ))}
-        {pendingUserMessage !== null && <ChatBubble role="user" text={pendingUserMessage} />}
-        {streamingText.length > 0 && <ChatBubble role="assistant" text={streamingText} pending />}
+        {pendingUserMessage !== null && <UserTurn content={pendingUserMessage} time={liveTime} />}
+        {streamingText.length > 0 && (
+          <CoachTextTurn content={streamingText} time={liveTime} streaming />
+        )}
         {safety !== null && <SafetyNotice notice={safety} />}
       </TranscriptScroller>
       {error !== null && (

--- a/frontend/src/app/modules/coaching/components/coach-chat.component.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-chat.component.tsx
@@ -172,21 +172,21 @@ export const CoachChat = (): ReactElement => {
   // share one client-captured `HH:MM` so the pair doesn't visibly disagree
   // as tokens arrive. Captured once per exchange via React's blessed
   // "adjust state during render" pattern (comparing against a snapshot of
-  // the previous render's `pendingUserMessage`, tracked in state rather
-  // than a ref — `react-hooks/refs` forbids reading `ref.current` during
-  // render): on ANY transition of `pendingUserMessage` to a new value,
-  // `liveTime` is recomputed — non-null yields a fresh `new Date()` capture,
-  // null clears it. This covers not just null -> non-null but also a direct
-  // non-null -> different-non-null transition (e.g. sending a new message
-  // after a prior exchange errored without going through null), which would
-  // otherwise leave a stale timestamp on the new optimistic bubble. This
-  // `new Date()` read is the ONE sanctioned live wall-clock read — every
-  // persisted turn always uses its server `createdAt` instead.
-  const [prevPendingUserMessage, setPrevPendingUserMessage] = useState(pendingUserMessage)
+  // the previous render's `isStreaming`, tracked in state rather than a ref
+  // — `react-hooks/refs` forbids reading `ref.current` during render): on
+  // EVERY false -> true transition of `isStreaming`, `liveTime` gets a fresh
+  // `new Date()` capture. `isStreaming` flips on every `start` action — a
+  // fresh send, a new message sent right after a prior error, and a RETRY
+  // that re-sends the identical text all trigger it, so (unlike keying off
+  // `pendingUserMessage`'s string value) an identical-text retry still gets
+  // a fresh timestamp instead of inheriting the original failed attempt's.
+  // This `new Date()` read is the ONE sanctioned live wall-clock read —
+  // every persisted turn always uses its server `createdAt` instead.
+  const [prevIsStreaming, setPrevIsStreaming] = useState(isStreaming)
   const [liveTime, setLiveTime] = useState('')
-  if (pendingUserMessage !== prevPendingUserMessage) {
-    setPrevPendingUserMessage(pendingUserMessage)
-    setLiveTime(pendingUserMessage !== null ? formatTurnTime(new Date().toISOString()) : '')
+  if (isStreaming !== prevIsStreaming) {
+    setPrevIsStreaming(isStreaming)
+    if (isStreaming) setLiveTime(formatTurnTime(new Date().toISOString()))
   }
 
   const handleConfirm = useCallback(async (): Promise<void> => {
@@ -239,7 +239,7 @@ export const CoachChat = (): ReactElement => {
         className="min-h-0 flex-1 rounded-md border border-border bg-card p-4"
       >
         {dayGroups.map((group) => (
-          <Fragment key={`day-${group.turns[0]?.turnId ?? group.label}`}>
+          <Fragment key={`day-${group.turns[0].turnId}`}>
             <DateDivider label={group.label} />
             {group.turns.map((turn) => (
               <TimelineRow key={turn.turnId} turn={turn} units={units} />

--- a/frontend/src/app/modules/coaching/components/coach-composer.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-composer.component.spec.tsx
@@ -5,6 +5,15 @@ import { describe, expect, it, vi } from 'vitest'
 import { CoachComposer } from './coach-composer.component'
 
 describe('CoachComposer', () => {
+  it('shows the design placeholder copy and a 48px clay-square send control with an aria-label', () => {
+    render(<CoachComposer onSend={vi.fn()} isStreaming={false} />)
+
+    expect(screen.getByPlaceholderText('Ask, or describe a run to log…')).toBeInTheDocument()
+    expect(screen.getByLabelText(/message your coach/i)).toHaveClass('min-h-12')
+    const send = screen.getByRole('button', { name: 'Send message' })
+    expect(send).toHaveClass('size-12')
+  })
+
   it('disables the send control until a non-blank message is typed', async () => {
     const user = userEvent.setup()
     render(<CoachComposer onSend={vi.fn()} isStreaming={false} />)

--- a/frontend/src/app/modules/coaching/components/coach-composer.component.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-composer.component.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, type KeyboardEvent, type ReactElement } from 'react'
+import { ArrowUp } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
@@ -69,21 +70,27 @@ export const CoachComposer = ({
         event.preventDefault()
         submit()
       }}
-      className="flex items-end gap-2"
+      className="flex items-end gap-[10px]"
       data-testid="coach-composer"
     >
       <Textarea
         ref={textareaRef}
         aria-label="Message your coach"
-        placeholder="Ask a question or describe a run to log…"
+        placeholder="Ask, or describe a run to log…"
         value={value}
         onChange={(event) => setValue(event.target.value)}
         onKeyDown={handleKeyDown}
         rows={2}
-        className="flex-1 resize-none"
+        className="flex-1 resize-none min-h-12"
       />
-      <Button type="submit" disabled={!canSend}>
-        Send
+      <Button
+        type="submit"
+        size="icon"
+        aria-label="Send message"
+        disabled={!canSend}
+        className="size-12 rounded-md"
+      >
+        <ArrowUp aria-hidden className="size-5" />
       </Button>
     </form>
   )

--- a/frontend/src/app/modules/coaching/components/coach-composer.component.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-composer.component.tsx
@@ -80,7 +80,7 @@ export const CoachComposer = ({
         value={value}
         onChange={(event) => setValue(event.target.value)}
         onKeyDown={handleKeyDown}
-        rows={2}
+        rows={1}
         className="flex-1 resize-none min-h-12"
       />
       <Button

--- a/frontend/src/app/modules/coaching/components/coach-text-turn.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-text-turn.component.spec.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import {
+  expectDualThemeParity,
+  renderInBothThemes,
+} from '~/modules/common/test-utils/render-in-both-themes'
+import { CoachTextTurn } from './coach-text-turn.component'
+
+describe('CoachTextTurn', () => {
+  it('renders no bubble — just a mono COACH · HH:MM label and bone body text', () => {
+    render(<CoachTextTurn content="You ran well." time="06:59" />)
+
+    const root = screen.getByTestId('coach-text-turn')
+    expect(root).not.toHaveClass('bg-muted')
+    expect(root).not.toHaveClass('bg-primary')
+    expect(screen.getByText(/COACH · 06:59/)).toBeInTheDocument()
+    expect(screen.getByText(/COACH · 06:59/)).toHaveClass('text-clay-text')
+    expect(screen.getByText('You ran well.')).toBeInTheDocument()
+  })
+
+  it('renders no markdown — literal asterisks render verbatim', () => {
+    render(<CoachTextTurn content="Run **easy** today, not your pace-zone limit." time="06:59" />)
+    expect(screen.getByText(/Run \*\*easy\*\* today/)).toBeInTheDocument()
+  })
+
+  it('preserves whitespace with no clamp on long content', () => {
+    const longContent = 'first line\nsecond line\n' + 'y'.repeat(500)
+    render(<CoachTextTurn content={longContent} time="06:59" />)
+
+    const paragraph = screen.getByText(
+      (_, element) => element?.textContent?.startsWith(longContent) ?? false,
+    )
+    expect(paragraph).toHaveClass('whitespace-pre-wrap')
+    expect(paragraph.className).not.toMatch(/line-clamp|truncate/)
+  })
+
+  it('renders the clay block-cursor inline at the end of the body when streaming', () => {
+    render(<CoachTextTurn content="A tempo run is" time="06:59" streaming />)
+
+    const cursor = screen.getByTestId('coach-stream-cursor')
+    expect(cursor).toHaveAttribute('aria-hidden')
+    expect(cursor).toHaveClass('bg-primary')
+  })
+
+  it('renders no cursor when not streaming', () => {
+    render(<CoachTextTurn content="You ran well." time="06:59" />)
+    expect(screen.queryByTestId('coach-stream-cursor')).not.toBeInTheDocument()
+  })
+
+  // The assertions live inside the shared expectDualThemeParity helper —
+  // sonarjs's static check can't see through the function call.
+  // eslint-disable-next-line sonarjs/assertions-in-tests
+  it('holds dual-theme structural parity with no raw hex colour literals', () => {
+    const result = renderInBothThemes(<CoachTextTurn content="You ran well." time="06:59" />)
+    expectDualThemeParity(result, 'coach-text-turn')
+  })
+})

--- a/frontend/src/app/modules/coaching/components/coach-text-turn.component.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-text-turn.component.tsx
@@ -9,9 +9,9 @@ export interface CoachTextTurnProps {
   time: string
   /** Appends the clay block-cursor inline at the end of the body when a live stream is still in flight. */
   streaming?: boolean
-  /** PR-D wires this into a durable `LoggedRunReceipt`; left undefined by every PR-B call site. */
+  /** Wires into the durable `LoggedRunReceipt` (spec §3 PR-D); undefined when the receipt isn't rendered. */
   loggedRun?: LoggedRunSummaryDto | null
-  /** PR-D uses this for the receipt's unit-aware distance. Defaults to Kilometers. */
+  /** Unit-aware distance for the receipt (spec §3 PR-D). Defaults to Kilometers. */
   units?: PreferredUnits
   className?: string
 }
@@ -24,9 +24,8 @@ export interface CoachTextTurnProps {
  * of the body while a live reply is still arriving.
  *
  * `loggedRun`/`units` are declared here (not destructured) as forward
- * compatibility for PR-D, which renders `<LoggedRunReceipt>` beneath the
- * body when `loggedRun` is non-null:
- * // PR-D: render <LoggedRunReceipt summary={loggedRun} units={units}> beneath the body.
+ * compatibility for the durable receipt (spec §3 PR-D), which renders
+ * `<LoggedRunReceipt>` beneath the body when `loggedRun` is non-null.
  */
 export const CoachTextTurn = ({
   content,

--- a/frontend/src/app/modules/coaching/components/coach-text-turn.component.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-text-turn.component.tsx
@@ -1,0 +1,52 @@
+import type { ReactElement } from 'react'
+
+import { cn } from '@/lib/utils'
+import type { PreferredUnits } from '~/api/generated'
+import type { LoggedRunSummaryDto } from '~/modules/coaching/models/conversation.model'
+
+export interface CoachTextTurnProps {
+  content: string
+  time: string
+  /** Appends the clay block-cursor inline at the end of the body when a live stream is still in flight. */
+  streaming?: boolean
+  /** PR-D wires this into a durable `LoggedRunReceipt`; left undefined by every PR-B call site. */
+  loggedRun?: LoggedRunSummaryDto | null
+  /** PR-D uses this for the receipt's unit-aware distance. Defaults to Kilometers. */
+  units?: PreferredUnits
+  className?: string
+}
+
+/**
+ * A coach reply in the transcript (D3) — no bubble, just a mono
+ * `COACH · HH:MM` clay-text label above plain bone body text. Never
+ * markdown: `whitespace-pre-wrap` renders literal `**asterisks**` verbatim.
+ * `streaming` appends an `aria-hidden` clay block-cursor inline at the end
+ * of the body while a live reply is still arriving.
+ *
+ * `loggedRun`/`units` are declared here (not destructured) as forward
+ * compatibility for PR-D, which renders `<LoggedRunReceipt>` beneath the
+ * body when `loggedRun` is non-null:
+ * // PR-D: render <LoggedRunReceipt summary={loggedRun} units={units}> beneath the body.
+ */
+export const CoachTextTurn = ({
+  content,
+  time,
+  streaming,
+  className,
+}: CoachTextTurnProps): ReactElement => (
+  <div data-testid="coach-text-turn" className={cn('flex flex-col gap-1', className)}>
+    <span className="font-mono text-[10px] font-semibold tracking-[0.1em] text-clay-text">
+      COACH · {time}
+    </span>
+    <p className="font-body text-[14.5px] leading-[1.55] whitespace-pre-wrap text-foreground">
+      {content}
+      {streaming === true && (
+        <span
+          aria-hidden
+          data-testid="coach-stream-cursor"
+          className="ml-0.5 inline-block h-[15px] w-2 bg-primary [vertical-align:text-bottom]"
+        />
+      )}
+    </p>
+  </div>
+)

--- a/frontend/src/app/modules/coaching/components/date-divider.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/date-divider.component.spec.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import {
+  expectDualThemeParity,
+  renderInBothThemes,
+} from '~/modules/common/test-utils/render-in-both-themes'
+import { DateDivider } from './date-divider.component'
+
+describe('DateDivider', () => {
+  it('renders the label flanked by two hairlines', () => {
+    render(<DateDivider label="TUE JUN 30" />)
+
+    const root = screen.getByTestId('date-divider')
+    expect(screen.getByText('TUE JUN 30')).toBeInTheDocument()
+    expect(screen.getByText('TUE JUN 30')).toHaveClass('text-[var(--alp-faint)]')
+    const hairlines = root.querySelectorAll('.bg-border')
+    expect(hairlines).toHaveLength(2)
+  })
+
+  it('renders a TODAY-prefixed label verbatim', () => {
+    render(<DateDivider label="TODAY — WED JUL 8" />)
+    expect(screen.getByText('TODAY — WED JUL 8')).toBeInTheDocument()
+  })
+
+  // The assertions live inside the shared expectDualThemeParity helper —
+  // sonarjs's static check can't see through the function call.
+  // eslint-disable-next-line sonarjs/assertions-in-tests
+  it('holds dual-theme structural parity with no raw hex colour literals', () => {
+    const result = renderInBothThemes(<DateDivider label="TUE JUN 30" />)
+    expectDualThemeParity(result, 'date-divider')
+  })
+})

--- a/frontend/src/app/modules/coaching/components/date-divider.component.tsx
+++ b/frontend/src/app/modules/coaching/components/date-divider.component.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement } from 'react'
+
+import { cn } from '@/lib/utils'
+
+export interface DateDividerProps {
+  label: string
+  className?: string
+}
+
+/**
+ * A transcript date divider (D7) — a mono faint label flanked by two
+ * hairlines, emitted before each new local-calendar-day group of persisted
+ * timeline turns (see `groupTurnsByLocalDay` in `transcript-time.
+ * helpers.ts`, which supplies `label`).
+ */
+export const DateDivider = ({ label, className }: DateDividerProps): ReactElement => (
+  <div data-testid="date-divider" className={cn('flex items-center gap-[10px]', className)}>
+    <span className="h-px flex-1 bg-border" />
+    <span className="font-mono text-[9.5px] font-medium tracking-[0.1em] text-[var(--alp-faint)]">
+      {label}
+    </span>
+    <span className="h-px flex-1 bg-border" />
+  </div>
+)

--- a/frontend/src/app/modules/coaching/components/message-bubble.component.tsx
+++ b/frontend/src/app/modules/coaching/components/message-bubble.component.tsx
@@ -1,15 +1,13 @@
 import type { ReactElement } from 'react'
 
-// Retained, unmounted-by-transcript as of Slice 3 PR-B: `coach-chat.
-// component.tsx`'s transcript now renders `UserTurn`/`CoachTextTurn`
-// instead of `MessageBubble`/`ChatBubble`. This component (and its
-// content-block filter) stays because it is the documented Slice-4
-// tool-use content-block contract — kept intentionally, not dead code.
+// Retained intentionally, not dead code. This component (and its
+// content-block filter) represents the documented tool-use
+// content-block contract.
 
 // Anthropic content-block discriminator. The chat surface only renders
-// `text` blocks in Slice 1; `thinking`, `tool_use`, `tool_result`, and
+// `text` blocks today; `thinking`, `tool_use`, `tool_result`, and
 // `signature` blocks pass through opaquely (never rendered as text) so the
-// component contract stays stable when Slice 4 turns on tool use.
+// component contract stays stable once tool use turns on.
 export type MessageContentBlock =
   | { type: 'text'; text: string }
   | { type: 'thinking'; thinking: string }

--- a/frontend/src/app/modules/coaching/components/message-bubble.component.tsx
+++ b/frontend/src/app/modules/coaching/components/message-bubble.component.tsx
@@ -1,5 +1,11 @@
 import type { ReactElement } from 'react'
 
+// Retained, unmounted-by-transcript as of Slice 3 PR-B: `coach-chat.
+// component.tsx`'s transcript now renders `UserTurn`/`CoachTextTurn`
+// instead of `MessageBubble`/`ChatBubble`. This component (and its
+// content-block filter) stays because it is the documented Slice-4
+// tool-use content-block contract — kept intentionally, not dead code.
+
 // Anthropic content-block discriminator. The chat surface only renders
 // `text` blocks in Slice 1; `thinking`, `tool_use`, `tool_result`, and
 // `signature` blocks pass through opaquely (never rendered as text) so the

--- a/frontend/src/app/modules/coaching/components/transcript-time.helpers.spec.ts
+++ b/frontend/src/app/modules/coaching/components/transcript-time.helpers.spec.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  formatDividerLabel,
+  formatDurationSeconds,
+  formatTurnTime,
+  groupTurnsByLocalDay,
+} from './transcript-time.helpers'
+
+describe('formatTurnTime', () => {
+  it('formats a local time as 24h, zero-padded HH:MM', () => {
+    const d = new Date(2026, 5, 29, 6, 58) // local: Jun 29 2026, 06:58
+    expect(formatTurnTime(d.toISOString())).toBe('06:58')
+  })
+
+  it('zero-pads a single-digit hour and minute', () => {
+    const d = new Date(2026, 5, 29, 1, 5)
+    expect(formatTurnTime(d.toISOString())).toBe('01:05')
+  })
+
+  it('renders midnight as 00:00, not 24:00 or 12:00', () => {
+    const d = new Date(2026, 5, 29, 0, 0)
+    expect(formatTurnTime(d.toISOString())).toBe('00:00')
+  })
+
+  it('renders 23:59 (last minute of the day) correctly', () => {
+    const d = new Date(2026, 5, 29, 23, 59)
+    expect(formatTurnTime(d.toISOString())).toBe('23:59')
+  })
+})
+
+describe('formatDividerLabel', () => {
+  it('formats a past day as "{WEEKDAY} {MONTH} {DAY}", no TODAY prefix', () => {
+    const dayDate = new Date(2026, 5, 30) // Tuesday Jun 30 2026
+    const todayDate = new Date(2026, 6, 8) // Wed Jul 8 2026
+    expect(formatDividerLabel(dayDate, todayDate)).toBe('TUE JUN 30')
+  })
+
+  it('prefixes TODAY — when dayDate is the same local calendar day as todayDate', () => {
+    const dayDate = new Date(2026, 6, 8, 9, 0) // Wed Jul 8, 09:00
+    const todayDate = new Date(2026, 6, 8, 23, 0) // same day, different time
+    expect(formatDividerLabel(dayDate, todayDate)).toBe('TODAY — WED JUL 8')
+  })
+
+  it('does not prefix TODAY when the day differs even by one calendar day', () => {
+    const dayDate = new Date(2026, 6, 7)
+    const todayDate = new Date(2026, 6, 8)
+    expect(formatDividerLabel(dayDate, todayDate)).toBe('TUE JUL 7')
+  })
+})
+
+describe('groupTurnsByLocalDay', () => {
+  const turn = (createdAt: string, turnId: string): { createdAt: string; turnId: string } => ({
+    createdAt,
+    turnId,
+  })
+
+  it('returns an empty array for an empty timeline', () => {
+    expect(groupTurnsByLocalDay([])).toEqual([])
+  })
+
+  it('groups all turns from a single calendar day into one group', () => {
+    const turns = [
+      turn(new Date(2026, 5, 29, 9, 0).toISOString(), 't1'),
+      turn(new Date(2026, 5, 29, 15, 0).toISOString(), 't2'),
+    ]
+    const groups = groupTurnsByLocalDay(turns)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].turns).toHaveLength(2)
+  })
+
+  it('splits turns spanning two local calendar days into two oldest-first groups', () => {
+    const turns = [
+      turn(new Date(2026, 5, 29, 9, 0).toISOString(), 't1'),
+      turn(new Date(2026, 5, 30, 9, 0).toISOString(), 't2'),
+    ]
+    const groups = groupTurnsByLocalDay(turns)
+    expect(groups).toHaveLength(2)
+    expect(groups[0].turns.map((t) => t.turnId)).toEqual(['t1'])
+    expect(groups[1].turns.map((t) => t.turnId)).toEqual(['t2'])
+  })
+
+  it('re-opens a new group when a day recurs non-consecutively (buckets consecutive runs only)', () => {
+    const turns = [
+      turn(new Date(2026, 5, 29, 9, 0).toISOString(), 't1'),
+      turn(new Date(2026, 5, 30, 9, 0).toISOString(), 't2'),
+      turn(new Date(2026, 5, 29, 10, 0).toISOString(), 't3'),
+    ]
+    const groups = groupTurnsByLocalDay(turns)
+    expect(groups).toHaveLength(3)
+  })
+
+  describe('TZ-offset local-midnight grouping', () => {
+    const originalTz = process.env.TZ
+
+    afterEach(() => {
+      // `originalTz` is `undefined` when TZ was unset before this suite ran —
+      // assigning `undefined` back would coerce it to the literal string
+      // "undefined" (env vars are always strings), leaking a bogus TZ into
+      // later tests in the same worker. Delete the key instead.
+      if (originalTz === undefined) {
+        delete process.env.TZ
+      } else {
+        process.env.TZ = originalTz
+      }
+    })
+
+    it('groups a near-midnight UTC turn under its LOCAL day in a TZ far ahead of UTC', () => {
+      process.env.TZ = 'Pacific/Kiritimati' // UTC+14
+      // 23:30 UTC on Jul 8 is 13:30 local on Jul 9 under UTC+14 — must
+      // bucket under Jul 9 locally, not Jul 8 (the UTC day).
+      const turns = [turn('2026-07-08T23:30:00Z', 't1')]
+      const groups = groupTurnsByLocalDay(turns)
+      expect(groups).toHaveLength(1)
+      expect(groups[0].label).toMatch(/JUL 9$/)
+    })
+
+    it('groups a near-midnight UTC turn under its LOCAL day in a TZ far behind UTC', () => {
+      process.env.TZ = 'Pacific/Niue' // UTC-11
+      // 00:30 UTC on Jul 8 is 13:30 local on Jul 7 under UTC-11 — must
+      // bucket under Jul 7 locally, not Jul 8 (the UTC day).
+      const turns = [turn('2026-07-08T00:30:00Z', 't1')]
+      const groups = groupTurnsByLocalDay(turns)
+      expect(groups).toHaveLength(1)
+      expect(groups[0].label).toMatch(/JUL 7$/)
+    })
+  })
+})
+
+describe('formatDurationSeconds', () => {
+  it('formats sub-minute durations as m:ss', () => {
+    expect(formatDurationSeconds(45)).toBe('0:45')
+  })
+
+  it('formats a duration under an hour as m:ss', () => {
+    expect(formatDurationSeconds(41 * 60)).toBe('41:00')
+  })
+
+  it('zero-pads the seconds component', () => {
+    expect(formatDurationSeconds(61)).toBe('1:01')
+  })
+
+  it('formats durations at or beyond an hour as h:mm:ss', () => {
+    expect(formatDurationSeconds(3661)).toBe('1:01:01')
+  })
+
+  it('rounds a fractional-second input defensively', () => {
+    expect(formatDurationSeconds(45.6)).toBe('0:46')
+  })
+
+  it('formats exactly zero seconds', () => {
+    expect(formatDurationSeconds(0)).toBe('0:00')
+  })
+})

--- a/frontend/src/app/modules/coaching/components/transcript-time.helpers.ts
+++ b/frontend/src/app/modules/coaching/components/transcript-time.helpers.ts
@@ -1,15 +1,11 @@
 // Transcript timestamp + local-day-grouping helpers (spec §4.1) — LOCAL
-// wall-clock, deliberately distinct from `plan-display.helpers`' UTC
-// plan-calendar pipeline (§4.2). A message shows the time it was sent in
+// wall-clock. A message shows the time it was sent in
 // the READER's timezone, not the server's or the plan's anchor timezone, so
 // every getter here is a local (`getHours`/`getDay`/`getMonth`/`getDate`)
 // read — never a `getUTC*` one.
 //
-// `formatDurationSeconds` (§4.3) lives here too: it is the receipt
-// formatter's home file per the spec, even though the receipt itself
-// (`LoggedRunReceipt`) is PR-D scope — shipping the helper (and its unit
-// test) alongside `formatTurnTime`/`formatDividerLabel`/
-// `groupTurnsByLocalDay` avoids a same-file split across two PRs.
+// `formatDurationSeconds` (§4.3) is the receipt formatter's home file per
+// the spec.
 
 const WEEKDAY_ABBR = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'] as const
 
@@ -102,8 +98,7 @@ export function groupTurnsByLocalDay<T extends { createdAt: string }>(
  * Formats a duration in seconds as `m:ss`, or `h:mm:ss` once the total
  * reaches an hour. `s` is the wire's `durationSeconds` (a `double`) — a
  * fractional part is not expected in practice, but `Math.round` guards
- * defensively. Local `pad2` reuse only — `log-confirmation-card.
- * component.tsx`'s own `pad` is module-private, not imported here.
+ * defensively. Local `pad2` reuse only.
  */
 export function formatDurationSeconds(s: number): string {
   const total = Math.round(s)

--- a/frontend/src/app/modules/coaching/components/transcript-time.helpers.ts
+++ b/frontend/src/app/modules/coaching/components/transcript-time.helpers.ts
@@ -1,0 +1,114 @@
+// Transcript timestamp + local-day-grouping helpers (spec §4.1) — LOCAL
+// wall-clock, deliberately distinct from `plan-display.helpers`' UTC
+// plan-calendar pipeline (§4.2). A message shows the time it was sent in
+// the READER's timezone, not the server's or the plan's anchor timezone, so
+// every getter here is a local (`getHours`/`getDay`/`getMonth`/`getDate`)
+// read — never a `getUTC*` one.
+//
+// `formatDurationSeconds` (§4.3) lives here too: it is the receipt
+// formatter's home file per the spec, even though the receipt itself
+// (`LoggedRunReceipt`) is PR-D scope — shipping the helper (and its unit
+// test) alongside `formatTurnTime`/`formatDividerLabel`/
+// `groupTurnsByLocalDay` avoids a same-file split across two PRs.
+
+const WEEKDAY_ABBR = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'] as const
+
+const MONTH_ABBR = [
+  'JAN',
+  'FEB',
+  'MAR',
+  'APR',
+  'MAY',
+  'JUN',
+  'JUL',
+  'AUG',
+  'SEP',
+  'OCT',
+  'NOV',
+  'DEC',
+] as const
+
+const pad2 = (value: number): string => value.toString().padStart(2, '0')
+
+/**
+ * Formats an ISO `createdAt` timestamp as a 24-hour, zero-padded local
+ * `HH:MM` (e.g. `"06:58"`). Reads the reader's local wall-clock via
+ * `getHours`/`getMinutes` — never `getUTCHours`/`getUTCMinutes`.
+ */
+export function formatTurnTime(createdAtIso: string): string {
+  const d = new Date(createdAtIso)
+  return `${pad2(d.getHours())}:${pad2(d.getMinutes())}`
+}
+
+/**
+ * Formats a local-calendar-day divider label, e.g. `"TUE JUN 30"`, or
+ * `"TODAY — TUE JUN 30"` when `dayDate` falls on the same local calendar
+ * day as `todayDate`. Both dates are read via LOCAL getters
+ * (`getFullYear`/`getMonth`/`getDate`/`getDay`) — this is the reader's
+ * wall-clock day, not a UTC one.
+ */
+export function formatDividerLabel(dayDate: Date, todayDate: Date): string {
+  const label = `${WEEKDAY_ABBR[dayDate.getDay()]} ${MONTH_ABBR[dayDate.getMonth()]} ${dayDate.getDate()}`
+  const isToday =
+    dayDate.getFullYear() === todayDate.getFullYear() &&
+    dayDate.getMonth() === todayDate.getMonth() &&
+    dayDate.getDate() === todayDate.getDate()
+  return isToday ? `TODAY — ${label}` : label
+}
+
+/** One local-calendar-day group of turns, oldest-first, produced by {@link groupTurnsByLocalDay}. */
+export interface LocalDayGroup<T> {
+  label: string
+  turns: T[]
+}
+
+const localDayKey = (date: Date): string =>
+  `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`
+
+/**
+ * Groups an oldest-first array of turns into consecutive local-calendar-day
+ * buckets, one group per distinct local day, each labelled via
+ * {@link formatDividerLabel} against "now" at call time. Turns are grouped
+ * by their `createdAt`'s LOCAL calendar day — a turn near local midnight
+ * under a non-UTC `TZ` groups under its local day, not the UTC day (the
+ * turn's `createdAt` is a UTC instant on the wire; only the local
+ * interpretation of it decides the bucket).
+ *
+ * `turns` must already be oldest-first (the composed timeline's own
+ * order) — this function does not sort, only buckets consecutive runs.
+ */
+export function groupTurnsByLocalDay<T extends { createdAt: string }>(
+  turns: readonly T[],
+): LocalDayGroup<T>[] {
+  const today = new Date()
+  const groups: LocalDayGroup<T>[] = []
+  let currentKey: string | null = null
+
+  for (const turn of turns) {
+    const date = new Date(turn.createdAt)
+    const key = localDayKey(date)
+    if (key !== currentKey) {
+      groups.push({ label: formatDividerLabel(date, today), turns: [turn] })
+      currentKey = key
+    } else {
+      groups[groups.length - 1].turns.push(turn)
+    }
+  }
+
+  return groups
+}
+
+/**
+ * Formats a duration in seconds as `m:ss`, or `h:mm:ss` once the total
+ * reaches an hour. `s` is the wire's `durationSeconds` (a `double`) — a
+ * fractional part is not expected in practice, but `Math.round` guards
+ * defensively. Local `pad2` reuse only — `log-confirmation-card.
+ * component.tsx`'s own `pad` is module-private, not imported here.
+ */
+export function formatDurationSeconds(s: number): string {
+  const total = Math.round(s)
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const sec = total % 60
+  return h >= 1 ? `${h}:${pad2(m)}:${pad2(sec)}` : `${m}:${pad2(sec)}`
+}

--- a/frontend/src/app/modules/coaching/components/user-turn.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/user-turn.component.spec.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import {
+  expectDualThemeParity,
+  renderInBothThemes,
+} from '~/modules/common/test-utils/render-in-both-themes'
+import { UserTurn } from './user-turn.component'
+
+describe('UserTurn', () => {
+  it('renders a right-aligned bubble with the message content and a YOU · HH:MM meta line', () => {
+    render(<UserTurn content="how was my run?" time="06:58" />)
+
+    const root = screen.getByTestId('user-turn')
+    expect(root).toHaveClass('items-end')
+    expect(screen.getByText('how was my run?')).toBeInTheDocument()
+    expect(screen.getByTestId('turn-meta')).toHaveTextContent('YOU · 06:58')
+    expect(screen.getByTestId('turn-meta')).toHaveClass('text-[var(--alp-faint)]')
+  })
+
+  it('applies the bubble shape/surface classes (rounded corner, bg-muted, max-width, no clamp)', () => {
+    render(<UserTurn content="a message" time="09:00" />)
+
+    const bubble = screen.getByText('a message').parentElement
+    expect(bubble).toHaveClass('max-w-[85%]')
+    expect(bubble).toHaveClass('rounded-[10px_10px_4px_10px]')
+    expect(bubble).toHaveClass('bg-muted')
+  })
+
+  it('preserves the runner’s own line breaks and wraps long unbroken content, never clamping', () => {
+    const longContent = 'line one\nline two\n' + 'x'.repeat(500)
+    const { container } = render(<UserTurn content={longContent} time="06:58" />)
+
+    const paragraph = container.querySelector('p')
+    expect(paragraph?.textContent).toBe(longContent)
+    expect(paragraph).toHaveClass('whitespace-pre-wrap')
+    expect(paragraph).toHaveClass('break-words')
+    expect(paragraph).not.toHaveClass('truncate')
+    expect(paragraph?.className).not.toMatch(/line-clamp/)
+  })
+
+  it('renders no markdown — literal asterisks pass through verbatim', () => {
+    render(<UserTurn content="ran **5k** today" time="06:58" />)
+    expect(screen.getByText('ran **5k** today')).toBeInTheDocument()
+  })
+
+  // The assertions live inside the shared expectDualThemeParity helper —
+  // sonarjs's static check can't see through the function call.
+  // eslint-disable-next-line sonarjs/assertions-in-tests
+  it('holds dual-theme structural parity with no raw hex colour literals', () => {
+    const result = renderInBothThemes(<UserTurn content="how was my run?" time="06:58" />)
+    expectDualThemeParity(result, 'user-turn')
+  })
+})

--- a/frontend/src/app/modules/coaching/components/user-turn.component.tsx
+++ b/frontend/src/app/modules/coaching/components/user-turn.component.tsx
@@ -1,0 +1,31 @@
+import type { ReactElement } from 'react'
+
+import { cn } from '@/lib/utils'
+
+export interface UserTurnProps {
+  content: string
+  time: string
+  className?: string
+}
+
+/**
+ * A runner's message in the transcript (D2) — a right-aligned bubble with a
+ * mono `YOU · HH:MM` meta line beneath it. Renders at any content length
+ * with no clamp; `whitespace-pre-wrap break-words` preserves the runner's
+ * own line breaks without ever overflowing the bubble.
+ */
+export const UserTurn = ({ content, time, className }: UserTurnProps): ReactElement => (
+  <div data-testid="user-turn" className={cn('flex flex-col items-end gap-[6px]', className)}>
+    <div className="max-w-[85%] rounded-[10px_10px_4px_10px] bg-muted px-[14px] py-[10px]">
+      <p className="font-body text-[14px] leading-[1.5] whitespace-pre-wrap break-words text-foreground">
+        {content}
+      </p>
+    </div>
+    <span
+      data-testid="turn-meta"
+      className="font-mono text-[9px] font-medium tracking-[0.08em] text-[var(--alp-faint)]"
+    >
+      YOU · {time}
+    </span>
+  </div>
+)


### PR DESCRIPTION
## Slice 3 (Coach) — PR-B: turn kinds, timestamps, dividers, composer restyle

The first **frontend** PR of Slice 3. Restyles the `/coach` transcript onto the Alpine turn system per `docs/specs/slice-3-coach/spec.md` §3 PR-B (DU-1/2/3/7/8). Frontend-only — no wire change (PR-A #288 already shipped the backend `loggedRun` field). Slice 3 order: **A ✅ → B (this) → C → D**.

### What's in it
- **New turn components** — `UserTurn` (D2, right-aligned bubble + `YOU · HH:MM` meta), `CoachTextTurn` (D3, no bubble, `COACH · HH:MM` clay label, inline streaming block-cursor), `DateDivider` (D7). These replace `MessageBubble`/`ChatBubble` in the transcript render path.
- **New `transcript-time.helpers`** — `formatTurnTime`, `formatDividerLabel`, `groupTurnsByLocalDay` (local wall-clock, deliberately distinct from the plan-calendar UTC pipeline) and `formatDurationSeconds`.
- **`coach-chat` rewrite** — turn-kind dispatch, local-day date-divider grouping, a single client-captured live timestamp shared by the optimistic user/coach pair, a restyled historical errored turn (copy only, **no** RETRY) vs the live retry affordance (keeps its `retryable` gate + `retry()` wiring).
- **Composer restyle** — 48px clay square send button (`ArrowUp`, `aria-label="Send message"`), new placeholder `"Ask, or describe a run to log…"`. All behavior unchanged: Enter/Shift+Enter, `initialValue`/`autoFocus`/`textareaRef`, the prefill/focus receiver.
- `CoachTextTurn` declares `loggedRun`/`units` for **PR-D** forward-compat but does not render the durable receipt yet.
- `MessageBubble` retained unmounted (the Slice-4 tool-use content-block contract), with a header note.

### Two deviations (deliberate, recorded)
1. **`liveTime` uses React's "adjust state during render" pattern, not the spec's literal `useRef`.** This repo's `eslint-plugin-react-hooks` v7 `recommended` enables `react-hooks/refs: error`, which forbids reading `ref.current` during render — the spec's snippet would fail lint. The state-pair pattern is semantically identical (one shared `HH:MM` per pending exchange, cleared on return to null) and lint-clean.
2. **The failure-surface `bg-danger-surface` token is deferred to PR-C.** The spec's PR-B text styles the retry surface with `bg-danger-surface`, but that token is defined in PR-C and the spec declares B/C independent — an ordering conflict. Resolved low-risk: PR-B stays out of `index.css`/`check-contrast` and uses `bg-secondary` + `border-l-destructive` for the retry accent, with a code comment pointing at PR-C.

### How it was built & verified
Built and adversarially verified via a sonnet multi-agent workflow: build → five review lenses (spec-compliance, correctness, conventions/a11y/tokens, test-quality, regression) → per-finding validation (refutation pass) → fix. Six findings raised, five confirmed and fixed — one real bug (**a stale live timestamp when a new message is sent directly after a prior stream errored, without passing through the null state**) plus test-coverage hardening (turn-dispatch testid scoping, `text-clay-text`/`min-h-12`/`--alp-faint` class assertions). The sixth (useRef-vs-useState) was validated as not-a-bug.

### Gates (independently re-run)
- `npm run build` ✓ · `eslint` (0 problems) ✓ · `npm run test` — **885/885** ✓ · `npm run check-contrast` — **38/38** ✓
- No backend/codegen change; no out-of-scope files touched.

### Non-negotiables (HANDOFF §8)
`role="log"`/`aria-live` transcript semantics preserved · no markdown (literal asterisks render verbatim) · icon send button has an accessible name, block-cursor `aria-hidden` · semantic tokens only, `--alp-faint` used only as decorative meta · trademark-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APgsBYCEhhvwwwndxtJhDJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer transcript formatting with separate runner and coach messages.
  - Added timestamps to conversation turns and synchronized timestamps for live exchanges.
  - Grouped conversation history by local calendar day with date dividers.
  - Added streaming indicators and improved persisted error messaging.
  - Updated the composer with a send icon, accessible labeling, and refreshed placeholder text.

- **Bug Fixes**
  - Retry controls are now hidden for non-retryable errors.
  - Preserved line breaks and long-message readability in transcript content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->