### PR TITLE
feat(split-ui): Slice 3 PR-C — Coach adaptation + safety turns + danger-surface token

### DIFF
--- a/frontend/scripts/__tests__/check-contrast.spec.ts
+++ b/frontend/scripts/__tests__/check-contrast.spec.ts
@@ -453,9 +453,9 @@ describe('runChecks (against the committed index.css)', () => {
     }
   })
 
-  it('reports 38 results (19 pairs × 2 modes), all passing', () => {
+  it('reports 42 results (21 pairs × 2 modes), all passing', () => {
     const results = runChecks(readFileSync(realIndexCssPath, 'utf8'))
-    expect(results).toHaveLength(38)
+    expect(results).toHaveLength(42)
     for (const result of results) {
       expect(result.passed).toBe(true)
     }
@@ -491,7 +491,7 @@ describe('check-contrast script (integration)', () => {
   it('exits 0 and reports all pairs passing against the committed tokens', () => {
     const { status, stdout } = runGate()
     expect(status).toBe(0)
-    expect(stdout).toContain('all 38 pairs pass WCAG thresholds')
+    expect(stdout).toContain('all 42 pairs pass WCAG thresholds')
   }, 30000)
 
   it('exits non-zero and names the failing pair + ratio on stderr when a token regresses', () => {

--- a/frontend/scripts/__tests__/check-contrast.spec.ts
+++ b/frontend/scripts/__tests__/check-contrast.spec.ts
@@ -453,9 +453,9 @@ describe('runChecks (against the committed index.css)', () => {
     }
   })
 
-  it('reports 42 results (21 pairs × 2 modes), all passing', () => {
+  it('reports 44 results (22 pairs × 2 modes), all passing', () => {
     const results = runChecks(readFileSync(realIndexCssPath, 'utf8'))
-    expect(results).toHaveLength(42)
+    expect(results).toHaveLength(44)
     for (const result of results) {
       expect(result.passed).toBe(true)
     }
@@ -491,7 +491,7 @@ describe('check-contrast script (integration)', () => {
   it('exits 0 and reports all pairs passing against the committed tokens', () => {
     const { status, stdout } = runGate()
     expect(status).toBe(0)
-    expect(stdout).toContain('all 42 pairs pass WCAG thresholds')
+    expect(stdout).toContain('all 44 pairs pass WCAG thresholds')
   }, 30000)
 
   it('exits non-zero and names the failing pair + ratio on stderr when a token regresses', () => {

--- a/frontend/scripts/check-contrast.ts
+++ b/frontend/scripts/check-contrast.ts
@@ -25,7 +25,9 @@
  * EXEMPT (never asserted, by design — WCAG 1.4.11 decorative / non-text):
  *   --border      — a pure divider between rows/sections.
  *   --warning     — a supplementary severity accent (the severity is always
- *     also conveyed by content and structure, never by colour alone).
+ *     also conveyed by content and structure, never by colour alone). The
+ *     text variant --warning-text (amber heading copy) is a separate token and
+ *     IS asserted below.
  *   --alp-faint   — a decorative-only label tint that fails AA by design and
  *     must never carry essential text; documented, not machine-checked.
  *   --clay-marker — the "current" marker: border/fill only, never text (THE
@@ -193,6 +195,11 @@ export const PAIRS: readonly Pair[] = [
     bg: 'danger-surface',
     threshold: 4.5,
   },
+  // Amber safety-turn heading (spec §3 PR-C). The amber tier's card fill is
+  // plain --card, and the heading renders in the dedicated --warning-text
+  // token, NOT the border-accent --warning — raw --warning (--alp-amber)
+  // measures only ~1.8:1 on the light card. This asserts the gated text token.
+  { label: '--warning-text on --card', fg: 'warning-text', bg: 'card', threshold: 4.5 },
   // Non-text UI pairs — WCAG SC 1.4.11, 3:1. --ring and --input are checked
   // against --background, the surface they border. --input is the resting
   // boundary of an empty form field (see the header comment) and must stay

--- a/frontend/scripts/check-contrast.ts
+++ b/frontend/scripts/check-contrast.ts
@@ -174,6 +174,25 @@ export const PAIRS: readonly Pair[] = [
     bg: 'input-fill',
     threshold: 4.5,
   },
+  // Failure surface (spec §3 PR-C) — the red safety-turn card / live retry
+  // affordance's fill. Both the body copy (--foreground) and the 12px
+  // semibold red heading render directly on it. Plain --destructive
+  // measures only ~4.05:1 (dark) / ~3.24:1 (light) against --danger-surface
+  // — short of AA — so the heading uses the dedicated --danger-text variant
+  // instead (§9 #3 option (a): an AA-passing on-danger foreground, not an
+  // exemption), which this pair asserts.
+  {
+    label: '--foreground on --danger-surface',
+    fg: 'foreground',
+    bg: 'danger-surface',
+    threshold: 4.5,
+  },
+  {
+    label: '--danger-text on --danger-surface',
+    fg: 'danger-text',
+    bg: 'danger-surface',
+    threshold: 4.5,
+  },
   // Non-text UI pairs — WCAG SC 1.4.11, 3:1. --ring and --input are checked
   // against --background, the surface they border. --input is the resting
   // boundary of an empty form field (see the header comment) and must stay

--- a/frontend/src/app/modules/coaching/components/adaptation-digest.helpers.spec.ts
+++ b/frontend/src/app/modules/coaching/components/adaptation-digest.helpers.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { PreferredUnits } from '~/api/generated'
 import type { PlanAdaptationDiffDto } from '~/modules/coaching/models/conversation.model'
 import { buildDiffWorkout } from './conversation.fixture'
-import { composeAdaptationHeadline } from './adaptation-digest.helpers'
+import { composeAdaptationHeadline, formatChangeLocusDate } from './adaptation-digest.helpers'
 
 const emptyDiff: PlanAdaptationDiffDto = { workoutChanges: [], weeklyTargetChanges: [] }
 
@@ -166,5 +166,31 @@ describe('composeAdaptationHeadline', () => {
     expect(composeAdaptationHeadline({ diff, currentWeek: 3, units: PreferredUnits.Miles })).toBe(
       'This week 18.6 mi → 16.2 mi.',
     )
+  })
+})
+
+describe('formatChangeLocusDate', () => {
+  it('resolves the week-1 Sunday anchor', () => {
+    expect(
+      formatChangeLocusDate({ planStartDate: '2026-06-28', weekNumber: 1, dayOfWeek: 0 }),
+    ).toBe('JUN 28')
+  })
+
+  it('resolves the week-1 Saturday', () => {
+    expect(
+      formatChangeLocusDate({ planStartDate: '2026-06-28', weekNumber: 1, dayOfWeek: 6 }),
+    ).toBe('JUL 4')
+  })
+
+  it('resolves the week-2 Sunday anchor', () => {
+    expect(
+      formatChangeLocusDate({ planStartDate: '2026-06-28', weekNumber: 2, dayOfWeek: 0 }),
+    ).toBe('JUL 5')
+  })
+
+  it('returns null for an unparseable planStartDate', () => {
+    expect(
+      formatChangeLocusDate({ planStartDate: 'not-a-date', weekNumber: 1, dayOfWeek: 0 }),
+    ).toBeNull()
   })
 })

--- a/frontend/src/app/modules/coaching/components/adaptation-digest.helpers.ts
+++ b/frontend/src/app/modules/coaching/components/adaptation-digest.helpers.ts
@@ -3,7 +3,11 @@
 
 import { PreferredUnits } from '~/api/generated'
 import { formatDistanceKm } from '~/modules/common/utils/unit-format.helpers'
-import { DAY_OF_WEEK_LABELS } from '~/modules/plan/components/plan-display.helpers'
+import {
+  DAY_OF_WEEK_LABELS,
+  formatShortDateUtc,
+  resolveCalendarDateUtc,
+} from '~/modules/plan/components/plan-display.helpers'
 import type { PlanAdaptationDiffDto } from '~/modules/coaching/models/conversation.model'
 
 /**
@@ -66,4 +70,22 @@ export function composeAdaptationHeadline(params: {
   }
 
   return sentences.slice(0, 2).join(' ')
+}
+
+/**
+ * Resolves the calendar-date locus for one adaptation-diff row — e.g.
+ * `"JUN 28"` — anchored against the plan's `planStartDate` (spec §3 PR-C,
+ * §4.2). `null` when `planStartDate` is unparseable, so callers degrade to
+ * the week-index locus rather than rendering an epoch or crashing. UTC, not
+ * local wall-clock: a plan slot is a fixed calendar date independent of the
+ * reader's timezone (distinct from `transcript-time.helpers`' local-day
+ * pipeline).
+ */
+export function formatChangeLocusDate(params: {
+  planStartDate: string
+  weekNumber: number
+  dayOfWeek: number
+}): string | null {
+  const date = resolveCalendarDateUtc(params.planStartDate, params.weekNumber, params.dayOfWeek)
+  return date === null ? null : formatShortDateUtc(date)
 }

--- a/frontend/src/app/modules/coaching/components/adaptation-turn.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/adaptation-turn.component.spec.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { PreferredUnits } from '~/api/generated'
+import {
+  ADAPTATION_KIND,
+  CONVERSATION_ROLE,
+  type AdaptationTurnDto,
+} from '~/modules/coaching/models/conversation.model'
+import { buildDiff } from './conversation.fixture'
+import { AdaptationTurn } from './adaptation-turn.component'
+
+const baseTurn = (overrides: Partial<AdaptationTurnDto> = {}): AdaptationTurnDto => ({
+  triggeringPlanEventId: 'evt-1',
+  role: CONVERSATION_ROLE.assistantAdaptation,
+  content: 'I cut this week to help you recover.',
+  escalationLevel: 2,
+  safetyTier: 0,
+  referralCategory: 0,
+  adaptationKind: ADAPTATION_KIND.restructure,
+  diff: buildDiff(),
+  triggeringWorkoutLogId: 'w1',
+  createdAt: '2026-06-30T06:58:00Z',
+  ...overrides,
+})
+
+describe('AdaptationTurn', () => {
+  it('renders a restructure turn with the clay left edge, PLAN ADJUSTED label, timestamp, and explanation', () => {
+    render(<AdaptationTurn turn={baseTurn()} planStartDate="2026-06-28" time="06:58" />)
+
+    const article = screen.getByTestId('restructure-turn')
+    expect(article).toHaveClass('border-l-clay-marker')
+    expect(screen.getByText('PLAN ADJUSTED')).toBeInTheDocument()
+    expect(screen.getByText('06:58')).toBeInTheDocument()
+    expect(screen.getByText('I cut this week to help you recover.')).toBeInTheDocument()
+    // Collapsed by default.
+    expect(screen.getByTestId('diff-toggle')).toBeInTheDocument()
+    expect(screen.getByTestId('before-after-diff')).not.toBeVisible()
+  })
+
+  it('resolves calendar-date-anchored loci for every diff-row kind when the expander opens', async () => {
+    const user = userEvent.setup()
+    render(<AdaptationTurn turn={baseTurn()} planStartDate="2026-06-28" time="06:58" />)
+
+    await user.click(screen.getByTestId('diff-toggle'))
+
+    // Workout swap: week 1, dayOfWeek 2 (Tuesday) -> 2026-06-30.
+    expect(screen.getByText('WK JUN 30 · TUESDAY')).toBeInTheDocument()
+    // Current-week (week 1) volume change: Sunday anchor -> 2026-06-28.
+    expect(screen.getByText('WK JUN 28 · VOLUME')).toBeInTheDocument()
+    // Upcoming-week (week 2) volume change: Sunday anchor -> 2026-07-05.
+    expect(screen.getByText('WK JUL 5 · VOLUME')).toBeInTheDocument()
+    // Every before -> after value line renders the arrow in clay.
+    const clayArrows = document.querySelectorAll('.text-clay-text')
+    expect(Array.from(clayArrows).some((el) => el.textContent === '→')).toBe(true)
+  })
+
+  it('degrades every locus to the week-index form when planStartDate is undefined', async () => {
+    const user = userEvent.setup()
+    render(<AdaptationTurn turn={baseTurn()} time="06:58" />)
+
+    await user.click(screen.getByTestId('diff-toggle'))
+
+    expect(screen.getByText('WK 1 · TUESDAY')).toBeInTheDocument()
+    expect(screen.getAllByText('WK 1 · VOLUME')[0]).toBeInTheDocument()
+    expect(screen.getByText('WK 2 · VOLUME')).toBeInTheDocument()
+  })
+
+  it('degrades every locus to the week-index form when planStartDate is unparseable', async () => {
+    const user = userEvent.setup()
+    render(<AdaptationTurn turn={baseTurn()} planStartDate="not-a-date" time="06:58" />)
+
+    await user.click(screen.getByTestId('diff-toggle'))
+
+    expect(screen.getByText('WK 1 · TUESDAY')).toBeInTheDocument()
+    expect(screen.getByText('WK 2 · VOLUME')).toBeInTheDocument()
+  })
+
+  it('renders a nudge turn as a plain coach line with no card', () => {
+    render(
+      <AdaptationTurn
+        turn={baseTurn({
+          adaptationKind: ADAPTATION_KIND.nudge,
+          content: 'Nudged tomorrow easier.',
+        })}
+        time="06:58"
+      />,
+    )
+
+    expect(screen.getByTestId('nudge-turn')).toHaveTextContent('Nudged tomorrow easier.')
+    expect(screen.queryByTestId('restructure-turn')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing for an absorb turn (defensive)', () => {
+    const { container } = render(
+      <AdaptationTurn turn={baseTurn({ adaptationKind: ADAPTATION_KIND.absorb })} time="06:58" />,
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('threads the unit preference into the diff', async () => {
+    const user = userEvent.setup()
+    render(
+      <AdaptationTurn
+        turn={baseTurn({
+          diff: {
+            workoutChanges: [],
+            weeklyTargetChanges: [
+              { weekNumber: 1, beforeWeeklyTargetKm: 36, afterWeeklyTargetKm: 28 },
+            ],
+          },
+        })}
+        units={PreferredUnits.Miles}
+        time="06:58"
+      />,
+    )
+
+    await user.click(screen.getByTestId('diff-toggle'))
+
+    // 36 km -> 22.4 mi ; 28 km -> 17.4 mi
+    const weeklyTargetRow = screen.getByTestId('diff-weekly-target-change')
+    expect(weeklyTargetRow).toHaveTextContent('22.4 mi')
+    expect(weeklyTargetRow).toHaveTextContent('17.4 mi')
+  })
+})

--- a/frontend/src/app/modules/coaching/components/adaptation-turn.component.tsx
+++ b/frontend/src/app/modules/coaching/components/adaptation-turn.component.tsx
@@ -15,6 +15,14 @@ export interface AdaptationTurnProps {
    * tests) render the km form unchanged.
    */
   units?: PreferredUnits
+  /**
+   * The owning plan's calendar anchor, threaded through to `BeforeAfterDiff`
+   * (spec §3 PR-C). `undefined` degrades every diff row's locus to the
+   * week-index form.
+   */
+  planStartDate?: string
+  /** The turn's local wall-clock `HH:MM`, supplied by the caller (`formatTurnTime(turn.createdAt)`). */
+  time: string
 }
 
 /**
@@ -24,15 +32,17 @@ export interface AdaptationTurnProps {
  *   - absorb — never persisted as a turn; rendered as nothing defensively
  *     should one ever arrive.
  *   - nudge — a quiet inline one-liner, no block chrome, no diff.
- *   - restructure — an expandable block carrying the coach's rationale
+ *   - restructure — a `PLAN ADJUSTED` card carrying the coach's rationale
  *     (validate → what I saw → what I changed → path back, authored
- *     server-side) with the collapsible before/after diff and a subtle
- *     left-edge amber accent. No loud badges — the `--warning` accent is a
- *     supplementary indicator; severity is conveyed by the copy itself.
+ *     server-side) with the collapsible before/after diff and a 2px clay
+ *     left-edge marker (`--clay-marker`, border/fill-only — no loud badges;
+ *     severity is conveyed by the copy itself, not the accent).
  */
 export const AdaptationTurn = ({
   turn,
   units = PreferredUnits.Kilometers,
+  planStartDate,
+  time,
 }: AdaptationTurnProps): ReactElement | null => {
   if (turn.adaptationKind === ADAPTATION_KIND.absorb) {
     return null
@@ -40,7 +50,7 @@ export const AdaptationTurn = ({
 
   if (turn.adaptationKind === ADAPTATION_KIND.nudge) {
     return (
-      <p data-testid="nudge-turn" className="px-1 text-sm text-foreground">
+      <p data-testid="nudge-turn" className="font-body text-[14px] text-foreground">
         {turn.content}
       </p>
     )
@@ -49,10 +59,18 @@ export const AdaptationTurn = ({
   return (
     <article
       data-testid="restructure-turn"
-      className="flex flex-col gap-2 rounded-md border border-l-2 border-l-warning bg-card p-4"
+      className="rounded-lg border border-border border-l-2 border-l-clay-marker bg-card p-[14px]"
     >
-      <p className="text-sm whitespace-pre-wrap text-card-foreground">{turn.content}</p>
-      <BeforeAfterDiff diff={turn.diff} units={units} />
+      <div className="flex items-baseline justify-between">
+        <span className="font-condensed text-[12px] font-semibold tracking-[0.16em] text-clay-text uppercase">
+          PLAN ADJUSTED
+        </span>
+        <span className="font-mono text-[10px] text-[var(--alp-faint)]">{time}</span>
+      </div>
+      <p className="mt-2 font-body text-[14px] leading-[1.55] whitespace-pre-wrap text-foreground">
+        {turn.content}
+      </p>
+      <BeforeAfterDiff diff={turn.diff} units={units} planStartDate={planStartDate} />
     </article>
   )
 }

--- a/frontend/src/app/modules/coaching/components/before-after-diff.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/before-after-diff.component.spec.tsx
@@ -3,7 +3,10 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import { PreferredUnits } from '~/api/generated'
 import { buildDiff, buildDiffWorkout } from './conversation.fixture'
-import { describeWeeklyTargetChange, describeWorkoutChange } from './before-after-diff.helpers'
+import {
+  describeWeeklyTargetChangeParts,
+  describeWorkoutChangeParts,
+} from './before-after-diff.helpers'
 import { BeforeAfterDiff } from './before-after-diff.component'
 
 describe('BeforeAfterDiff', () => {
@@ -125,6 +128,25 @@ describe('BeforeAfterDiff', () => {
     expect(screen.getByText('WK 1 · DAY 7')).toBeInTheDocument()
   })
 
+  it('degrades an out-of-range dayOfWeek to the week index even when planStartDate resolves', async () => {
+    const user = userEvent.setup()
+    const diff = buildDiff({
+      workoutChanges: [
+        { weekNumber: 1, dayOfWeek: 7, before: buildDiffWorkout(), after: buildDiffWorkout() },
+      ],
+      weeklyTargetChanges: [],
+    })
+    // `resolveCalendarDateUtc` does unbounded epoch math, so dayOfWeek=7 would
+    // roll into the next week's Sunday and render a plausible-but-wrong date
+    // (e.g. `WK JUL 5 · DAY 7`). The out-of-range guard degrades the week label
+    // to the raw index instead, so the malformed day is never dressed as a real
+    // calendar date.
+    render(<BeforeAfterDiff diff={diff} planStartDate="2026-06-28" />)
+
+    await user.click(screen.getByTestId('diff-toggle'))
+    expect(screen.getByText('WK 1 · DAY 7')).toBeInTheDocument()
+  })
+
   it('renders nothing for an empty diff (no dangling toggle)', () => {
     const { container } = render(
       <BeforeAfterDiff diff={{ workoutChanges: [], weeklyTargetChanges: [] }} />,
@@ -135,7 +157,7 @@ describe('BeforeAfterDiff', () => {
 
   it('skips a meaningless both-null workout change', () => {
     expect(
-      describeWorkoutChange({ weekNumber: 1, dayOfWeek: 1, before: null, after: null }),
+      describeWorkoutChangeParts({ weekNumber: 1, dayOfWeek: 1, before: null, after: null }),
     ).toBeNull()
   })
 
@@ -144,22 +166,22 @@ describe('BeforeAfterDiff', () => {
     // formatter; the helper substitutes an em-dash rather than a misleading
     // `0.0 km`/`0.0 mi`.
     expect(
-      describeWorkoutChange({
+      describeWorkoutChangeParts({
         weekNumber: 1,
         dayOfWeek: 1,
         before: null,
         after: buildDiffWorkout({ title: 'Cross-Train', targetDistanceKm: 0 }),
       }),
-    ).toBe('Added Cross-Train (—)')
+    ).toEqual({ kind: 'text', text: 'Added Cross-Train (—)' })
   })
 
   it('renders an em-dash placeholder for a non-positive weekly volume target', () => {
     expect(
-      describeWeeklyTargetChange({
+      describeWeeklyTargetChangeParts({
         weekNumber: 3,
         beforeWeeklyTargetKm: 0,
         afterWeeklyTargetKm: 28,
       }),
-    ).toBe('— → 28.0 km')
+    ).toEqual({ kind: 'arrow', before: '—', after: '28.0 km' })
   })
 })

--- a/frontend/src/app/modules/coaching/components/before-after-diff.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/before-after-diff.component.spec.tsx
@@ -10,7 +10,7 @@ describe('BeforeAfterDiff', () => {
   it('renders collapsed by default with only the toggle visible', () => {
     render(<BeforeAfterDiff diff={buildDiff()} />)
 
-    expect(screen.getByTestId('diff-toggle')).toHaveTextContent('Show what changed')
+    expect(screen.getByTestId('diff-toggle')).toHaveTextContent('WHAT CHANGED')
     // Radix keeps the closed content mounted but `hidden` — assert
     // visibility, not presence.
     expect(screen.getByTestId('before-after-diff')).not.toBeVisible()
@@ -24,11 +24,40 @@ describe('BeforeAfterDiff', () => {
     expect(screen.getByTestId('before-after-diff')).toBeVisible()
     expect(screen.getAllByTestId('diff-workout-change')).toHaveLength(1)
     expect(screen.getAllByTestId('diff-weekly-target-change')).toHaveLength(2)
-    expect(screen.getByText('Week 2 volume')).toBeInTheDocument()
-    expect(screen.getByText('38.0 km → 36.0 km')).toBeInTheDocument()
+    // No planStartDate supplied — loci degrade to the week-index form.
+    expect(screen.getByText('WK 2 · VOLUME')).toBeInTheDocument()
+    const weekTwoVolume = screen.getAllByTestId('diff-weekly-target-change')[1]
+    expect(weekTwoVolume).toHaveTextContent('38.0 km')
+    expect(weekTwoVolume).toHaveTextContent('36.0 km')
+    expect(weekTwoVolume.querySelector('.text-clay-text')).toHaveTextContent('→')
 
     await user.click(screen.getByTestId('diff-toggle'))
     expect(screen.getByTestId('before-after-diff')).not.toBeVisible()
+  })
+
+  it('renders calendar-date-anchored loci when planStartDate is supplied', async () => {
+    const user = userEvent.setup()
+    render(<BeforeAfterDiff diff={buildDiff()} planStartDate="2026-06-28" />)
+
+    await user.click(screen.getByTestId('diff-toggle'))
+
+    // Week-1 workout swap: dayOfWeek 2 (Tuesday) = 2026-06-30.
+    expect(screen.getByText('WK JUN 30 · TUESDAY')).toBeInTheDocument()
+    // Week-1 volume change: the Sunday week-anchor = 2026-06-28.
+    expect(screen.getByText('WK JUN 28 · VOLUME')).toBeInTheDocument()
+    // Week-2 volume change: the Sunday week-anchor = 2026-07-05.
+    expect(screen.getByText('WK JUL 5 · VOLUME')).toBeInTheDocument()
+  })
+
+  it('degrades to the week-index locus when planStartDate is unparseable', async () => {
+    const user = userEvent.setup()
+    render(<BeforeAfterDiff diff={buildDiff()} planStartDate="not-a-date" />)
+
+    await user.click(screen.getByTestId('diff-toggle'))
+
+    expect(screen.getByText('WK 1 · TUESDAY')).toBeInTheDocument()
+    expect(screen.getAllByText('WK 1 · VOLUME')[0]).toBeInTheDocument()
+    expect(screen.getByText('WK 2 · VOLUME')).toBeInTheDocument()
   })
 
   it('renders the before/after distances in miles when units=Miles', async () => {
@@ -37,11 +66,13 @@ describe('BeforeAfterDiff', () => {
 
     await user.click(screen.getByTestId('diff-toggle'))
     // 38 km / 1.609344 = 23.61... -> 23.6 mi ; 36 km -> 22.4 mi
-    expect(screen.getByText('23.6 mi → 22.4 mi')).toBeInTheDocument()
+    const weekTwoVolume = screen.getAllByTestId('diff-weekly-target-change')[1]
+    expect(weekTwoVolume).toHaveTextContent('23.6 mi')
+    expect(weekTwoVolume).toHaveTextContent('22.4 mi')
     // 10 km (before) -> 6.2 mi ; 8 km (after) -> 5.0 mi
-    expect(
-      screen.getByText('Threshold Intervals (6.2 mi) → Easy Aerobic Run (5.0 mi)'),
-    ).toBeInTheDocument()
+    const workoutChange = screen.getByTestId('diff-workout-change')
+    expect(workoutChange).toHaveTextContent('Threshold Intervals (6.2 mi)')
+    expect(workoutChange).toHaveTextContent('Easy Aerobic Run (5.0 mi)')
   })
 
   it('renders an added workout (null before) as an Added line', async () => {
@@ -55,7 +86,7 @@ describe('BeforeAfterDiff', () => {
     render(<BeforeAfterDiff diff={diff} />)
 
     await user.click(screen.getByTestId('diff-toggle'))
-    expect(screen.getByText('Week 1 · Friday')).toBeInTheDocument()
+    expect(screen.getByText('WK 1 · FRIDAY')).toBeInTheDocument()
     expect(screen.getByText('Added Easy Aerobic Run (8.0 km)')).toBeInTheDocument()
   })
 
@@ -76,6 +107,22 @@ describe('BeforeAfterDiff', () => {
 
     await user.click(screen.getByTestId('diff-toggle'))
     expect(screen.getByText('Removed Tempo Run (9.0 km)')).toBeInTheDocument()
+  })
+
+  it('renders an out-of-range dayOfWeek without crashing when the expander opens', async () => {
+    const user = userEvent.setup()
+    const diff = buildDiff({
+      workoutChanges: [
+        { weekNumber: 1, dayOfWeek: 7, before: buildDiffWorkout(), after: buildDiffWorkout() },
+      ],
+      weeklyTargetChanges: [],
+    })
+    render(<BeforeAfterDiff diff={diff} />)
+
+    // Without the `DAY_OF_WEEK_LABELS[dayOfWeek] ?? \`Day N\`` guard,
+    // `undefined.toUpperCase()` throws a TypeError and crashes the card.
+    await user.click(screen.getByTestId('diff-toggle'))
+    expect(screen.getByText('WK 1 · DAY 7')).toBeInTheDocument()
   })
 
   it('renders nothing for an empty diff (no dangling toggle)', () => {

--- a/frontend/src/app/modules/coaching/components/before-after-diff.component.tsx
+++ b/frontend/src/app/modules/coaching/components/before-after-diff.component.tsx
@@ -47,9 +47,9 @@ const ChangeValueLine = ({ parts }: { parts: ChangeDescriptionParts }): ReactEle
  * `PlanAdaptationDiff` payload — per-workout micro-week swaps and per-week
  * meso volume-target edits — as a definition list, never parsed prose. An
  * empty diff renders nothing (no dangling toggle). Row loci are calendar-
- * date-anchored against `planStartDate` (§4.2 UTC plan-calendar math) rather
- * than the legacy week-index `workoutChangeLocus`/`weeklyTargetChangeLocus`
- * helpers, which stay exported for backward compat only.
+ * date-anchored against `planStartDate` (§4.2 UTC plan-calendar math), and
+ * degrade to a week-index locus when `planStartDate` is absent/unparseable or
+ * the `dayOfWeek` is out of range.
  */
 export const BeforeAfterDiff = ({
   diff,
@@ -64,16 +64,23 @@ export const BeforeAfterDiff = ({
 
   // The week-label side of both loci: the calendar date when `planStartDate`
   // resolves, else the raw week index. Shared so the two locus builders can't
-  // drift apart.
-  const resolveWeekLabel = (weekNumber: number, dayOfWeek: number): string =>
-    planStartDate === undefined
-      ? String(weekNumber)
-      : (formatChangeLocusDate({ planStartDate, weekNumber, dayOfWeek }) ?? String(weekNumber))
+  // drift apart. An out-of-range `dayOfWeek` (a malformed payload's 7/-1) has
+  // no calendar meaning — `resolveCalendarDateUtc` does raw epoch math with no
+  // bounds check and would roll it into an adjacent week, rendering a
+  // plausible-but-wrong date — so it degrades to the raw week index too.
+  // `weeklyTargetLocus` always passes `dayOfWeek` 0 (in range), so only a
+  // malformed workout day degrades here.
+  const resolveWeekLabel = (weekNumber: number, dayOfWeek: number): string => {
+    const dayInRange = DAY_OF_WEEK_LABELS[dayOfWeek] !== undefined
+    if (planStartDate === undefined || !dayInRange) {
+      return String(weekNumber)
+    }
+    return formatChangeLocusDate({ planStartDate, weekNumber, dayOfWeek }) ?? String(weekNumber)
+  }
 
   // `DAY_OF_WEEK_LABELS[dayOfWeek]` is `undefined` for an out-of-range index
   // (a malformed payload's 7/-1); the `?? Day N` guard keeps `.toUpperCase()`
-  // from throwing and crashing the whole card, mirroring the legacy
-  // `workoutChangeLocus` helper it replaced.
+  // from throwing and crashing the whole card.
   const weekdayLabel = (dayOfWeek: number): string =>
     (DAY_OF_WEEK_LABELS[dayOfWeek] ?? `Day ${dayOfWeek}`).toUpperCase()
 

--- a/frontend/src/app/modules/coaching/components/before-after-diff.component.tsx
+++ b/frontend/src/app/modules/coaching/components/before-after-diff.component.tsx
@@ -6,11 +6,12 @@ import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { PreferredUnits } from '~/api/generated'
 import type { PlanAdaptationDiffDto } from '~/modules/coaching/models/conversation.model'
+import { DAY_OF_WEEK_LABELS } from '~/modules/plan/components/plan-display.helpers'
+import { formatChangeLocusDate } from './adaptation-digest.helpers'
 import {
-  describeWeeklyTargetChange,
-  describeWorkoutChange,
-  weeklyTargetChangeLocus,
-  workoutChangeLocus,
+  describeWeeklyTargetChangeParts,
+  describeWorkoutChangeParts,
+  type ChangeDescriptionParts,
 } from './before-after-diff.helpers'
 
 export interface BeforeAfterDiffProps {
@@ -21,24 +22,66 @@ export interface BeforeAfterDiffProps {
    * km form unchanged.
    */
   units?: PreferredUnits
+  /**
+   * The owning plan's calendar anchor, threaded from `AdaptationTurn` (spec
+   * §3 PR-C). Row loci resolve a real calendar date against it; `undefined`
+   * or an unparseable value degrades to the week-index locus rather than
+   * crashing or showing an epoch.
+   */
+  planStartDate?: string
 }
 
+/** Renders one value-line's before/after copy, clay-coloring the `→` glyph when present. */
+const ChangeValueLine = ({ parts }: { parts: ChangeDescriptionParts }): ReactElement =>
+  parts.kind === 'arrow' ? (
+    <>
+      {parts.before} <span className="text-clay-text">→</span> {parts.after}
+    </>
+  ) : (
+    <>{parts.text}</>
+  )
+
 /**
- * The collapsible "Show what changed" before/after expander on a restructure
- * turn (spec 17 § Unit 7, OI-5). Collapsed by default; renders the structured
+ * The collapsible `WHAT CHANGED` before/after expander on a restructure turn
+ * (spec §3 PR-C). Collapsed by default; renders the structured
  * `PlanAdaptationDiff` payload — per-workout micro-week swaps and per-week
  * meso volume-target edits — as a definition list, never parsed prose. An
- * empty diff renders nothing (no dangling toggle).
+ * empty diff renders nothing (no dangling toggle). Row loci are calendar-
+ * date-anchored against `planStartDate` (§4.2 UTC plan-calendar math) rather
+ * than the legacy week-index `workoutChangeLocus`/`weeklyTargetChangeLocus`
+ * helpers, which stay exported for backward compat only.
  */
 export const BeforeAfterDiff = ({
   diff,
   units = PreferredUnits.Kilometers,
+  planStartDate,
 }: BeforeAfterDiffProps): ReactElement | null => {
   const [isOpen, setIsOpen] = useState(false)
 
   if (diff.workoutChanges.length === 0 && diff.weeklyTargetChanges.length === 0) {
     return null
   }
+
+  // The week-label side of both loci: the calendar date when `planStartDate`
+  // resolves, else the raw week index. Shared so the two locus builders can't
+  // drift apart.
+  const resolveWeekLabel = (weekNumber: number, dayOfWeek: number): string =>
+    planStartDate === undefined
+      ? String(weekNumber)
+      : (formatChangeLocusDate({ planStartDate, weekNumber, dayOfWeek }) ?? String(weekNumber))
+
+  // `DAY_OF_WEEK_LABELS[dayOfWeek]` is `undefined` for an out-of-range index
+  // (a malformed payload's 7/-1); the `?? Day N` guard keeps `.toUpperCase()`
+  // from throwing and crashing the whole card, mirroring the legacy
+  // `workoutChangeLocus` helper it replaced.
+  const weekdayLabel = (dayOfWeek: number): string =>
+    (DAY_OF_WEEK_LABELS[dayOfWeek] ?? `Day ${dayOfWeek}`).toUpperCase()
+
+  const workoutLocus = (weekNumber: number, dayOfWeek: number): string =>
+    `WK ${resolveWeekLabel(weekNumber, dayOfWeek)} · ${weekdayLabel(dayOfWeek)}`
+
+  const weeklyTargetLocus = (weekNumber: number): string =>
+    `WK ${resolveWeekLabel(weekNumber, 0)} · VOLUME`
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen} className="flex flex-col gap-2">
@@ -47,10 +90,10 @@ export const BeforeAfterDiff = ({
           type="button"
           variant="ghost"
           size="sm"
-          className="w-fit justify-start px-2"
+          className="w-fit justify-start gap-1 px-2 font-mono text-[10px] font-semibold tracking-[0.1em] text-muted-foreground"
           data-testid="diff-toggle"
         >
-          Show what changed
+          WHAT CHANGED
           <ChevronDownIcon
             aria-hidden="true"
             className={`size-4 transition-transform duration-200 ease-out motion-reduce:transition-none ${
@@ -63,24 +106,36 @@ export const BeforeAfterDiff = ({
         data-testid="before-after-diff"
         className="data-[state=open]:animate-in data-[state=closed]:animate-out motion-reduce:animate-none"
       >
-        <dl className="flex flex-col gap-2 text-sm">
+        <dl className="flex flex-col gap-2">
           {diff.workoutChanges.map((change) => {
-            const description = describeWorkoutChange(change, units)
-            if (description === null) {
+            const parts = describeWorkoutChangeParts(change, units)
+            if (parts === null) {
               return null
             }
             return (
               <div key={`workout-${change.weekNumber}-${change.dayOfWeek}`}>
-                <dt className="text-muted-foreground">{workoutChangeLocus(change)}</dt>
-                <dd data-testid="diff-workout-change">{description}</dd>
+                <dt className="font-mono text-[9.5px] font-medium tracking-[0.06em] text-[var(--alp-faint)]">
+                  {workoutLocus(change.weekNumber, change.dayOfWeek)}
+                </dt>
+                <dd
+                  data-testid="diff-workout-change"
+                  className="font-body text-[13px] text-muted-foreground"
+                >
+                  <ChangeValueLine parts={parts} />
+                </dd>
               </div>
             )
           })}
           {diff.weeklyTargetChanges.map((change) => (
             <div key={`weekly-target-${change.weekNumber}`}>
-              <dt className="text-muted-foreground">{weeklyTargetChangeLocus(change)}</dt>
-              <dd data-testid="diff-weekly-target-change">
-                {describeWeeklyTargetChange(change, units)}
+              <dt className="font-mono text-[9.5px] font-medium tracking-[0.06em] text-[var(--alp-faint)]">
+                {weeklyTargetLocus(change.weekNumber)}
+              </dt>
+              <dd
+                data-testid="diff-weekly-target-change"
+                className="font-body text-[13px] text-muted-foreground"
+              >
+                <ChangeValueLine parts={describeWeeklyTargetChangeParts(change, units)} />
               </dd>
             </div>
           ))}

--- a/frontend/src/app/modules/coaching/components/before-after-diff.helpers.ts
+++ b/frontend/src/app/modules/coaching/components/before-after-diff.helpers.ts
@@ -67,3 +67,48 @@ export const describeWeeklyTargetChange = (
   `${formatDistanceKm(change.beforeWeeklyTargetKm, units) ?? '—'} → ${
     formatDistanceKm(change.afterWeeklyTargetKm, units) ?? '—'
   }`
+
+/**
+ * A change-row's value-line copy, split so the `→` glyph can be rendered in
+ * clay by the component (spec §3 PR-C) while `describeWorkoutChange`/
+ * `describeWeeklyTargetChange` above stay intact for backward compat. An
+ * `arrow` row has a real before/after pair to join with a clay `→`; a
+ * `text` row (an added/removed workout) has no before/after split — its
+ * whole copy renders as one plain run.
+ */
+export type ChangeDescriptionParts =
+  { kind: 'arrow'; before: string; after: string } | { kind: 'text'; text: string }
+
+/**
+ * `workoutChangeLocus`'s value-line counterpart, arrow-split. Returns `null`
+ * for the same meaningless both-null case `describeWorkoutChange` guards.
+ */
+export const describeWorkoutChangeParts = (
+  change: WorkoutChangeDto,
+  units: PreferredUnits = PreferredUnits.Kilometers,
+): ChangeDescriptionParts | null => {
+  if (change.before !== null && change.after !== null) {
+    return {
+      kind: 'arrow',
+      before: describeWorkout(change.before, units),
+      after: describeWorkout(change.after, units),
+    }
+  }
+  if (change.after !== null) {
+    return { kind: 'text', text: `Added ${describeWorkout(change.after, units)}` }
+  }
+  if (change.before !== null) {
+    return { kind: 'text', text: `Removed ${describeWorkout(change.before, units)}` }
+  }
+  return null
+}
+
+/** `weeklyTargetChangeLocus`'s value-line counterpart, arrow-split — always an `arrow` row. */
+export const describeWeeklyTargetChangeParts = (
+  change: WeeklyTargetChangeDto,
+  units: PreferredUnits = PreferredUnits.Kilometers,
+): ChangeDescriptionParts => ({
+  kind: 'arrow',
+  before: formatDistanceKm(change.beforeWeeklyTargetKm, units) ?? '—',
+  after: formatDistanceKm(change.afterWeeklyTargetKm, units) ?? '—',
+})

--- a/frontend/src/app/modules/coaching/components/before-after-diff.helpers.ts
+++ b/frontend/src/app/modules/coaching/components/before-after-diff.helpers.ts
@@ -1,6 +1,5 @@
 import { PreferredUnits } from '~/api/generated'
 import { formatDistanceKm } from '~/modules/common/utils/unit-format.helpers'
-import { DAY_OF_WEEK_LABELS } from '~/modules/plan/components/plan-display.helpers'
 import type {
   WeeklyTargetChangeDto,
   WorkoutChangeDto,
@@ -19,69 +18,20 @@ const describeWorkout = (workout: MicroWorkoutCardDto, units: PreferredUnits): s
   `${workout.title} (${formatDistanceKm(workout.targetDistanceKm, units) ?? '—'})`
 
 /**
- * Where a workout change applies: `Week 2 · Tuesday`. Falls back to the raw
- * index for an out-of-range `dayOfWeek` so a malformed payload still renders
- * a defined locus instead of throwing.
- */
-export const workoutChangeLocus = (change: WorkoutChangeDto): string => {
-  const day = DAY_OF_WEEK_LABELS[change.dayOfWeek] ?? `Day ${change.dayOfWeek}`
-  return `Week ${change.weekNumber} · ${day}`
-}
-
-/**
- * The before → after copy for one workout change. A null `before` denotes an
- * added workout, a null `after` a removed one; both-null is meaningless and
- * yields `null` so the caller skips the line. Defaults to Kilometers so
- * callers that predate the unit preference (and isolated tests) render the
- * km form unchanged.
- */
-export const describeWorkoutChange = (
-  change: WorkoutChangeDto,
-  units: PreferredUnits = PreferredUnits.Kilometers,
-): string | null => {
-  if (change.before !== null && change.after !== null) {
-    return `${describeWorkout(change.before, units)} → ${describeWorkout(change.after, units)}`
-  }
-  if (change.after !== null) {
-    return `Added ${describeWorkout(change.after, units)}`
-  }
-  if (change.before !== null) {
-    return `Removed ${describeWorkout(change.before, units)}`
-  }
-  return null
-}
-
-/** Where a weekly-target change applies: `Week 3 volume`. */
-export const weeklyTargetChangeLocus = (change: WeeklyTargetChangeDto): string =>
-  `Week ${change.weekNumber} volume`
-
-/**
- * The before → after copy for one weekly volume-target change. Defaults to
- * Kilometers so callers that predate the unit preference (and isolated
- * tests) render the km form unchanged.
- */
-export const describeWeeklyTargetChange = (
-  change: WeeklyTargetChangeDto,
-  units: PreferredUnits = PreferredUnits.Kilometers,
-): string =>
-  `${formatDistanceKm(change.beforeWeeklyTargetKm, units) ?? '—'} → ${
-    formatDistanceKm(change.afterWeeklyTargetKm, units) ?? '—'
-  }`
-
-/**
  * A change-row's value-line copy, split so the `→` glyph can be rendered in
- * clay by the component (spec §3 PR-C) while `describeWorkoutChange`/
- * `describeWeeklyTargetChange` above stay intact for backward compat. An
- * `arrow` row has a real before/after pair to join with a clay `→`; a
- * `text` row (an added/removed workout) has no before/after split — its
- * whole copy renders as one plain run.
+ * clay by the component (spec §3 PR-C). An `arrow` row has a real before/after
+ * pair to join with a clay `→`; a `text` row (an added/removed workout) has no
+ * before/after split — its whole copy renders as one plain run.
  */
 export type ChangeDescriptionParts =
   { kind: 'arrow'; before: string; after: string } | { kind: 'text'; text: string }
 
 /**
- * `workoutChangeLocus`'s value-line counterpart, arrow-split. Returns `null`
- * for the same meaningless both-null case `describeWorkoutChange` guards.
+ * The before → after copy for one workout change, arrow-split. A null `before`
+ * denotes an added workout, a null `after` a removed one; both-null is
+ * meaningless and yields `null` so the caller skips the line. Defaults to
+ * Kilometers so callers that predate the unit preference (and isolated tests)
+ * render the km form unchanged.
  */
 export const describeWorkoutChangeParts = (
   change: WorkoutChangeDto,
@@ -103,7 +53,7 @@ export const describeWorkoutChangeParts = (
   return null
 }
 
-/** `weeklyTargetChangeLocus`'s value-line counterpart, arrow-split — always an `arrow` row. */
+/** The before → after copy for one weekly volume-target change — always an `arrow` row. */
 export const describeWeeklyTargetChangeParts = (
   change: WeeklyTargetChangeDto,
   units: PreferredUnits = PreferredUnits.Kilometers,

--- a/frontend/src/app/modules/coaching/components/coach-chat.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-chat.component.spec.tsx
@@ -10,6 +10,7 @@ import type {
   ConversationTimelineTurnDto,
   PlanAdaptationDiffDto,
 } from '~/modules/coaching/models/conversation.model'
+import { formatTurnTime } from '~/modules/coaching/components/transcript-time.helpers'
 
 interface MockLocation {
   state: unknown
@@ -26,6 +27,7 @@ const {
   toastErrorMock,
   reportClientErrorMock,
   preferredUnitsMock,
+  usePlanMock,
 } = vi.hoisted(() => ({
   timelineMock: vi.fn(),
   streamMock: vi.fn(),
@@ -36,6 +38,7 @@ const {
   toastErrorMock: vi.fn(),
   reportClientErrorMock: vi.fn(),
   preferredUnitsMock: vi.fn<() => PreferredUnits>(),
+  usePlanMock: vi.fn(),
 }))
 
 vi.mock('~/api/conversation.api', () => ({
@@ -59,6 +62,12 @@ vi.mock('~/error-boundary/report-client-error', () => ({
 // through a mockable ref (see `preferredUnitsMock` above).
 vi.mock('~/modules/settings/hooks/use-preferred-units.hooks', () => ({
   usePreferredUnits: () => preferredUnitsMock(),
+}))
+// `CoachChat` reads the plan's `planStartDate` via this hook to join into
+// `AdaptationTurn`'s calendar-date loci (spec §3 PR-C); stub it the same way
+// as the unit-preference hook above.
+vi.mock('~/modules/plan/hooks/use-plan.hooks', () => ({
+  usePlan: () => usePlanMock(),
 }))
 
 import { CoachChat } from './coach-chat.component'
@@ -123,12 +132,20 @@ const turnAt = (
   proactive: null,
 })
 
+// The wrapper `createdAt` and the proactive `createdAt` are deliberately
+// DISTINCT (4h30m apart, so the local HH:MM differs in minutes under any TZ)
+// so the timestamp-wiring test below actually pins that the PLAN ADJUSTED
+// card reads `formatTurnTime(proactive.createdAt)` — not the wrapper's — and a
+// field-swap regression fails instead of being masked by equal values.
+const RESTRUCTURE_WRAPPER_CREATED_AT = '2026-06-29T10:00:02Z'
+const RESTRUCTURE_PROACTIVE_CREATED_AT = '2026-06-29T14:30:02Z'
+
 const restructureTurn = (
   diff: PlanAdaptationDiffDto = { workoutChanges: [], weeklyTargetChanges: [] },
 ): ConversationTimelineTurnDto => ({
   kind: 2,
   turnId: 'a1',
-  createdAt: '2026-06-29T10:00:02Z',
+  createdAt: RESTRUCTURE_WRAPPER_CREATED_AT,
   interactive: null,
   proactive: {
     triggeringPlanEventId: 'a1',
@@ -140,7 +157,7 @@ const restructureTurn = (
     adaptationKind: 2,
     diff,
     triggeringWorkoutLogId: 'w1',
-    createdAt: '2026-06-29T10:00:02Z',
+    createdAt: RESTRUCTURE_PROACTIVE_CREATED_AT,
   },
 })
 
@@ -197,6 +214,9 @@ describe('CoachChat', () => {
     // Plain `TabBar` navigation carries no `state` — the default for every
     // test that doesn't care about the composer receiver contract.
     locationMock.mockReturnValue({ state: null, key: 'default' })
+    // No plan warm by default — the locus join degrades to the week-index
+    // form; the dedicated locus test below supplies a real planStartDate.
+    usePlanMock.mockReturnValue({ plan: undefined })
   })
 
   afterEach(() => {
@@ -241,7 +261,58 @@ describe('CoachChat', () => {
     await user.click(within(screen.getByTestId('restructure-turn')).getByTestId('diff-toggle'))
 
     // 36 km / 1.609344 = 22.37... -> 22.4 mi ; 28 km -> 17.4 mi
-    expect(screen.getByText('22.4 mi → 17.4 mi')).toBeInTheDocument()
+    const weeklyTargetRow = screen.getByTestId('diff-weekly-target-change')
+    expect(weeklyTargetRow).toHaveTextContent('22.4 mi')
+    expect(weeklyTargetRow).toHaveTextContent('17.4 mi')
+  })
+
+  it('joins the plan into the restructure diff so its rows show calendar-date loci', async () => {
+    const user = userEvent.setup()
+    usePlanMock.mockReturnValue({ plan: { planStartDate: '2026-06-28' } })
+    setTimeline([
+      restructureTurn({
+        workoutChanges: [],
+        weeklyTargetChanges: [{ weekNumber: 1, beforeWeeklyTargetKm: 36, afterWeeklyTargetKm: 28 }],
+      }),
+    ])
+    streamMock.mockReturnValue(idleStream())
+
+    renderChat()
+    await user.click(within(screen.getByTestId('restructure-turn')).getByTestId('diff-toggle'))
+
+    // Week-1 volume change: the Sunday week-anchor = 2026-06-28.
+    expect(screen.getByText('WK JUN 28 · VOLUME')).toBeInTheDocument()
+  })
+
+  it('renders the PLAN ADJUSTED timestamp from the proactive createdAt, not the wrapper createdAt', () => {
+    setTimeline([restructureTurn()])
+    streamMock.mockReturnValue(idleStream())
+
+    renderChat()
+
+    const card = screen.getByTestId('restructure-turn')
+    // The card must render the proactive turn's own local HH:MM. Computing the
+    // expected value the same way the component does keeps this TZ-invariant;
+    // asserting the wrapper's time is ABSENT is what actually catches a
+    // field-swap (the two fixture times differ in minutes under any TZ).
+    expect(card).toHaveTextContent(formatTurnTime(RESTRUCTURE_PROACTIVE_CREATED_AT))
+    expect(card).not.toHaveTextContent(formatTurnTime(RESTRUCTURE_WRAPPER_CREATED_AT))
+  })
+
+  it('degrades the restructure diff locus to the week-index form when no plan is warm', async () => {
+    const user = userEvent.setup()
+    setTimeline([
+      restructureTurn({
+        workoutChanges: [],
+        weeklyTargetChanges: [{ weekNumber: 1, beforeWeeklyTargetKm: 36, afterWeeklyTargetKm: 28 }],
+      }),
+    ])
+    streamMock.mockReturnValue(idleStream())
+
+    renderChat()
+    await user.click(within(screen.getByTestId('restructure-turn')).getByTestId('diff-toggle'))
+
+    expect(screen.getByText('WK 1 · VOLUME')).toBeInTheDocument()
   })
 
   it('renders streamed coach prose as plain text using approved pace-zone wording', () => {
@@ -570,6 +641,7 @@ describe('CoachChat', () => {
     renderChat()
     expect(screen.getByText('My end broke.')).toBeInTheDocument()
     expect(screen.getByTestId('coach-error')).toHaveClass('border-l-destructive')
+    expect(screen.getByTestId('coach-error')).toHaveClass('bg-danger-surface')
     await user.click(screen.getByRole('button', { name: /retry/i }))
 
     expect(retry).toHaveBeenCalledOnce()
@@ -589,16 +661,16 @@ describe('CoachChat', () => {
     expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument()
   })
 
-  it('renders the deterministic safety notice during an exchange', () => {
+  it('renders the deterministic safety notice during an exchange with role="alert"', () => {
     setTimeline([])
     streamMock.mockReturnValue(
       idleStream({ safety: { content: 'Call 988 now.', tier: 2, category: 1 } }),
     )
 
     renderChat()
-    expect(
-      within(screen.getByTestId('coach-safety-notice')).getByText(/call 988 now/i),
-    ).toBeInTheDocument()
+    const notice = screen.getByTestId('coach-safety-notice')
+    expect(within(notice).getByText(/call 988 now/i)).toBeInTheDocument()
+    expect(notice).toHaveAttribute('role', 'alert')
   })
 
   describe('composer prefill/focus receiver', () => {

--- a/frontend/src/app/modules/coaching/components/coach-chat.component.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-chat.component.tsx
@@ -11,15 +11,14 @@ import {
 import { reportClientError } from '~/error-boundary/report-client-error'
 import {
   useCoachStream,
-  type CoachSafetyNotice,
   type CoachStreamError,
 } from '~/modules/coaching/hooks/use-coach-stream.hooks'
 import {
   CONVERSATION_ROLE,
   CONVERSATION_TIMELINE_TURN_KIND,
-  SAFETY_TIER,
   type ConversationTimelineTurnDto,
 } from '~/modules/coaching/models/conversation.model'
+import { usePlan } from '~/modules/plan/hooks/use-plan.hooks'
 import { usePreferredUnits } from '~/modules/settings/hooks/use-preferred-units.hooks'
 import { AdaptationTurn } from './adaptation-turn.component'
 import { CoachComposer } from './coach-composer.component'
@@ -79,18 +78,6 @@ const ErroredCoachNote = (): ReactElement => (
   </div>
 )
 
-const SafetyNotice = ({ notice }: { notice: CoachSafetyNotice }): ReactElement => (
-  <div
-    role="alert"
-    data-testid="coach-safety-notice"
-    className={`rounded-md border border-l-2 bg-card p-4 text-sm whitespace-pre-wrap text-card-foreground ${
-      notice.tier === SAFETY_TIER.red ? 'border-l-destructive' : 'border-l-warning'
-    }`}
-  >
-    {notice.content}
-  </div>
-)
-
 interface RetryAffordanceProps {
   error: CoachStreamError
   onRetry: () => void
@@ -100,8 +87,7 @@ const RetryAffordance = ({ error, onRetry }: RetryAffordanceProps): ReactElement
   <div
     role="alert"
     data-testid="coach-error"
-    // Failure-surface token bg-danger-surface lands in PR-C (spec §3 PR-C); using bg-secondary here until then.
-    className="flex items-center justify-between gap-3 rounded-md border-l-[3px] border-l-destructive bg-secondary px-3 py-2"
+    className="flex items-center justify-between gap-3 rounded-md border-l-[3px] border-l-destructive bg-danger-surface px-3 py-2"
   >
     <span className="font-mono text-[12px] text-foreground">{error.message}</span>
     {error.retryable && (
@@ -121,9 +107,11 @@ const RetryAffordance = ({ error, onRetry }: RetryAffordanceProps): ReactElement
 const TimelineRow = ({
   turn,
   units,
+  planStartDate,
 }: {
   turn: ConversationTimelineTurnDto
   units: PreferredUnits
+  planStartDate: string | undefined
 }): ReactElement | null => {
   // Narrow on the payload null-ness — exactly one of interactive/proactive is set.
   if (turn.interactive !== null) {
@@ -142,9 +130,14 @@ const TimelineRow = ({
     )
   }
   return turn.proactive.role === CONVERSATION_ROLE.systemSafety ? (
-    <SafetyTurn turn={turn.proactive} />
+    <SafetyTurn tier={turn.proactive.safetyTier} content={turn.proactive.content} />
   ) : (
-    <AdaptationTurn turn={turn.proactive} units={units} />
+    <AdaptationTurn
+      turn={turn.proactive}
+      units={units}
+      planStartDate={planStartDate}
+      time={formatTurnTime(turn.proactive.createdAt)}
+    />
   )
 }
 
@@ -152,6 +145,7 @@ export const CoachChat = (): ReactElement => {
   const { data } = useGetConversationTimelineQuery(undefined)
   const timeline = data?.turns ?? NO_TURNS
   const units = usePreferredUnits()
+  const { plan } = usePlan()
   const location = useLocation()
   const locationState = isCoachChatLocationState(location.state) ? location.state : null
   const {
@@ -242,7 +236,12 @@ export const CoachChat = (): ReactElement => {
           <Fragment key={`day-${group.turns[0].turnId}`}>
             <DateDivider label={group.label} />
             {group.turns.map((turn) => (
-              <TimelineRow key={turn.turnId} turn={turn} units={units} />
+              <TimelineRow
+                key={turn.turnId}
+                turn={turn}
+                units={units}
+                planStartDate={plan?.planStartDate}
+              />
             ))}
           </Fragment>
         ))}
@@ -250,7 +249,14 @@ export const CoachChat = (): ReactElement => {
         {streamingText.length > 0 && (
           <CoachTextTurn content={streamingText} time={liveTime} streaming />
         )}
-        {safety !== null && <SafetyNotice notice={safety} />}
+        {safety !== null && (
+          <SafetyTurn
+            tier={safety.tier}
+            content={safety.content}
+            role="alert"
+            testId="coach-safety-notice"
+          />
+        )}
       </TranscriptScroller>
       {error !== null && (
         <RetryAffordance

--- a/frontend/src/app/modules/coaching/components/safety-turn.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/safety-turn.component.spec.tsx
@@ -15,7 +15,8 @@ describe('SafetyTurn', () => {
     // regression to the old width fails, not just the colour.
     expect(article).toHaveClass('border-l-[3px]')
     expect(article).toHaveClass('bg-card')
-    expect(screen.getByText('WORTH A PROFESSIONAL LOOK')).toHaveClass('text-warning')
+    // Source copy is sentence case; the uppercase display is CSS (.t-section-label).
+    expect(screen.getByText('Worth a professional look')).toHaveClass('text-warning-text')
     expect(screen.getByText('See a physio about that knee.')).toBeInTheDocument()
   })
 
@@ -28,7 +29,7 @@ describe('SafetyTurn', () => {
     // DU-5: 3px edge this PR (was border-l-4) — pin the width against a regression.
     expect(article).toHaveClass('border-l-[3px]')
     expect(article).toHaveClass('bg-danger-surface')
-    expect(screen.getByText('STOP — GET SEEN')).toHaveClass('text-danger-text')
+    expect(screen.getByText('Stop — get seen')).toHaveClass('text-danger-text')
   })
 
   it('renders the defensive green tier with a neutral edge and no heading', () => {
@@ -37,8 +38,8 @@ describe('SafetyTurn', () => {
     const article = screen.getByTestId('safety-turn')
     expect(article).toHaveAttribute('data-tier', 'green')
     expect(article).toHaveClass('border-l-border')
-    expect(screen.queryByText('WORTH A PROFESSIONAL LOOK')).not.toBeInTheDocument()
-    expect(screen.queryByText('STOP — GET SEEN')).not.toBeInTheDocument()
+    expect(screen.queryByText('Worth a professional look')).not.toBeInTheDocument()
+    expect(screen.queryByText('Stop — get seen')).not.toBeInTheDocument()
   })
 
   // AX-01 — the acceptance bar: a pathological-length scripted message

--- a/frontend/src/app/modules/coaching/components/safety-turn.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/safety-turn.component.spec.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { SAFETY_TIER } from '~/modules/coaching/models/conversation.model'
+import { SafetyTurn } from './safety-turn.component'
+
+describe('SafetyTurn', () => {
+  it('renders the amber tier with its heading, edge, and surface', () => {
+    render(<SafetyTurn tier={SAFETY_TIER.amber} content="See a physio about that knee." />)
+
+    const article = screen.getByTestId('safety-turn')
+    expect(article).toHaveAttribute('data-tier', 'amber')
+    expect(article).not.toHaveAttribute('role')
+    expect(article).toHaveClass('border-l-warning')
+    // DU-5: the edge is 3px this PR (was border-l-2) — pin the width so a
+    // regression to the old width fails, not just the colour.
+    expect(article).toHaveClass('border-l-[3px]')
+    expect(article).toHaveClass('bg-card')
+    expect(screen.getByText('WORTH A PROFESSIONAL LOOK')).toHaveClass('text-warning')
+    expect(screen.getByText('See a physio about that knee.')).toBeInTheDocument()
+  })
+
+  it('renders the red tier with its heading, edge, and danger surface', () => {
+    render(<SafetyTurn tier={SAFETY_TIER.red} content="Call 988 if you are in crisis." />)
+
+    const article = screen.getByTestId('safety-turn')
+    expect(article).toHaveAttribute('data-tier', 'red')
+    expect(article).toHaveClass('border-l-destructive')
+    // DU-5: 3px edge this PR (was border-l-4) — pin the width against a regression.
+    expect(article).toHaveClass('border-l-[3px]')
+    expect(article).toHaveClass('bg-danger-surface')
+    expect(screen.getByText('STOP — GET SEEN')).toHaveClass('text-danger-text')
+  })
+
+  it('renders the defensive green tier with a neutral edge and no heading', () => {
+    render(<SafetyTurn tier={SAFETY_TIER.green} content="All clear." />)
+
+    const article = screen.getByTestId('safety-turn')
+    expect(article).toHaveAttribute('data-tier', 'green')
+    expect(article).toHaveClass('border-l-border')
+    expect(screen.queryByText('WORTH A PROFESSIONAL LOOK')).not.toBeInTheDocument()
+    expect(screen.queryByText('STOP — GET SEEN')).not.toBeInTheDocument()
+  })
+
+  // AX-01 — the acceptance bar: a pathological-length scripted message
+  // renders in FULL, never clamped/collapsed/truncated, with no competing CTA.
+  it('renders a pathological-length message in full with no clamp/truncate/max-h class (AX-01)', () => {
+    const paragraphs = Array.from(
+      { length: 40 },
+      (_, i) =>
+        `Paragraph ${i}: this is a long scripted safety message that must never be cut off.`,
+    )
+    const content = paragraphs.join('\n\n')
+    render(<SafetyTurn tier={SAFETY_TIER.red} content={content} />)
+
+    const article = screen.getByTestId('safety-turn')
+    // The full text is present verbatim.
+    expect(article).toHaveTextContent(paragraphs[0])
+    expect(article).toHaveTextContent(paragraphs[paragraphs.length - 1])
+
+    const contentEl = screen.getByText((_, element) => element?.textContent === content)
+    expect(contentEl.className).not.toMatch(/line-clamp/)
+    expect(contentEl.className).not.toMatch(/truncate/)
+    expect(contentEl.className).not.toMatch(/max-h/)
+    // No competing CTA rendered alongside the safety content.
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('renders the live in-flight notice with role="alert" and the coach-safety-notice testid', () => {
+    render(
+      <SafetyTurn
+        tier={SAFETY_TIER.red}
+        content="Call 988 now."
+        role="alert"
+        testId="coach-safety-notice"
+      />,
+    )
+
+    const article = screen.getByTestId('coach-safety-notice')
+    expect(article).toHaveAttribute('role', 'alert')
+    expect(screen.queryByTestId('safety-turn')).not.toBeInTheDocument()
+  })
+
+  it('renders the persisted timeline turn without role="alert" (not re-announced)', () => {
+    render(<SafetyTurn tier={SAFETY_TIER.amber} content="See a physio." />)
+
+    expect(screen.getByTestId('safety-turn')).not.toHaveAttribute('role')
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/modules/coaching/components/safety-turn.component.tsx
+++ b/frontend/src/app/modules/coaching/components/safety-turn.component.tsx
@@ -1,13 +1,16 @@
 import type { ReactElement } from 'react'
 
-import {
-  SAFETY_TIER,
-  type SafetyTier,
-  type SafetyTurnDto,
-} from '~/modules/coaching/models/conversation.model'
+import { cn } from '@/lib/utils'
+import { SAFETY_TIER, type SafetyTier } from '~/modules/coaching/models/conversation.model'
 
 export interface SafetyTurnProps {
-  turn: SafetyTurnDto
+  tier: SafetyTier
+  content: string
+  /** Set by the LIVE path so a new safety message announces; omitted for persisted history. */
+  role?: 'alert'
+  /** Defaults to `'safety-turn'`; the live path passes `'coach-safety-notice'`. */
+  testId?: string
+  className?: string
 }
 
 /** Wire-tier → human-readable name, exposed as `data-tier` for tests/E2E. */
@@ -17,30 +20,83 @@ const TIER_NAMES: Record<SafetyTier, string> = {
   [SAFETY_TIER.red]: 'red',
 }
 
-// Severity styling per tier. Red is the always-prominent case (DEC-079): the
-// scripted crisis/emergency copy renders in full with the strongest accent.
-// Amber referrals keep the same subtle treatment as a restructure block. A
-// Green safety turn is never emitted (SafetySignalRaised is non-Green only);
-// the neutral entry keeps the map total for the defensive case.
-const TIER_STYLES: Record<SafetyTier, string> = {
+/** Client-derived heading copy per tier (spec §3 PR-C table) — never on the wire. */
+const TIER_HEADINGS: Record<SafetyTier, string> = {
+  [SAFETY_TIER.green]: '',
+  [SAFETY_TIER.amber]: 'WORTH A PROFESSIONAL LOOK',
+  [SAFETY_TIER.red]: 'STOP — GET SEEN',
+}
+
+/** The left-edge accent per tier — supplementary; the heading + content carry the severity. */
+const TIER_EDGE: Record<SafetyTier, string> = {
   [SAFETY_TIER.green]: 'border-l-2 border-l-border',
-  [SAFETY_TIER.amber]: 'border-l-2 border-l-warning',
-  [SAFETY_TIER.red]: 'border-l-4 border-l-destructive bg-destructive/5',
+  [SAFETY_TIER.amber]: 'border-l-[3px] border-l-warning',
+  [SAFETY_TIER.red]: 'border-l-[3px] border-l-destructive',
+}
+
+/** The card surface per tier — red gets the dedicated danger wash, amber/green stay on `--card`. */
+const TIER_SURFACE: Record<SafetyTier, string> = {
+  [SAFETY_TIER.green]: 'bg-card',
+  [SAFETY_TIER.amber]: 'bg-card',
+  [SAFETY_TIER.red]: 'bg-danger-surface',
 }
 
 /**
- * One deterministic safety turn in the read-only panel (spec 17 § Unit 7,
- * DEC-079). The scripted `content` (crisis resources, emergency referral, or
- * Amber injury/RED-S referral) always renders in full — never truncated or
- * collapsed — decoupled from any plan-change escalation level. The left-edge
- * accent is supplementary; the message itself carries the severity.
+ * The heading's text color per tier. Red uses the dedicated `--danger-text`
+ * token, NOT `--destructive` — plain `--destructive` measures only ~4.05:1
+ * (dark) / ~3.24:1 (light) against `--danger-surface`, short of the 4.5:1 AA
+ * text threshold (spec §9 #3 option (a): an AA-passing on-danger foreground
+ * variant, chosen over exempting the heading).
  */
-export const SafetyTurn = ({ turn }: SafetyTurnProps): ReactElement => (
-  <article
-    data-testid="safety-turn"
-    data-tier={TIER_NAMES[turn.safetyTier]}
-    className={`flex flex-col gap-2 rounded-md border bg-card p-4 ${TIER_STYLES[turn.safetyTier]}`}
-  >
-    <p className="text-sm whitespace-pre-wrap text-card-foreground">{turn.content}</p>
-  </article>
-)
+const TIER_HEADING_COLOR: Record<SafetyTier, string> = {
+  [SAFETY_TIER.green]: 'text-muted-foreground',
+  [SAFETY_TIER.amber]: 'text-warning',
+  [SAFETY_TIER.red]: 'text-danger-text',
+}
+
+/**
+ * The shared presentational core for a safety turn (D5, AX-01), rendered by
+ * BOTH the persisted timeline path (`safety-turn`, no `role`) and the live
+ * in-flight notice (`coach-safety-notice`, `role="alert"`). The scripted
+ * `content` (crisis resources, emergency referral, or Amber injury/RED-S
+ * referral) always renders in full — never truncated, clamped, or collapsed,
+ * and with no competing CTA — decoupled from any plan-change escalation
+ * level. The left-edge accent + heading are supplementary; the content
+ * itself always carries the severity.
+ */
+export const SafetyTurn = ({
+  tier,
+  content,
+  role,
+  testId,
+  className,
+}: SafetyTurnProps): ReactElement => {
+  const heading = TIER_HEADINGS[tier]
+  return (
+    <article
+      data-testid={testId ?? 'safety-turn'}
+      data-tier={TIER_NAMES[tier]}
+      role={role}
+      className={cn(
+        'flex flex-col gap-2 rounded-lg border border-border p-[14px]',
+        TIER_EDGE[tier],
+        TIER_SURFACE[tier],
+        className,
+      )}
+    >
+      {heading !== '' && (
+        <span
+          className={cn(
+            'font-condensed text-[12px] font-semibold tracking-[0.16em] uppercase',
+            TIER_HEADING_COLOR[tier],
+          )}
+        >
+          {heading}
+        </span>
+      )}
+      <p className="font-body text-[14px] leading-[1.55] whitespace-pre-wrap text-foreground">
+        {content}
+      </p>
+    </article>
+  )
+}

--- a/frontend/src/app/modules/coaching/components/safety-turn.component.tsx
+++ b/frontend/src/app/modules/coaching/components/safety-turn.component.tsx
@@ -20,11 +20,15 @@ const TIER_NAMES: Record<SafetyTier, string> = {
   [SAFETY_TIER.red]: 'red',
 }
 
-/** Client-derived heading copy per tier (spec §3 PR-C table) — never on the wire. */
+/**
+ * Client-derived heading copy per tier (spec §3 PR-C table) — never on the
+ * wire. Stored sentence case; the uppercase display is a CSS concern applied
+ * by `.t-section-label` at the render site.
+ */
 const TIER_HEADINGS: Record<SafetyTier, string> = {
   [SAFETY_TIER.green]: '',
-  [SAFETY_TIER.amber]: 'WORTH A PROFESSIONAL LOOK',
-  [SAFETY_TIER.red]: 'STOP — GET SEEN',
+  [SAFETY_TIER.amber]: 'Worth a professional look',
+  [SAFETY_TIER.red]: 'Stop — get seen',
 }
 
 /** The left-edge accent per tier — supplementary; the heading + content carry the severity. */
@@ -42,15 +46,18 @@ const TIER_SURFACE: Record<SafetyTier, string> = {
 }
 
 /**
- * The heading's text color per tier. Red uses the dedicated `--danger-text`
- * token, NOT `--destructive` — plain `--destructive` measures only ~4.05:1
- * (dark) / ~3.24:1 (light) against `--danger-surface`, short of the 4.5:1 AA
- * text threshold (spec §9 #3 option (a): an AA-passing on-danger foreground
- * variant, chosen over exempting the heading).
+ * The heading's text color per tier — each a gated text-on-surface token, NOT
+ * the border-accent `--warning`/`--destructive`. Amber uses `--warning-text`
+ * on `--card` and red uses `--danger-text` on `--danger-surface`: the plain
+ * accent variants render bright amber (`--warning` ~1.8:1 on the light card)
+ * or red (`--destructive` ~4.05:1 dark / ~3.24:1 light on the danger wash)
+ * that fall short of the 4.5:1 AA text threshold, so each tier gets its own
+ * AA-passing foreground (spec §9 #3 option (a): a gated on-surface variant,
+ * chosen over exempting the heading).
  */
 const TIER_HEADING_COLOR: Record<SafetyTier, string> = {
   [SAFETY_TIER.green]: 'text-muted-foreground',
-  [SAFETY_TIER.amber]: 'text-warning',
+  [SAFETY_TIER.amber]: 'text-warning-text',
   [SAFETY_TIER.red]: 'text-danger-text',
 }
 
@@ -85,18 +92,9 @@ export const SafetyTurn = ({
       )}
     >
       {heading !== '' && (
-        <span
-          className={cn(
-            'font-condensed text-[12px] font-semibold tracking-[0.16em] uppercase',
-            TIER_HEADING_COLOR[tier],
-          )}
-        >
-          {heading}
-        </span>
+        <h3 className={cn('t-section-label', TIER_HEADING_COLOR[tier])}>{heading}</h3>
       )}
-      <p className="font-body text-[14px] leading-[1.55] whitespace-pre-wrap text-foreground">
-        {content}
-      </p>
+      <p className="t-body whitespace-pre-wrap text-foreground">{content}</p>
     </article>
   )
 }

--- a/frontend/src/app/modules/coaching/pages/coach.page.spec.tsx
+++ b/frontend/src/app/modules/coaching/pages/coach.page.spec.tsx
@@ -5,10 +5,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PreferredUnits } from '~/api/generated'
 import type { UseCoachStreamReturn } from '~/modules/coaching/hooks/use-coach-stream.hooks'
 
-const { timelineMock, streamMock, preferredUnitsMock } = vi.hoisted(() => ({
+const { timelineMock, streamMock, preferredUnitsMock, usePlanMock } = vi.hoisted(() => ({
   timelineMock: vi.fn(),
   streamMock: vi.fn(),
   preferredUnitsMock: vi.fn<() => PreferredUnits>(),
+  usePlanMock: vi.fn(),
 }))
 
 vi.mock('~/api/conversation.api', () => ({
@@ -20,6 +21,9 @@ vi.mock('~/modules/coaching/hooks/use-coach-stream.hooks', () => ({
 }))
 vi.mock('~/modules/settings/hooks/use-preferred-units.hooks', () => ({
   usePreferredUnits: () => preferredUnitsMock(),
+}))
+vi.mock('~/modules/plan/hooks/use-plan.hooks', () => ({
+  usePlan: () => usePlanMock(),
 }))
 
 import { CoachPage } from './coach.page'
@@ -48,6 +52,7 @@ describe('CoachPage', () => {
     timelineMock.mockReturnValue({ data: { turns: [] }, isLoading: false, isError: false })
     streamMock.mockReturnValue(idleStream())
     preferredUnitsMock.mockReturnValue(PreferredUnits.Kilometers)
+    usePlanMock.mockReturnValue({ plan: undefined })
   })
 
   it('mounts under the coach-page testid', () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -117,6 +117,11 @@
    * R: 196+0.15*(255-196)=204.85→205 (0xCD); G: 85+0.15*(255-85)=110.5→111
    * (0x6F); B: 77+0.15*(255-77)=103.7→104 (0x68) = #CD6F68 (~5.17:1). */
   --alp-danger-text: #cd6f68;
+  /* Text-safe amber for the amber safety-turn heading rendered ON --alp-surface
+   * (the amber tier's card fill). Plain --alp-amber clears AA on this dark card
+   * (~7.5:1), so dark keeps the accent value unchanged; the .light block below
+   * darkens it, where raw --alp-amber measures only ~1.8:1 on the light card. */
+  --alp-warning-text: #d9a441;
   --alp-muted: #a9a594;
   --alp-faint: #6f6d5e;
   --alp-clay: #d06a3b;
@@ -218,6 +223,12 @@
    * R: 196*0.78=152.88→153 (0x99); G: 85*0.78=66.3→66 (0x42);
    * B: 77*0.78=60.06→60 (0x3C) = #99423C (~4.81:1). */
   --alp-danger-text: #99423c;
+  /* Text-safe amber for the amber safety-turn heading on the light card
+   * (--alp-surface #eae5d7) — raw --alp-amber (#d9a441) measures only ~1.8:1
+   * there (fails AA). Darkened 45% from --alp-amber toward black:
+   * R: 217*0.55=119.35→119 (0x77); G: 164*0.55=90.2→90 (0x5A);
+   * B: 65*0.55=35.75→36 (0x24) = #775A24 (~5.1:1). */
+  --alp-warning-text: #775a24;
 }
 
 /* ── Semantic tier — shadcn slots (+ project slots) mapped to the primitive
@@ -272,6 +283,10 @@
    * exempt) — the turn's severity is always conveyed by its content and
    * structure, never by this colour alone. Never use it for text. */
   --warning: var(--alp-amber);
+  /* The amber safety-turn heading's text-safe amber on --card. Unlike
+   * --warning (a non-text border accent, exempt), this IS a text token and is
+   * gated against --card (see check-contrast.ts). */
+  --warning-text: var(--alp-warning-text);
 
   /* --border is a decorative divider (WCAG 1.4.11 exempt). --input is a
    * form-control boundary held to the 3:1 UI-component rule: it is the only
@@ -318,7 +333,7 @@
   --surface-dim: var(--alp-surface-dim);
   /* The failure-surface fill behind a red safety turn / the live retry
    * affordance (spec §3 PR-C) — a text-on-fill pair (both --foreground body
-   * copy and the --destructive heading render directly on it), so unlike
+   * copy and the --danger-text heading render directly on it), so unlike
    * --surface-dim it IS gated (see check-contrast.ts). */
   --danger-surface: var(--alp-danger-surface);
   /* The safety-turn heading's text-safe red on --danger-surface — plain
@@ -369,6 +384,10 @@
   --destructive-foreground: var(--alp-on-danger);
 
   --warning: var(--alp-amber);
+  /* The amber safety-turn heading's text-safe amber on --card. Unlike
+   * --warning (a non-text border accent, exempt), this IS a text token and is
+   * gated against --card (see check-contrast.ts). */
+  --warning-text: var(--alp-warning-text);
 
   --border: var(--alp-hairline);
   --input: var(--alp-input-border);
@@ -442,6 +461,7 @@
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
   --color-warning: var(--warning);
+  --color-warning-text: var(--warning-text);
   --color-border: var(--border);
   --color-input: var(--input);
   /* Exposes the sunken input-fill semantic slot (distinct from the --input

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -104,7 +104,19 @@
    * semantic-tier `--surface-dim` comment below for the full derivation and
    * the `.light` value's arithmetic). */
   --alp-surface-dim: #141911;
+  /* Danger-surface fill for the red safety-turn card and the live retry
+   * affordance (spec §3 PR-C) — an exact match to the mock's #1C1614. No
+   * existing primitive matched it. See the `.light` block below for the
+   * derived light value's arithmetic. */
+  --alp-danger-surface: #1c1614;
   --alp-bone: #ede8db;
+  /* Text-safe red for the safety-turn heading rendered ON --alp-danger-surface
+   * (spec §3 PR-C / §9 #3) — plain --alp-danger measures only 4.05:1 against
+   * this near-black fill (fails AA), so this is a lightened variant tuned to
+   * clear 4.5:1: --alp-danger (#c4554d) lightened 15% toward white —
+   * R: 196+0.15*(255-196)=204.85→205 (0xCD); G: 85+0.15*(255-85)=110.5→111
+   * (0x6F); B: 77+0.15*(255-77)=103.7→104 (0x68) = #CD6F68 (~5.17:1). */
+  --alp-danger-text: #cd6f68;
   --alp-muted: #a9a594;
   --alp-faint: #6f6d5e;
   --alp-clay: #d06a3b;
@@ -177,6 +189,15 @@
    * 238.5→239; G: (240+229)/2=234.5→235; B: (231+215)/2=223 →
    * rgb(239,235,223) = #efebdf. */
   --alp-surface-dim: #efebdf;
+  /* Derived, not guessed: a FAINT danger wash over light --alp-bg — a 15%
+   * component-wise blend of light --alp-bg (#f3f0e7) toward light --alp-danger
+   * (#c4554d), mirroring --alp-surface-dim's component-wise-midpoint method
+   * above but weighted toward bg (a literal 50/50 midpoint measured too
+   * saturated/pink to read as "faint" and pushed the AA-passing heading
+   * color into a near-maroon). R: 243+0.15*(196-243)=235.95→236 (0xEC);
+   * G: 240+0.15*(85-240)=216.75→217 (0xD9); B: 231+0.15*(77-231)=207.9→208
+   * (0xD0) = #ECD9D0. */
+  --alp-danger-surface: #ecd9d0;
   --alp-bone: #1c2418;
   --alp-muted: #5b5c4e;
   --alp-faint: #8b897a;
@@ -191,6 +212,12 @@
   --alp-btn-border: #c9c3b1;
   --alp-clay-marker: #c05a2e;
   --alp-clay-pressed: #c56438;
+  /* Text-safe red for the safety-turn heading on light --alp-danger-surface —
+   * plain --alp-danger measures only 3.24:1 against the light wash above
+   * (fails AA). Darkened 22% from --alp-danger (#c4554d) toward black:
+   * R: 196*0.78=152.88→153 (0x99); G: 85*0.78=66.3→66 (0x42);
+   * B: 77*0.78=60.06→60 (0x3C) = #99423C (~4.81:1). */
+  --alp-danger-text: #99423c;
 }
 
 /* ── Semantic tier — shadcn slots (+ project slots) mapped to the primitive
@@ -289,6 +316,15 @@
    * layered over a cell), so it carries the same contrast exemption as
    * `--border`/`--clay-marker`. */
   --surface-dim: var(--alp-surface-dim);
+  /* The failure-surface fill behind a red safety turn / the live retry
+   * affordance (spec §3 PR-C) — a text-on-fill pair (both --foreground body
+   * copy and the --destructive heading render directly on it), so unlike
+   * --surface-dim it IS gated (see check-contrast.ts). */
+  --danger-surface: var(--alp-danger-surface);
+  /* The safety-turn heading's text-safe red on --danger-surface — plain
+   * --clay-text/--destructive are both tuned for OTHER backgrounds; this is
+   * its own gated text-on-fill pair (see check-contrast.ts). */
+  --danger-text: var(--alp-danger-text);
 
   /* Alpine accent ramp for charts — non-text, decorative. */
   --chart-1: var(--alp-clay);
@@ -345,6 +381,8 @@
   --input-fill: var(--alp-input);
   --clay-marker: var(--alp-clay-marker);
   --surface-dim: var(--alp-surface-dim);
+  --danger-surface: var(--alp-danger-surface);
+  --danger-text: var(--alp-danger-text);
 
   --chart-1: var(--alp-clay);
   --chart-2: var(--alp-moss);
@@ -419,6 +457,8 @@
   --color-clay-pressed: var(--clay-pressed);
   --color-clay-marker: var(--clay-marker);
   --color-surface-dim: var(--surface-dim);
+  --color-danger-surface: var(--danger-surface);
+  --color-danger-text: var(--danger-text);
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);
   --color-chart-3: var(--chart-3);


### PR DESCRIPTION
## Slice 3 PR-C — Coach adaptation + safety turns + danger-surface token

Third PR of Slice 3 (Coach) in the SPLIT/Alpine UI redesign. Rebuilds the two proactive `/coach` turn kinds to the Alpine design and lands the deferred failure-surface token. Frontend-only. Spec: `docs/specs/slice-3-coach/spec.md` § 3 PR-C; DEC-089.

### What changed
- **Adaptation turn (D4).** The restructure turn is now a `PLAN ADJUSTED` card — 2px clay left edge (`--clay-marker`), clay-text label + mono timestamp, pre-wrapped explanation. The `WHAT CHANGED` expander (collapsed by default) renders **per-row calendar-date loci** derived UTC from the plan's Sunday anchor (`resolveCalendarDateUtc` + new `formatChangeLocusDate`, joined via `usePlan()`), with the `→` in clay. Loci degrade to the week-index form (`WK {n} · {WEEKDAY|VOLUME}`) when `planStartDate` is absent/unparseable — never a crash, never an epoch. Nudge → plain coach line; absorb → nothing.
- **Safety turn (D5).** `SafetyTurn` refactored to a shared `{ tier, content, role?, testId? }` core used by **both** the persisted timeline path (`safety-turn`) and the live in-flight notice (`coach-safety-notice`, `role="alert"`); the local `SafetyNotice` component is deleted. Client-derived tier headings (`WORTH A PROFESSIONAL LOOK` / `STOP — GET SEEN`); content always renders **in full** (AX-01) — no clamp/collapse/competing CTA.
- **Tokens.** Adds `--alp-danger-surface` / `--danger-surface` (dark `#1c1614` from the mock; light `#ecd9d0` derived as a 15% danger wash over light `--alp-bg`, arithmetic in the CSS comment) and `--alp-danger-text` / `--danger-text` (an AA-passing red for the safety heading — plain `--destructive` measured only ~4.05:1/~3.24:1 on the wash, so § 9 #3 option (a) was taken). The live `RetryAffordance` moves onto `bg-danger-surface`, resolving PR-B's interim `bg-secondary`. `check-contrast` gates the two new pairs (42 total).

### Out of scope (PR-D)
Log-draft card saving/success/failure states + the durable `loggedRun` receipt (renders PR-A's persisted field).

### Verification
- `npm run build` ✓ · `npm run test` → **911 passed** · `npm run lint` (touched files) ✓ · `npm run check-contrast` → **all 42 pairs pass**.
- New behavior-pinning specs: `adaptation-turn.component.spec.tsx`, `safety-turn.component.spec.tsx`; extended `before-after-diff`, `adaptation-digest.helpers`, `coach-chat`, `coach.page`, `check-contrast` specs.

### Review notes
Ran a multi-agent deep-review before opening. Fixes applied from it: restored an out-of-range `dayOfWeek` guard the restyle had dropped (would have crashed the card on a malformed payload) + deduped the locus builders; removed a stale/contradictory CSS derivation comment; added test guards for the 3px safety edge width and the adaptation timestamp field-wiring (distinct fixture times so a `createdAt` field-swap fails).

Deliberately **not** changed (spec-adjudicated): `--alp-faint` on the diff-row loci (spec § 8/§ 9 #5 classify loci as decorative meta, check-contrast-exempt — a noted a11y tension, revisit design-wide not here); the `SafetyTurnProps` `role?`/`testId?` shape (spec-locked interface, 2 controlled call sites); the retained legacy diff helpers (spec said keep; now production-orphaned → candidate for a follow-up cleanup PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coaching adaptation changes now show calendar-based dates when available, with week-based labels as a fallback.
  * Expanded change details display clear before-and-after values, including unit conversions.
  * Safety messages support tier-specific styling, accessibility alerts, and full multi-paragraph content.

* **Bug Fixes**
  * Improved live coaching error and retry surface styling.
  * Added safer handling for missing plans and invalid dates.
  * Expanded contrast checks to cover additional safety messaging colors.

* **Tests**
  * Added coverage for adaptation dates, change details, safety messages, accessibility behavior, and contrast validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->