### PR TITLE
feat(split-ui): Slice 3 PR-D — durable loggedRun receipt + log-draft card states (DEC-091)

### DIFF
--- a/frontend/e2e/conversation-streaming.spec.ts
+++ b/frontend/e2e/conversation-streaming.spec.ts
@@ -104,7 +104,17 @@ const ackTurn = {
   kind: 1,
   turnId: 'ack-1',
   createdAt: '2026-06-29T10:05:00Z',
-  interactive: { content: 'Logged — solid work.', isErrored: false },
+  interactive: {
+    content: 'Logged — solid work.',
+    isErrored: false,
+    loggedRun: {
+      workoutLogId: '11111111-1111-4111-8111-111111111111',
+      distanceKm: 5,
+      durationSeconds: 1500,
+      occurredOn: '2026-06-29',
+      completionStatus: 0,
+    },
+  },
   proactive: null,
 }
 
@@ -240,10 +250,21 @@ test('register → ask a question → describe a workout → confirm the parsed 
   await expect(card.getByText(/5 km/i)).toBeVisible()
   await expect(card.getByText('25:00')).toBeVisible()
 
-  // 3. Confirm → the card dismisses and the coach ack turn appears (timeline refetch).
+  // 3. Confirm → the card dismisses and the coach ack turn appears (timeline refetch),
+  //    carrying the durable receipt (DEC-091) sourced from the persisted `loggedRun`.
   await card.getByRole('button', { name: /^confirm$/i }).click()
   await expect(card).toBeHidden()
   await expect(page.getByText('Logged — solid work.')).toBeVisible()
+  const receipt = page.getByTestId('logged-run-receipt')
+  await expect(receipt).toBeVisible()
+  await expect(receipt).toContainText('LOGGED — 5.0 km · 25:00 · JUN 29')
+  await expect(page.getByTestId('logged-run-receipt-logbook')).toHaveAttribute('href', '/history')
+
+  // 4. Reload — the receipt is a persisted turn field, not ephemeral card
+  //    state, so it must still be present after a fresh `GET /timeline`.
+  await page.reload()
+  await expect(page.getByTestId('coach-chat')).toBeVisible()
+  await expect(page.getByTestId('logged-run-receipt')).toBeVisible()
 
   // Trademark guard — no "VDOT" anywhere in the rendered DOM.
   const bodyHtml = await page.locator('body').innerHTML()

--- a/frontend/src/app/modules/coaching/components/coach-chat.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-chat.component.spec.tsx
@@ -571,6 +571,64 @@ describe('CoachChat', () => {
     expect(send).toHaveBeenCalledExactlyOnceWith('how was my run?')
   })
 
+  it('renders the durable receipt on a persisted confirm-ack coach turn carrying loggedRun', () => {
+    setTimeline([
+      userTurn('logged my run'),
+      {
+        kind: 1,
+        turnId: 'ack-1',
+        createdAt: '2026-06-29T10:00:01Z',
+        interactive: {
+          content: "Logged your run. Your plan's updated — take a look.",
+          isErrored: false,
+          loggedRun: {
+            workoutLogId: 'wl-1',
+            distanceKm: 9.2,
+            durationSeconds: 41 * 60,
+            occurredOn: '2026-07-08',
+            completionStatus: 0,
+          },
+        },
+        proactive: null,
+      },
+    ])
+    streamMock.mockReturnValue(idleStream())
+
+    renderChat()
+
+    // The receipt renders wherever the ack turn sits in the timeline — it is
+    // sourced from the persisted `loggedRun` field, not any in-session card
+    // state, so it survives a fresh GET /timeline (reload) by construction.
+    expect(screen.getByTestId('logged-run-receipt')).toHaveTextContent(
+      'LOGGED — 9.2 km · 41:00 · JUL 8',
+    )
+    expect(screen.getByTestId('logged-run-receipt-logbook')).toHaveAttribute('href', '/history')
+  })
+
+  it('threads the unit preference into the confirmation card so the on-plan target renders mile-based', () => {
+    preferredUnitsMock.mockReturnValue(PreferredUnits.Miles)
+    setTimeline([])
+    streamMock.mockReturnValue(
+      idleStream({
+        card: {
+          ...sampleCard,
+          prescription: {
+            workoutType: 'Easy',
+            distanceMeters: 8000,
+            durationSeconds: 2400,
+            paceFastSecPerKm: 300,
+            paceEasySecPerKm: 360,
+          },
+        },
+      }),
+    )
+
+    renderChat()
+
+    // 8 km / 1.609344 = 4.9709... -> 5.0 mi
+    expect(screen.getByTestId('log-confirmation-card')).toHaveTextContent('TARGET 5.0 mi')
+  })
+
   it('confirms a card through the mutation and dismisses it on success', async () => {
     const user = userEvent.setup()
     const dismissCard = vi.fn()

--- a/frontend/src/app/modules/coaching/components/coach-chat.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-chat.component.spec.tsx
@@ -598,7 +598,7 @@ describe('CoachChat', () => {
 
     // The receipt renders wherever the ack turn sits in the timeline — it is
     // sourced from the persisted `loggedRun` field, not any in-session card
-    // state, so it survives a fresh GET /timeline (reload) by construction.
+    // state, so it survives a fresh `GET /timeline` (reload) by construction.
     expect(screen.getByTestId('logged-run-receipt')).toHaveTextContent(
       'LOGGED — 9.2 km · 41:00 · JUL 8',
     )
@@ -625,7 +625,7 @@ describe('CoachChat', () => {
 
     renderChat()
 
-    // 8 km / 1.609344 = 4.9709... -> 5.0 mi
+    // `8 km / 1.609344 = 4.9709…` → `5.0 mi`
     expect(screen.getByTestId('log-confirmation-card')).toHaveTextContent('TARGET 5.0 mi')
   })
 

--- a/frontend/src/app/modules/coaching/components/coach-chat.component.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-chat.component.tsx
@@ -269,6 +269,7 @@ export const CoachChat = (): ReactElement => {
       {card !== null && (
         <LogConfirmationCard
           card={card}
+          units={units}
           isConfirming={isConfirming}
           onConfirm={() => {
             void handleConfirm()

--- a/frontend/src/app/modules/coaching/components/coach-text-turn.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-text-turn.component.spec.tsx
@@ -1,11 +1,22 @@
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
 
+import { PreferredUnits } from '~/api/generated'
+import type { LoggedRunSummaryDto } from '~/modules/coaching/models/conversation.model'
 import {
   expectDualThemeParity,
   renderInBothThemes,
 } from '~/modules/common/test-utils/render-in-both-themes'
 import { CoachTextTurn } from './coach-text-turn.component'
+
+const loggedRun: LoggedRunSummaryDto = {
+  workoutLogId: 'wl-1',
+  distanceKm: 9.2,
+  durationSeconds: 41 * 60,
+  occurredOn: '2026-07-08',
+  completionStatus: 0,
+}
 
 describe('CoachTextTurn', () => {
   it('renders no bubble — just a mono COACH · HH:MM label and bone body text', () => {
@@ -54,5 +65,64 @@ describe('CoachTextTurn', () => {
   it('holds dual-theme structural parity with no raw hex colour literals', () => {
     const result = renderInBothThemes(<CoachTextTurn content="You ran well." time="06:59" />)
     expectDualThemeParity(result, 'coach-text-turn')
+  })
+
+  it('renders the durable receipt beneath the body when loggedRun is non-null', () => {
+    render(
+      <MemoryRouter>
+        <CoachTextTurn
+          content="Logged your run. Your plan's updated — take a look."
+          time="06:59"
+          loggedRun={loggedRun}
+          units={PreferredUnits.Kilometers}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByTestId('logged-run-receipt')).toHaveTextContent(
+      'LOGGED — 9.2 km · 41:00 · JUL 8',
+    )
+  })
+
+  it('defaults units to Kilometers when loggedRun is set but units is omitted', () => {
+    render(
+      <MemoryRouter>
+        <CoachTextTurn
+          content="Logged your run. Your plan's updated — take a look."
+          time="06:59"
+          loggedRun={loggedRun}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByTestId('logged-run-receipt')).toHaveTextContent('9.2 km')
+  })
+
+  it('renders no receipt for a historical ack turn whose loggedRun is null', () => {
+    render(<CoachTextTurn content="Logged your run." time="06:59" loggedRun={null} />)
+
+    expect(screen.queryByTestId('logged-run-receipt')).not.toBeInTheDocument()
+  })
+
+  it('renders no receipt when loggedRun is undefined (e.g. live streaming turns)', () => {
+    render(<CoachTextTurn content="You ran well." time="06:59" />)
+
+    expect(screen.queryByTestId('logged-run-receipt')).not.toBeInTheDocument()
+  })
+
+  it('renders the receipt in miles when units=Miles', () => {
+    render(
+      <MemoryRouter>
+        <CoachTextTurn
+          content="Logged your run."
+          time="06:59"
+          loggedRun={loggedRun}
+          units={PreferredUnits.Miles}
+        />
+      </MemoryRouter>,
+    )
+
+    // 9.2 km / 1.609344 = 5.7156... -> 5.7 mi
+    expect(screen.getByTestId('logged-run-receipt')).toHaveTextContent('5.7 mi')
   })
 })

--- a/frontend/src/app/modules/coaching/components/coach-text-turn.component.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-text-turn.component.tsx
@@ -10,7 +10,7 @@ export interface CoachTextTurnProps {
   time: string
   /** Appends the clay block-cursor inline at the end of the body when a live stream is still in flight. */
   streaming?: boolean
-  /** Renders the durable `LoggedRunReceipt` beneath the body when non-null; null/undefined render no receipt. */
+  /** Renders the durable `LoggedRunReceipt` beneath the body when non-null; `null` / `undefined` render no receipt. */
   loggedRun?: LoggedRunSummaryDto | null
   /** Unit-aware distance for the receipt. Defaults to Kilometers. */
   units?: PreferredUnits

--- a/frontend/src/app/modules/coaching/components/coach-text-turn.component.tsx
+++ b/frontend/src/app/modules/coaching/components/coach-text-turn.component.tsx
@@ -1,17 +1,18 @@
 import type { ReactElement } from 'react'
 
 import { cn } from '@/lib/utils'
-import type { PreferredUnits } from '~/api/generated'
+import { PreferredUnits } from '~/api/generated'
 import type { LoggedRunSummaryDto } from '~/modules/coaching/models/conversation.model'
+import { LoggedRunReceipt } from './logged-run-receipt.component'
 
 export interface CoachTextTurnProps {
   content: string
   time: string
   /** Appends the clay block-cursor inline at the end of the body when a live stream is still in flight. */
   streaming?: boolean
-  /** Wires into the durable `LoggedRunReceipt` (spec §3 PR-D); undefined when the receipt isn't rendered. */
+  /** Renders the durable `LoggedRunReceipt` beneath the body when non-null; null/undefined render no receipt. */
   loggedRun?: LoggedRunSummaryDto | null
-  /** Unit-aware distance for the receipt (spec §3 PR-D). Defaults to Kilometers. */
+  /** Unit-aware distance for the receipt. Defaults to Kilometers. */
   units?: PreferredUnits
   className?: string
 }
@@ -23,14 +24,17 @@ export interface CoachTextTurnProps {
  * `streaming` appends an `aria-hidden` clay block-cursor inline at the end
  * of the body while a live reply is still arriving.
  *
- * `loggedRun`/`units` are declared here (not destructured) as forward
- * compatibility for the durable receipt (spec §3 PR-D), which renders
- * `<LoggedRunReceipt>` beneath the body when `loggedRun` is non-null.
+ * When `loggedRun` is non-null (the confirm-ack turn for a committed
+ * conversational log, DEC-091), renders the durable `LoggedRunReceipt`
+ * beneath the body — this is what survives reload, since it reads off the
+ * persisted timeline turn rather than any in-session card state.
  */
 export const CoachTextTurn = ({
   content,
   time,
   streaming,
+  loggedRun,
+  units = PreferredUnits.Kilometers,
   className,
 }: CoachTextTurnProps): ReactElement => (
   <div data-testid="coach-text-turn" className={cn('flex flex-col gap-1', className)}>
@@ -47,5 +51,6 @@ export const CoachTextTurn = ({
         />
       )}
     </p>
+    {loggedRun != null && <LoggedRunReceipt summary={loggedRun} units={units} className="mt-2" />}
   </div>
 )

--- a/frontend/src/app/modules/coaching/components/log-confirmation-card.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/log-confirmation-card.component.spec.tsx
@@ -2,7 +2,12 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
+import { PreferredUnits } from '~/api/generated'
 import type { CoachCard } from '~/modules/coaching/hooks/use-coach-stream.hooks'
+import {
+  expectDualThemeParity,
+  renderInBothThemes,
+} from '~/modules/common/test-utils/render-in-both-themes'
 
 import { LogConfirmationCard } from './log-confirmation-card.component'
 
@@ -24,6 +29,7 @@ const baseCard: CoachCard = {
 const renderCard = (overrides: Partial<Parameters<typeof LogConfirmationCard>[0]> = {}) => {
   const props = {
     card: baseCard,
+    units: PreferredUnits.Kilometers,
     onConfirm: vi.fn(),
     onEdit: vi.fn(),
     onCancel: vi.fn(),
@@ -35,11 +41,37 @@ const renderCard = (overrides: Partial<Parameters<typeof LogConfirmationCard>[0]
 }
 
 describe('LogConfirmationCard', () => {
-  it('renders the parsed distance, duration, and note', () => {
+  it('renders the LOG THIS RUN? heading, distance, duration, and humanized date', () => {
     renderCard()
 
+    expect(screen.getByText('LOG THIS RUN?')).toBeInTheDocument()
     expect(screen.getByText(/5 km/i)).toBeInTheDocument()
     expect(screen.getByText('25:00')).toBeInTheDocument()
+    // 2026-06-29 humanized via formatReceiptDate, not the raw ISO string.
+    expect(screen.getByText('JUN 29')).toBeInTheDocument()
+    expect(screen.queryByText('2026-06-29')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the raw ISO string when occurredOn is unparseable', () => {
+    renderCard({
+      card: {
+        ...baseCard,
+        draft: { ...baseCard.draft, occurredOn: 'not-a-date' },
+      },
+    })
+
+    expect(screen.getByText('not-a-date')).toBeInTheDocument()
+  })
+
+  it('renders the STATUS value in the positive (moss) token', () => {
+    renderCard()
+
+    const status = screen.getByText('Completed')
+    expect(status).toHaveClass('text-positive')
+  })
+
+  it('renders the note', () => {
+    renderCard()
     expect(screen.getByText(/legs felt heavy/i)).toBeInTheDocument()
   })
 
@@ -62,7 +94,7 @@ describe('LogConfirmationCard', () => {
     expect(screen.getByText('1:45:30')).toBeInTheDocument()
   })
 
-  it('shows the matched on-plan workout type when a prescription is present', () => {
+  it('shows the on-plan workout type AND the unit-aware target distance when a prescription is present', () => {
     renderCard({
       card: {
         ...baseCard,
@@ -76,26 +108,92 @@ describe('LogConfirmationCard', () => {
       },
     })
 
-    expect(screen.getByText(/easy/i)).toBeInTheDocument()
+    expect(screen.getByText(/ON-PLAN — EASY · TARGET 8\.0 km/i)).toBeInTheDocument()
+  })
+
+  it('renders the on-plan target distance in miles when units=Miles', () => {
+    renderCard({
+      units: PreferredUnits.Miles,
+      card: {
+        ...baseCard,
+        prescription: {
+          workoutType: 'Easy',
+          distanceMeters: 8000,
+          durationSeconds: 2400,
+          paceFastSecPerKm: 300,
+          paceEasySecPerKm: 360,
+        },
+      },
+    })
+
+    // 8 km / 1.609344 = 4.9709... -> 5.0 mi
+    expect(screen.getByText(/TARGET 5\.0 mi/i)).toBeInTheDocument()
+  })
+
+  it('renders no on-plan line when prescription is null', () => {
+    renderCard()
+    expect(screen.queryByText(/ON-PLAN/i)).not.toBeInTheDocument()
+  })
+
+  it('carries the log-confirm/log-edit/log-cancel testids', () => {
+    renderCard()
+
+    expect(screen.getByTestId('log-confirm')).toBeInTheDocument()
+    expect(screen.getByTestId('log-edit')).toBeInTheDocument()
+    expect(screen.getByTestId('log-cancel')).toBeInTheDocument()
   })
 
   it('wires Confirm, Edit, and Cancel', async () => {
     const user = userEvent.setup()
     const props = renderCard()
 
-    await user.click(screen.getByRole('button', { name: /^confirm$/i }))
+    await user.click(screen.getByTestId('log-confirm'))
     expect(props.onConfirm).toHaveBeenCalledOnce()
 
-    await user.click(screen.getByRole('button', { name: /^edit$/i }))
+    await user.click(screen.getByTestId('log-edit'))
     expect(props.onEdit).toHaveBeenCalledOnce()
 
-    await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+    await user.click(screen.getByTestId('log-cancel'))
     expect(props.onCancel).toHaveBeenCalledOnce()
   })
 
-  it('disables Confirm while a commit is in flight', () => {
-    renderCard({ isConfirming: true })
+  describe('saving state (isConfirming)', () => {
+    it('dims the card and disables Confirm and Edit', () => {
+      renderCard({ isConfirming: true })
 
-    expect(screen.getByRole('button', { name: /^confirm$/i })).toBeDisabled()
+      expect(screen.getByTestId('log-confirmation-card')).toHaveClass('opacity-75')
+      expect(screen.getByTestId('log-confirm')).toBeDisabled()
+      expect(screen.getByTestId('log-edit')).toBeDisabled()
+    })
+
+    it('swaps the CONFIRM label to Saving…', () => {
+      renderCard({ isConfirming: true })
+
+      expect(screen.getByTestId('log-confirm')).toHaveTextContent('Saving…')
+      expect(screen.queryByText(/^confirm$/i)).not.toBeInTheDocument()
+    })
+
+    it('hides Cancel entirely while saving', () => {
+      renderCard({ isConfirming: true })
+
+      expect(screen.queryByTestId('log-cancel')).not.toBeInTheDocument()
+    })
+  })
+
+  // The assertions live inside the shared expectDualThemeParity helper —
+  // sonarjs's static check can't see through the function call.
+  // eslint-disable-next-line sonarjs/assertions-in-tests
+  it('holds dual-theme structural parity with no raw hex colour literals', () => {
+    const result = renderInBothThemes(
+      <LogConfirmationCard
+        card={baseCard}
+        units={PreferredUnits.Kilometers}
+        onConfirm={vi.fn()}
+        onEdit={vi.fn()}
+        onCancel={vi.fn()}
+        isConfirming={false}
+      />,
+    )
+    expectDualThemeParity(result, 'log-confirmation-card')
   })
 })

--- a/frontend/src/app/modules/coaching/components/log-confirmation-card.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/log-confirmation-card.component.spec.tsx
@@ -47,7 +47,7 @@ describe('LogConfirmationCard', () => {
     expect(screen.getByText('LOG THIS RUN?')).toBeInTheDocument()
     expect(screen.getByText(/5 km/i)).toBeInTheDocument()
     expect(screen.getByText('25:00')).toBeInTheDocument()
-    // 2026-06-29 humanized via formatReceiptDate, not the raw ISO string.
+    // `2026-06-29` humanized via `formatReceiptDate`, not the raw ISO string.
     expect(screen.getByText('JUN 29')).toBeInTheDocument()
     expect(screen.queryByText('2026-06-29')).not.toBeInTheDocument()
   })
@@ -126,7 +126,7 @@ describe('LogConfirmationCard', () => {
       },
     })
 
-    // 8 km / 1.609344 = 4.9709... -> 5.0 mi
+    // `8 km / 1.609344 = 4.9709…` → `5.0 mi`
     expect(screen.getByText(/TARGET 5\.0 mi/i)).toBeInTheDocument()
   })
 
@@ -180,7 +180,7 @@ describe('LogConfirmationCard', () => {
     })
   })
 
-  // The assertions live inside the shared expectDualThemeParity helper —
+  // The assertions live inside the shared `expectDualThemeParity` helper —
   // sonarjs's static check can't see through the function call.
   // eslint-disable-next-line sonarjs/assertions-in-tests
   it('holds dual-theme structural parity with no raw hex colour literals', () => {

--- a/frontend/src/app/modules/coaching/components/log-confirmation-card.component.tsx
+++ b/frontend/src/app/modules/coaching/components/log-confirmation-card.component.tsx
@@ -1,8 +1,11 @@
 import type { ReactElement } from 'react'
 
+import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
-import type { CompletionStatus, RunnerDistanceUnit } from '~/api/generated'
+import type { CompletionStatus, PreferredUnits, RunnerDistanceUnit } from '~/api/generated'
+import { formatDistanceKm } from '~/modules/common/utils/unit-format.helpers'
 import type { CoachCard } from '~/modules/coaching/hooks/use-coach-stream.hooks'
+import { formatReceiptDate } from './transcript-time.helpers'
 
 // The confirmation card renders a parsed workout-log draft for an explicit
 // Confirm / Edit / Cancel. The plan-mutating commit fires only on Confirm — the
@@ -23,17 +26,23 @@ const formatDuration = (hours: number, minutes: number, seconds: number): string
 interface FieldProps {
   label: string
   value: string
+  valueClassName?: string
 }
 
-const Field = ({ label, value }: FieldProps): ReactElement => (
-  <div className="flex flex-col">
-    <dt className="text-xs text-muted-foreground">{label}</dt>
-    <dd className="text-foreground">{value}</dd>
+const Field = ({ label, value, valueClassName }: FieldProps): ReactElement => (
+  <div className="flex flex-col gap-0.5">
+    <dt className="font-mono text-[9.5px] font-medium tracking-[0.1em] text-muted-foreground">
+      {label}
+    </dt>
+    <dd className={cn('font-condensed text-[22px] font-bold text-foreground', valueClassName)}>
+      {value}
+    </dd>
   </div>
 )
 
 export interface LogConfirmationCardProps {
   card: CoachCard
+  units: PreferredUnits
   onConfirm: () => void
   onEdit: () => void
   onCancel: () => void
@@ -42,6 +51,7 @@ export interface LogConfirmationCardProps {
 
 export const LogConfirmationCard = ({
   card,
+  units,
   onConfirm,
   onEdit,
   onCancel,
@@ -49,40 +59,64 @@ export const LogConfirmationCard = ({
 }: LogConfirmationCardProps): ReactElement => {
   const { draft, prescription } = card
   const hasNote = draft.notes !== null && draft.notes.length > 0
+  const dateLabel = formatReceiptDate(draft.occurredOn) ?? draft.occurredOn
+  const targetLabel =
+    prescription === null
+      ? null
+      : (formatDistanceKm(prescription.distanceMeters / 1000, units) ?? '—')
 
   return (
     <section
       data-testid="log-confirmation-card"
       aria-label="Confirm workout log"
-      className="flex flex-col gap-3 rounded-2xl border border-border bg-card p-4 text-sm text-card-foreground"
+      className={cn(
+        'flex flex-col gap-3 rounded-lg border border-border bg-card p-[14px] text-sm text-card-foreground',
+        isConfirming && 'opacity-75',
+      )}
     >
-      <h3 className="font-semibold text-foreground">Log this run?</h3>
-      <dl className="grid grid-cols-2 gap-x-4 gap-y-2">
+      <h3 className="font-condensed text-[13px] font-semibold tracking-[0.16em] text-foreground uppercase">
+        LOG THIS RUN?
+      </h3>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-[10px]">
         <Field
-          label="Distance"
+          label="DISTANCE"
           value={`${draft.distanceValue} ${DISTANCE_UNIT_LABEL[draft.distanceUnit]}`}
         />
         <Field
-          label="Time"
+          label="TIME"
           value={formatDuration(draft.durationHours, draft.durationMinutes, draft.durationSeconds)}
         />
-        <Field label="Date" value={draft.occurredOn} />
-        <Field label="Status" value={COMPLETION_LABEL[draft.completionStatus]} />
+        <Field label="DATE" value={dateLabel} />
+        <Field
+          label="STATUS"
+          value={COMPLETION_LABEL[draft.completionStatus]}
+          valueClassName="text-positive"
+        />
       </dl>
-      {hasNote && <p className="text-muted-foreground">{draft.notes}</p>}
+      {hasNote && <p className="font-body text-[13px] text-muted-foreground">{draft.notes}</p>}
       {prescription !== null && (
-        <p className="text-muted-foreground">On-plan: {prescription.workoutType} run</p>
+        <p className="font-mono text-[10px] tracking-[0.08em] text-muted-foreground">
+          ON-PLAN — {prescription.workoutType.toUpperCase()} · TARGET {targetLabel}
+        </p>
       )}
-      <div className="flex flex-wrap gap-2">
-        <Button type="button" onClick={onConfirm} disabled={isConfirming}>
-          Confirm
+      <div className="flex items-center gap-[10px]">
+        <Button type="button" data-testid="log-confirm" onClick={onConfirm} disabled={isConfirming}>
+          {isConfirming ? 'Saving…' : 'Confirm'}
         </Button>
-        <Button type="button" variant="secondary" onClick={onEdit} disabled={isConfirming}>
+        <Button
+          type="button"
+          variant="outline"
+          data-testid="log-edit"
+          onClick={onEdit}
+          disabled={isConfirming}
+        >
           Edit
         </Button>
-        <Button type="button" variant="ghost" onClick={onCancel} disabled={isConfirming}>
-          Cancel
-        </Button>
+        {!isConfirming && (
+          <Button type="button" variant="ghost" data-testid="log-cancel" onClick={onCancel}>
+            Cancel
+          </Button>
+        )}
       </div>
     </section>
   )

--- a/frontend/src/app/modules/coaching/components/logged-run-receipt.component.spec.tsx
+++ b/frontend/src/app/modules/coaching/components/logged-run-receipt.component.spec.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import { PreferredUnits } from '~/api/generated'
+import type { LoggedRunSummaryDto } from '~/modules/coaching/models/conversation.model'
+import {
+  expectDualThemeParity,
+  renderInBothThemes,
+} from '~/modules/common/test-utils/render-in-both-themes'
+
+import { LoggedRunReceipt } from './logged-run-receipt.component'
+
+const baseSummary: LoggedRunSummaryDto = {
+  workoutLogId: 'wl-1',
+  distanceKm: 9.2,
+  durationSeconds: 41 * 60,
+  occurredOn: '2026-07-08',
+  completionStatus: 0,
+}
+
+const renderReceipt = (
+  summary: LoggedRunSummaryDto = baseSummary,
+  units: PreferredUnits = PreferredUnits.Kilometers,
+) =>
+  render(
+    <MemoryRouter>
+      <LoggedRunReceipt summary={summary} units={units} />
+    </MemoryRouter>,
+  )
+
+describe('LoggedRunReceipt', () => {
+  it('renders the LOGGED format string with distance, duration, and humanized date', () => {
+    renderReceipt()
+
+    expect(screen.getByTestId('logged-run-receipt')).toHaveTextContent(
+      'LOGGED — 9.2 km · 41:00 · JUL 8',
+    )
+  })
+
+  it('renders a LOG BOOK → link to /history', () => {
+    renderReceipt()
+
+    const link = screen.getByTestId('logged-run-receipt-logbook')
+    expect(link).toHaveAttribute('href', '/history')
+    expect(link).toHaveTextContent('LOG BOOK →')
+  })
+
+  it('renders the distance in miles when units=Miles', () => {
+    renderReceipt(baseSummary, PreferredUnits.Miles)
+
+    // 9.2 km / 1.609344 = 5.7156... -> 5.7 mi
+    expect(screen.getByTestId('logged-run-receipt')).toHaveTextContent('5.7 mi')
+  })
+
+  it('omits the date fragment (and never crashes) when occurredOn is unparseable', () => {
+    renderReceipt({ ...baseSummary, occurredOn: 'not-a-date' })
+
+    const receipt = screen.getByTestId('logged-run-receipt')
+    expect(receipt).toHaveTextContent('LOGGED — 9.2 km · 41:00')
+    expect(receipt.textContent).not.toMatch(/JAN 1/)
+  })
+
+  it('falls back to an em dash for a non-positive distance', () => {
+    renderReceipt({ ...baseSummary, distanceKm: 0 })
+
+    expect(screen.getByTestId('logged-run-receipt')).toHaveTextContent('LOGGED — — · 41:00 · JUL 8')
+  })
+
+  // The assertions live inside the shared expectDualThemeParity helper —
+  // sonarjs's static check can't see through the function call.
+  // eslint-disable-next-line sonarjs/assertions-in-tests
+  it('holds dual-theme structural parity with no raw hex colour literals', () => {
+    const result = renderInBothThemes(
+      <MemoryRouter>
+        <LoggedRunReceipt summary={baseSummary} units={PreferredUnits.Kilometers} />
+      </MemoryRouter>,
+    )
+    expectDualThemeParity(result, 'logged-run-receipt')
+  })
+})

--- a/frontend/src/app/modules/coaching/components/logged-run-receipt.component.tsx
+++ b/frontend/src/app/modules/coaching/components/logged-run-receipt.component.tsx
@@ -1,0 +1,63 @@
+import type { ReactElement } from 'react'
+import { CheckIcon } from 'lucide-react'
+import { Link } from 'react-router-dom'
+
+import { cn } from '@/lib/utils'
+import type { PreferredUnits } from '~/api/generated'
+import { formatDistanceKm } from '~/modules/common/utils/unit-format.helpers'
+import type { LoggedRunSummaryDto } from '~/modules/coaching/models/conversation.model'
+import { formatDurationSeconds, formatReceiptDate } from './transcript-time.helpers'
+
+export interface LoggedRunReceiptProps {
+  summary: LoggedRunSummaryDto
+  units: PreferredUnits
+  className?: string
+}
+
+/**
+ * The durable one-line receipt for a confirmed conversational log (DEC-091,
+ * D6) — rendered solely by `CoachTextTurn` beneath the confirm-ack coach
+ * turn's body (sourced from `interactive.loggedRun`), which is what survives
+ * reload since it reads off the persisted timeline turn rather than any
+ * in-session card state. `LogConfirmationCard` never renders this component;
+ * an optimistic in-session bridge that would show it in the card slot while
+ * awaiting the post-confirm refetch is explicitly deferred (spec §9 #2).
+ * Distance is unit-aware; the date fragment is omitted (not crashed into the
+ * Unix epoch) when `occurredOn` is unparseable.
+ */
+export const LoggedRunReceipt = ({
+  summary,
+  units,
+  className,
+}: LoggedRunReceiptProps): ReactElement => {
+  const date = formatReceiptDate(summary.occurredOn)
+  const distance = formatDistanceKm(summary.distanceKm, units) ?? '—'
+  const duration = formatDurationSeconds(summary.durationSeconds)
+
+  return (
+    <div
+      data-testid="logged-run-receipt"
+      className={cn(
+        'flex items-center justify-between rounded-md border border-border bg-input-fill px-[14px] py-[11px]',
+        className,
+      )}
+    >
+      <span className="flex items-center gap-[10px]">
+        <span className="flex size-[18px] items-center justify-center rounded-xs bg-positive">
+          <CheckIcon aria-hidden className="size-3 text-background" strokeWidth={3.5} />
+        </span>
+        <span className="font-mono text-[12px] font-semibold tracking-[0.06em] text-muted-foreground">
+          LOGGED — {distance} · {duration}
+          {date !== null ? ` · ${date}` : ''}
+        </span>
+      </span>
+      <Link
+        to="/history"
+        data-testid="logged-run-receipt-logbook"
+        className="font-condensed text-[11px] font-semibold tracking-[0.1em] text-clay-text uppercase"
+      >
+        LOG BOOK →
+      </Link>
+    </div>
+  )
+}

--- a/frontend/src/app/modules/coaching/components/transcript-time.helpers.spec.ts
+++ b/frontend/src/app/modules/coaching/components/transcript-time.helpers.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   formatDividerLabel,
   formatDurationSeconds,
+  formatReceiptDate,
   formatTurnTime,
   groupTurnsByLocalDay,
 } from './transcript-time.helpers'
@@ -150,5 +151,19 @@ describe('formatDurationSeconds', () => {
 
   it('formats exactly zero seconds', () => {
     expect(formatDurationSeconds(0)).toBe('0:00')
+  })
+})
+
+describe('formatReceiptDate', () => {
+  it('formats a pure YYYY-MM-DD calendar date as MONTH DAY, UTC-safe', () => {
+    expect(formatReceiptDate('2026-07-08')).toBe('JUL 8')
+  })
+
+  it('returns null for an unparseable occurredOn instead of crashing or rendering the epoch', () => {
+    expect(formatReceiptDate('not-a-date')).toBeNull()
+  })
+
+  it('returns null for an invalid calendar date (e.g. Feb 30)', () => {
+    expect(formatReceiptDate('2026-02-30')).toBeNull()
   })
 })

--- a/frontend/src/app/modules/coaching/components/transcript-time.helpers.ts
+++ b/frontend/src/app/modules/coaching/components/transcript-time.helpers.ts
@@ -4,8 +4,13 @@
 // every getter here is a local (`getHours`/`getDay`/`getMonth`/`getDate`)
 // read — never a `getUTC*` one.
 //
-// `formatDurationSeconds` (§4.3) is the receipt formatter's home file per
-// the spec.
+// `formatDurationSeconds`/`formatReceiptDate` (§4.3) are the receipt
+// formatter's home in this file. `formatReceiptDate` is the one exception to
+// the local-wall-clock rule above: `occurredOn` is a pure calendar date
+// (`YYYY-MM-DD`, no time-of-day component), so it is parsed UTC-safe via the
+// shared plan-calendar primitives rather than a local `Date` read.
+
+import { formatShortDateUtc, parseIsoDateUtc } from '~/modules/plan/components/plan-display.helpers'
 
 const WEEKDAY_ABBR = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'] as const
 
@@ -106,4 +111,15 @@ export function formatDurationSeconds(s: number): string {
   const m = Math.floor((total % 3600) / 60)
   const sec = total % 60
   return h >= 1 ? `${h}:${pad2(m)}:${pad2(sec)}` : `${m}:${pad2(sec)}`
+}
+
+/**
+ * Formats a receipt's pure `YYYY-MM-DD` calendar date (e.g. a logged run's
+ * `occurredOn`) as `"JUL 8"`. `null` when `occurredOn` is unparseable, so
+ * callers omit the date fragment entirely rather than ever constructing
+ * `new Date(null)` (the Unix epoch, `JAN 1`) from a bad guard.
+ */
+export function formatReceiptDate(occurredOn: string): string | null {
+  const epoch = parseIsoDateUtc(occurredOn)
+  return epoch === null ? null : formatShortDateUtc(new Date(epoch))
 }


### PR DESCRIPTION
## Slice 3 PR-D — durable `loggedRun` receipt + log-draft card states

The final PR of Slice 3 (Coach) in the SPLIT / Alpine UI redesign, and the only one that depends on PR-A. Built from the locked, adversarially-verified spec `docs/specs/slice-3-coach/spec.md` § 3 (PR-D) / § 4.3 / DU-6. PR-A (backend `loggedRun`), PR-B (turn kinds), and PR-C (adaptation + safety turns) already shipped.

### What changed
- **`LoggedRunReceipt`** (new) — the durable one-line confirm-ack receipt: `✅ LOGGED — 5.0 km · 25:00 · JUN 29   LOG BOOK →`, `LOG BOOK →` links to `/history`. Rendered by `CoachTextTurn` from the **persisted** `interactive.loggedRun` (DEC-091), so it survives reload — durability comes entirely from the event-sourced turn, never from ephemeral card state.
- **`formatReceiptDate`** (new helper, `transcript-time.helpers.ts`) — guarded: on an unparseable `occurredOn` it omits the date fragment rather than crashing into the Unix epoch (`new Date(null)` → `JAN 1`). `formatDurationSeconds` already existed from PR-B and was reused unchanged.
- **`CoachTextTurn`** — renders the receipt beneath the coach body when `loggedRun` is non-null; `units` defaults to `Kilometers`.
- **`LogConfirmationCard`** — Alpine restyle (`LOG THIS RUN?`, 2×2 grid with STATUS in moss, humanized DATE, **ON-PLAN target distance** added), the **saving** state (dim, buttons locked, `Saving…`, CANCEL hidden), and `log-confirm` / `log-edit` / `log-cancel` testids. Confirm-success keeps the **locked** immediate-dismiss → refetch contract; the optimistic in-card bridge stays deferred (spec § 9 #2).
- **e2e realignment** (`conversation-streaming.spec.ts`) — the existing `/coach` confirm flow now asserts the durable receipt renders + its `LOG BOOK →` href, and reloads to prove reload durability (spec § 7).

### Deliberate spec deviation
The spec § 3 specifies `text-[var(--alp-faint)]` for the card's field labels and ON-PLAN line, but the field labels are **essential text** and the frontend `CLAUDE.md` § Styling is a hard rule: `--alp-faint` "must never carry essential text." `CLAUDE.md` wins — the labels use `text-muted-foreground` (AA-passing). Truly-decorative meta (timestamps, dividers) keeps `--alp-faint` as before.

### Verification
- `npm run build` clean · `npm run test` **937/937** vitest pass · `npm run check-contrast` **44/44** · scoped `eslint` on changed files clean.
- New/extended tests cover every DU-6 bullet + § 6 edge cases: receipt format, LOG BOOK link, `units === Miles`, unparseable-`occurredOn` omission (no epoch), receipt-absent on a historical `loggedRun: null` ack turn, default-units, the card saving state + ON-PLAN target, and confirm → durable receipt.

### Process
Built via an orchestrated sonnet workflow (recon → TDD implement → gate loop → 4-lens adversarial review → challenge → apply). All 7 confirmed review findings were applied; two the automated gate structurally cannot catch were fixed by hand and re-verified: a Playwright API error in the e2e edit (`toHaveTextContent` → `toContainText`) and reverting three unrelated auth/login/register lint-suppression edits that had crept in.

Not built (deferred, per spec): partial-parse `MISSING` card states (backend never emits a partial draft) and the optimistic in-card receipt bridge (§ 9 #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnVnYW3bL6bKDKT8sgnh1B


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a durable receipt after confirming a workout log, showing distance, duration, date, completion status, and a link to the log book.
  * Added support for displaying workout distances in either kilometers or miles.
  * Improved workout confirmation details, including on-plan targets and clearer saving-state feedback.
* **Bug Fixes**
  * Receipts now persist after page reloads and are safely omitted when workout data is unavailable or dates are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->