### PR TITLE
feat(split-ui): Slice 4 PR-B — /log Alpine restyle + prescribed banner + derived pace (DEC-089 D5)

### DIFF
--- a/frontend/src/app/modules/logging/components/completion-status-field.component.spec.tsx
+++ b/frontend/src/app/modules/logging/components/completion-status-field.component.spec.tsx
@@ -37,6 +37,11 @@ const Harness = ({ formRef }: HarnessProps = {}) => {
     if (formRef) {
       formRef.current = form
     }
+    return () => {
+      if (formRef) {
+        formRef.current = null
+      }
+    }
   }, [form, formRef])
 
   return (

--- a/frontend/src/app/modules/logging/components/completion-status-field.component.spec.tsx
+++ b/frontend/src/app/modules/logging/components/completion-status-field.component.spec.tsx
@@ -1,0 +1,114 @@
+import { useEffect } from 'react'
+import { useForm, type UseFormReturn } from 'react-hook-form'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { Form } from '@/components/ui/form'
+import { renderInBothThemes, testidsIn } from '~/modules/common/test-utils/render-in-both-themes'
+import {
+  makeDefaultWorkoutLogFormFields,
+  type WorkoutLogFormFields,
+  type WorkoutLogFormValues,
+} from '~/modules/logging/schemas/workout-log-form.schema'
+import { CompletionStatusField } from './completion-status-field.component'
+
+type HarnessForm = UseFormReturn<WorkoutLogFormFields, unknown, WorkoutLogFormValues>
+
+interface HarnessProps {
+  /** Mutable box the harness stashes its `useForm` instance into, so tests can read `getValues` after an interaction without subscribing via `watch` (which React Compiler flags as unmemoizable). */
+  formRef?: { current: HarnessForm | null }
+}
+
+// Minimal RHF harness: `CompletionStatusField` requires a real `Control`
+// carrying the workout-log form's input/output generics (a hand-built mock
+// `control` object would need to fake RHF's internal field-array/subject
+// wiring), so this mounts the field against an actual `useForm` instance
+// with the form's real defaults — the same "Complete" default and string
+// wire values the field carries in production.
+const Harness = ({ formRef }: HarnessProps = {}) => {
+  const form = useForm<WorkoutLogFormFields, unknown, WorkoutLogFormValues>({
+    defaultValues: makeDefaultWorkoutLogFormFields(),
+  })
+  // Ref writes are only valid outside render (effects, handlers) — `useForm`'s
+  // returned object is stable across re-renders, so a mount-time effect is
+  // enough to hand it to the test.
+  useEffect(() => {
+    if (formRef) {
+      formRef.current = form
+    }
+  }, [form, formRef])
+
+  return (
+    <Form {...form}>
+      <CompletionStatusField control={form.control} name="completionStatus" />
+    </Form>
+  )
+}
+
+describe('CompletionStatusField', () => {
+  it('renders three segments — Completed / Partial / Skipped — with the expected testids', () => {
+    // jsdom performs no real layout/style resolution, so `textContent` stays
+    // the sentence-case source string ("Completed") — the COMPLETED/
+    // PARTIAL/SKIPPED rendering is a CSS `uppercase` presentation effect
+    // from `SegmentedControlItem`, verified below via the `uppercase` class
+    // rather than the (untestable-in-jsdom) rendered glyphs.
+    render(<Harness />)
+
+    expect(screen.getByTestId('completion-completed')).toHaveTextContent('Completed')
+    expect(screen.getByTestId('completion-partial')).toHaveTextContent('Partial')
+    expect(screen.getByTestId('completion-skipped')).toHaveTextContent('Skipped')
+    for (const testId of ['completion-completed', 'completion-partial', 'completion-skipped']) {
+      expect(screen.getByTestId(testId)).toHaveClass('uppercase')
+    }
+  })
+
+  it('keeps the "Completion" FormLabel', () => {
+    render(<Harness />)
+
+    expect(screen.getByText('Completion')).toBeInTheDocument()
+  })
+
+  it("defaults to Completed — form value '0', completed segment radix-checked, the others unchecked", () => {
+    const formRef: { current: HarnessForm | null } = { current: null }
+    render(<Harness formRef={formRef} />)
+
+    expect(formRef.current?.getValues('completionStatus')).toBe('0')
+    expect(screen.getByTestId('completion-completed')).toHaveAttribute('data-state', 'checked')
+    expect(screen.getByTestId('completion-partial')).toHaveAttribute('data-state', 'unchecked')
+    expect(screen.getByTestId('completion-skipped')).toHaveAttribute('data-state', 'unchecked')
+  })
+
+  it("selecting PARTIAL calls onValueChange with the wire string '1' — the same string the radios produced", async () => {
+    const user = userEvent.setup()
+    const formRef: { current: HarnessForm | null } = { current: null }
+    render(<Harness formRef={formRef} />)
+
+    await user.click(screen.getByTestId('completion-partial'))
+
+    expect(formRef.current?.getValues('completionStatus')).toBe('1')
+    expect(screen.getByTestId('completion-partial')).toHaveAttribute('data-state', 'checked')
+    expect(screen.getByTestId('completion-completed')).toHaveAttribute('data-state', 'unchecked')
+  })
+
+  it("selecting SKIPPED calls onValueChange with the wire string '2' — the same string the radios produced", async () => {
+    const user = userEvent.setup()
+    const formRef: { current: HarnessForm | null } = { current: null }
+    render(<Harness formRef={formRef} />)
+
+    await user.click(screen.getByTestId('completion-skipped'))
+
+    expect(formRef.current?.getValues('completionStatus')).toBe('2')
+    expect(screen.getByTestId('completion-skipped')).toHaveAttribute('data-state', 'checked')
+    expect(screen.getByTestId('completion-completed')).toHaveAttribute('data-state', 'unchecked')
+  })
+
+  it('renders identically in both themes with zero raw colour literals', () => {
+    const { dark, light } = renderInBothThemes(<Harness />)
+    for (const result of [dark, light]) {
+      expect(result.getByTestId('completion-completed')).toBeInTheDocument()
+      expect(result.container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}\b/)
+    }
+    expect(testidsIn(dark.container)).toEqual(testidsIn(light.container))
+  })
+})

--- a/frontend/src/app/modules/logging/components/completion-status-field.component.tsx
+++ b/frontend/src/app/modules/logging/components/completion-status-field.component.tsx
@@ -1,18 +1,17 @@
 import type { FieldPath } from 'react-hook-form'
 
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
-import { Label } from '@/components/ui/label'
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { SegmentedControl, SegmentedControlItem } from '@/components/ui/segmented-control'
 import { CompletionStatus } from '~/api/generated'
 import type {
   WorkoutLogFormControl,
   WorkoutLogFormFields,
 } from '~/modules/logging/schemas/workout-log-form.schema'
 
-const COMPLETION_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
-  { value: String(CompletionStatus.Complete), label: 'Completed' },
-  { value: String(CompletionStatus.Partial), label: 'Partial' },
-  { value: String(CompletionStatus.Skipped), label: 'Skipped' },
+const COMPLETION_OPTIONS: ReadonlyArray<{ value: string; label: string; testId: string }> = [
+  { value: String(CompletionStatus.Complete), label: 'Completed', testId: 'completion-completed' },
+  { value: String(CompletionStatus.Partial), label: 'Partial', testId: 'completion-partial' },
+  { value: String(CompletionStatus.Skipped), label: 'Skipped', testId: 'completion-skipped' },
 ]
 
 export interface CompletionStatusFieldProps {
@@ -21,9 +20,11 @@ export interface CompletionStatusFieldProps {
 }
 
 /**
- * Radio selector for how fully the workout was completed. Values are the
- * `CompletionStatus` wire integers carried as strings in form state; the schema
- * coerces them back to the `0|1|2` union. Defaults to "Completed".
+ * Segmented-control selector for how fully the workout was completed. Values are
+ * the `CompletionStatus` wire integers carried as strings in form state; the
+ * schema coerces them back to the `0|1|2` union. Defaults to "Completed". Source
+ * labels stay sentence-case ("Completed"/"Partial"/"Skipped") — `SegmentedControlItem`
+ * applies the uppercase presentation via CSS.
  */
 export const CompletionStatusField = ({ control, name }: CompletionStatusFieldProps) => (
   <FormField
@@ -33,20 +34,17 @@ export const CompletionStatusField = ({ control, name }: CompletionStatusFieldPr
       <FormItem>
         <FormLabel>Completion</FormLabel>
         <FormControl>
-          <RadioGroup
-            value={field.value}
-            onValueChange={field.onChange}
-            className="flex flex-wrap gap-x-6 gap-y-2"
-          >
+          <SegmentedControl value={field.value} onValueChange={field.onChange}>
             {COMPLETION_OPTIONS.map((option) => (
-              <div key={option.value} className="flex items-center gap-2">
-                <RadioGroupItem value={option.value} id={`completion-status-${option.value}`} />
-                <Label htmlFor={`completion-status-${option.value}`} className="font-normal">
-                  {option.label}
-                </Label>
-              </div>
+              <SegmentedControlItem
+                key={option.value}
+                value={option.value}
+                data-testid={option.testId}
+              >
+                {option.label}
+              </SegmentedControlItem>
             ))}
-          </RadioGroup>
+          </SegmentedControl>
         </FormControl>
         <FormMessage />
       </FormItem>

--- a/frontend/src/app/modules/logging/components/date-chip.component.spec.tsx
+++ b/frontend/src/app/modules/logging/components/date-chip.component.spec.tsx
@@ -9,16 +9,18 @@ import {
 import { DateChip } from './date-chip.component'
 
 describe('DateChip', () => {
-  it('renders the formatted date-chip label for the given ISO value', () => {
+  it('renders the formatted date-chip label (sentence-case source text, uppercased via CSS) for the given ISO value', () => {
     render(<DateChip value="2026-07-08" onChange={vi.fn()} />)
 
-    expect(screen.getByTestId('log-date-chip')).toHaveTextContent('WED, JUL 8')
+    const label = screen.getByText('Wed, Jul 8')
+    expect(screen.getByTestId('log-date-chip')).toContainElement(label)
+    expect(label).toHaveClass('uppercase')
   })
 
-  it('renders the "SELECT DATE" placeholder instead of a garbage label when value is cleared', () => {
+  it('renders the "Select date" placeholder instead of a garbage label when value is cleared', () => {
     render(<DateChip value="" onChange={vi.fn()} />)
 
-    expect(screen.getByTestId('log-date-chip')).toHaveTextContent('SELECT DATE')
+    expect(screen.getByTestId('log-date-chip')).toHaveTextContent('Select date')
   })
 
   it('forwards a ref and injected FormControl props (id, aria-describedby, aria-invalid) onto the native input', () => {

--- a/frontend/src/app/modules/logging/components/date-chip.component.spec.tsx
+++ b/frontend/src/app/modules/logging/components/date-chip.component.spec.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  expectDualThemeParity,
+  renderInBothThemes,
+} from '~/modules/common/test-utils/render-in-both-themes'
+
+import { DateChip } from './date-chip.component'
+
+describe('DateChip', () => {
+  it('renders the formatted date-chip label for the given ISO value', () => {
+    render(<DateChip value="2026-07-08" onChange={vi.fn()} />)
+
+    expect(screen.getByTestId('log-date-chip')).toHaveTextContent('WED, JUL 8')
+  })
+
+  it('renders the "SELECT DATE" placeholder instead of a garbage label when value is cleared', () => {
+    render(<DateChip value="" onChange={vi.fn()} />)
+
+    expect(screen.getByTestId('log-date-chip')).toHaveTextContent('SELECT DATE')
+  })
+
+  it('forwards a ref and injected FormControl props (id, aria-describedby, aria-invalid) onto the native input', () => {
+    const ref = { current: null as HTMLInputElement | null }
+    render(
+      <DateChip
+        ref={ref}
+        value="2026-07-08"
+        onChange={vi.fn()}
+        id="occurredOn"
+        aria-describedby="err-1"
+        aria-invalid="true"
+      />,
+    )
+
+    const input = screen.getByLabelText('Date')
+    expect(input).toHaveAttribute('id', 'occurredOn')
+    expect(input).toHaveAttribute('aria-describedby', 'err-1')
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+    expect(ref.current).toBe(input)
+  })
+
+  it('exposes the native date input with accessible name "Date" and the given value', () => {
+    render(<DateChip value="2026-07-08" onChange={vi.fn()} />)
+
+    const input = screen.getByLabelText('Date') as HTMLInputElement
+    expect(input).toHaveAttribute('type', 'date')
+    expect(input.value).toBe('2026-07-08')
+  })
+
+  it('fires onChange with the new ISO string when the native input changes', () => {
+    const onChange = vi.fn()
+    render(<DateChip value="2026-07-08" onChange={onChange} />)
+
+    fireEvent.change(screen.getByLabelText('Date'), { target: { value: '2026-07-09' } })
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('2026-07-09')
+  })
+
+  it('accepts and forwards a back-dated (past) date unchanged', () => {
+    const onChange = vi.fn()
+    render(<DateChip value="2026-07-08" onChange={onChange} />)
+
+    fireEvent.change(screen.getByLabelText('Date'), { target: { value: '2020-01-01' } })
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('2020-01-01')
+  })
+
+  // The assertions live inside the shared expectDualThemeParity helper —
+  // sonarjs's static check can't see through the function call.
+  // eslint-disable-next-line sonarjs/assertions-in-tests
+  it('holds dual-theme structural parity with no raw hex colour literals', () => {
+    const result = renderInBothThemes(<DateChip value="2026-07-08" onChange={vi.fn()} />)
+    expectDualThemeParity(result, 'log-date-chip')
+  })
+})

--- a/frontend/src/app/modules/logging/components/date-chip.component.tsx
+++ b/frontend/src/app/modules/logging/components/date-chip.component.tsx
@@ -1,0 +1,74 @@
+import { forwardRef, type ComponentPropsWithoutRef } from 'react'
+import { CalendarIcon, ChevronDownIcon } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+import { formatDateChipLabel } from '~/modules/logging/log-derivations.helpers'
+
+/**
+ * Props for {@link DateChip}. Interface locked by the /log restyle spec.
+ * Extends the native `<input>` props (minus the ones this component owns)
+ * so that RHF's `FormControl` — a Radix `Slot` — can merge `id`,
+ * `aria-describedby`, and `aria-invalid` onto the real control; see the
+ * component doc for the forwarding contract.
+ */
+export interface DateChipProps extends Omit<
+  ComponentPropsWithoutRef<'input'>,
+  'value' | 'onChange' | 'type' | 'className'
+> {
+  /** ISO `YYYY-MM-DD` date-only string — never a full timestamp. */
+  value: string
+  /** Called with the new ISO `YYYY-MM-DD` string on every native picker change. */
+  onChange: (iso: string) => void
+  className?: string
+}
+
+/**
+ * Tappable date affordance for the /log form — a chip reading
+ * `CalendarIcon` + `formatDateChipLabel(value)` + `ChevronDownIcon` (e.g.
+ * "WED, JUL 8"). This is a purely presentational wrapper around the SAME
+ * native `<input type="date">` the form already used pre-restyle (D2: "→
+ * native date input") — no custom calendar widget, no date-parsing logic of
+ * its own. The native input is stretched to fully cover the chip
+ * (`absolute inset-0`, `opacity-0`) so a tap anywhere on the chip opens the
+ * platform date picker directly, while the chip's own text/icons render
+ * underneath as the visible affordance.
+ *
+ * A11y contract (do not break): the native input keeps `aria-label="Date"`
+ * as its ONLY accessible name — existing form/E2E coverage locates it via
+ * `getByLabelText('Date')`. Keyboard users tab to the (invisible but very
+ * real) input exactly as before; `has-[:focus-visible]` on the chip
+ * surfaces the shared focus ring around the visible chip even though the
+ * input itself renders transparent.
+ *
+ * `forwardRef`'d so RHF's `FormControl` (a Radix `Slot`) can attach its
+ * ref and spread its injected `id`/`aria-describedby`/`aria-invalid` onto
+ * the actual native `<input>` — the same control those attributes landed
+ * on pre-restyle. `...rest` is spread before the explicit `aria-label`/
+ * `value`/`onChange` below so those three can never be clobbered by an
+ * injected prop.
+ */
+export const DateChip = forwardRef<HTMLInputElement, DateChipProps>(
+  ({ value, onChange, className, ...rest }, ref) => (
+    <div
+      data-testid="log-date-chip"
+      className={cn(
+        'relative inline-flex min-h-11 items-center gap-1.5 rounded-sm border border-border bg-input-fill px-3 py-2 transition-colors duration-200 ease-out has-[:focus-visible]:border-ring has-[:focus-visible]:ring-[3px] has-[:focus-visible]:ring-ring/[0.22] motion-reduce:transition-none',
+        className,
+      )}
+    >
+      <CalendarIcon aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />
+      <span className="t-data-value text-foreground">{formatDateChipLabel(value)}</span>
+      <ChevronDownIcon aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />
+      <input
+        type="date"
+        {...rest}
+        ref={ref}
+        aria-label="Date"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0"
+      />
+    </div>
+  ),
+)
+DateChip.displayName = 'DateChip'

--- a/frontend/src/app/modules/logging/components/date-chip.component.tsx
+++ b/frontend/src/app/modules/logging/components/date-chip.component.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type ComponentPropsWithoutRef } from 'react'
+import { type ComponentProps } from 'react'
 import { CalendarIcon, ChevronDownIcon } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
@@ -11,7 +11,7 @@ import { formatDateChipLabel } from '~/modules/logging/log-derivations.helpers'
  * control; see the component doc for the forwarding contract.
  */
 export interface DateChipProps extends Omit<
-  ComponentPropsWithoutRef<'input'>,
+  ComponentProps<'input'>,
   'value' | 'onChange' | 'type' | 'className'
 > {
   /** ISO `YYYY-MM-DD` date-only string — never a full timestamp. */
@@ -41,34 +41,31 @@ export interface DateChipProps extends Omit<
  * ring around the visible chip even though the input itself renders
  * transparent.
  *
- * `forwardRef`'d so RHF's `FormControl` (a Radix `Slot`) can attach its ref
- * and spread its injected `id`/`aria-describedby`/`aria-invalid` onto the
- * actual native `<input>`. `...rest` is spread before the explicit
- * `aria-label`/`value`/`onChange` below so those three can never be
- * clobbered by an injected prop.
+ * Accepts `ref` as a regular prop (React 19) so RHF's `FormControl` (a
+ * Radix `Slot`) can attach its ref and spread its injected
+ * `id`/`aria-describedby`/`aria-invalid` onto the actual native `<input>`.
+ * `...rest` is spread before the explicit `aria-label`/`value`/`onChange`
+ * below so those three can never be clobbered by an injected prop.
  */
-export const DateChip = forwardRef<HTMLInputElement, DateChipProps>(
-  ({ value, onChange, className, ...rest }, ref) => (
-    <div
-      data-testid="log-date-chip"
-      className={cn(
-        'relative inline-flex min-h-11 items-center gap-1.5 rounded-sm border border-border bg-input-fill px-3 py-2 transition-colors duration-200 ease-out has-[:focus-visible]:border-ring has-[:focus-visible]:ring-[3px] has-[:focus-visible]:ring-ring/[0.22] motion-reduce:transition-none',
-        className,
-      )}
-    >
-      <CalendarIcon aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />
-      <span className="t-data-value uppercase text-foreground">{formatDateChipLabel(value)}</span>
-      <ChevronDownIcon aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />
-      <input
-        type="date"
-        {...rest}
-        ref={ref}
-        aria-label="Date"
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        className="absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0"
-      />
-    </div>
-  ),
+export const DateChip = ({ value, onChange, className, ref, ...rest }: DateChipProps) => (
+  <div
+    data-testid="log-date-chip"
+    className={cn(
+      'relative inline-flex min-h-11 items-center gap-1.5 rounded-sm border border-border bg-input-fill px-3 py-2 transition-colors duration-200 ease-out has-[:focus-visible]:border-ring has-[:focus-visible]:ring-[3px] has-[:focus-visible]:ring-ring/[0.22] motion-reduce:transition-none',
+      className,
+    )}
+  >
+    <CalendarIcon aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />
+    <span className="t-data-value uppercase text-foreground">{formatDateChipLabel(value)}</span>
+    <ChevronDownIcon aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />
+    <input
+      type="date"
+      {...rest}
+      ref={ref}
+      aria-label="Date"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      className="absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0"
+    />
+  </div>
 )
-DateChip.displayName = 'DateChip'

--- a/frontend/src/app/modules/logging/components/date-chip.component.tsx
+++ b/frontend/src/app/modules/logging/components/date-chip.component.tsx
@@ -5,11 +5,10 @@ import { cn } from '@/lib/utils'
 import { formatDateChipLabel } from '~/modules/logging/log-derivations.helpers'
 
 /**
- * Props for {@link DateChip}. Interface locked by the /log restyle spec.
- * Extends the native `<input>` props (minus the ones this component owns)
- * so that RHF's `FormControl` — a Radix `Slot` — can merge `id`,
- * `aria-describedby`, and `aria-invalid` onto the real control; see the
- * component doc for the forwarding contract.
+ * Props for {@link DateChip}. Extends the native `<input>` props (minus the
+ * ones this component owns) so that RHF's `FormControl` — a Radix `Slot` —
+ * can merge `id`, `aria-describedby`, and `aria-invalid` onto the real
+ * control; see the component doc for the forwarding contract.
  */
 export interface DateChipProps extends Omit<
   ComponentPropsWithoutRef<'input'>,
@@ -24,28 +23,29 @@ export interface DateChipProps extends Omit<
 
 /**
  * Tappable date affordance for the /log form — a chip reading
- * `CalendarIcon` + `formatDateChipLabel(value)` + `ChevronDownIcon` (e.g.
- * "WED, JUL 8"). This is a purely presentational wrapper around the SAME
- * native `<input type="date">` the form already used pre-restyle (D2: "→
- * native date input") — no custom calendar widget, no date-parsing logic of
- * its own. The native input is stretched to fully cover the chip
- * (`absolute inset-0`, `opacity-0`) so a tap anywhere on the chip opens the
- * platform date picker directly, while the chip's own text/icons render
- * underneath as the visible affordance.
+ * `CalendarIcon` + `formatDateChipLabel(value)` + `ChevronDownIcon`. The
+ * label span carries `formatDateChipLabel`'s sentence-case source string
+ * (e.g. `"Wed, Jul 8"`) plus a CSS `uppercase` class, so it still renders
+ * visually uppercase (e.g. "WED, JUL 8") even though the underlying string
+ * stays sentence case. This is a purely presentational wrapper around a
+ * native `<input type="date">` — no custom calendar widget, no
+ * date-parsing logic of its own. The native input is stretched to fully
+ * cover the chip (`absolute inset-0`, `opacity-0`) so a tap anywhere on the
+ * chip opens the platform date picker directly, while the chip's own
+ * text/icons render underneath as the visible affordance.
  *
  * A11y contract (do not break): the native input keeps `aria-label="Date"`
  * as its ONLY accessible name — existing form/E2E coverage locates it via
  * `getByLabelText('Date')`. Keyboard users tab to the (invisible but very
- * real) input exactly as before; `has-[:focus-visible]` on the chip
- * surfaces the shared focus ring around the visible chip even though the
- * input itself renders transparent.
+ * real) input; `has-[:focus-visible]` on the chip surfaces the shared focus
+ * ring around the visible chip even though the input itself renders
+ * transparent.
  *
- * `forwardRef`'d so RHF's `FormControl` (a Radix `Slot`) can attach its
- * ref and spread its injected `id`/`aria-describedby`/`aria-invalid` onto
- * the actual native `<input>` — the same control those attributes landed
- * on pre-restyle. `...rest` is spread before the explicit `aria-label`/
- * `value`/`onChange` below so those three can never be clobbered by an
- * injected prop.
+ * `forwardRef`'d so RHF's `FormControl` (a Radix `Slot`) can attach its ref
+ * and spread its injected `id`/`aria-describedby`/`aria-invalid` onto the
+ * actual native `<input>`. `...rest` is spread before the explicit
+ * `aria-label`/`value`/`onChange` below so those three can never be
+ * clobbered by an injected prop.
  */
 export const DateChip = forwardRef<HTMLInputElement, DateChipProps>(
   ({ value, onChange, className, ...rest }, ref) => (
@@ -57,7 +57,7 @@ export const DateChip = forwardRef<HTMLInputElement, DateChipProps>(
       )}
     >
       <CalendarIcon aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />
-      <span className="t-data-value text-foreground">{formatDateChipLabel(value)}</span>
+      <span className="t-data-value uppercase text-foreground">{formatDateChipLabel(value)}</span>
       <ChevronDownIcon aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />
       <input
         type="date"

--- a/frontend/src/app/modules/logging/components/log-form.component.tsx
+++ b/frontend/src/app/modules/logging/components/log-form.component.tsx
@@ -85,7 +85,13 @@ export const LogForm = ({
           render={({ field }) => (
             <FormItem>
               <FormControl>
-                <DateChip value={field.value} onChange={field.onChange} />
+                <DateChip
+                  ref={field.ref}
+                  name={field.name}
+                  value={field.value}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/frontend/src/app/modules/logging/components/log-form.component.tsx
+++ b/frontend/src/app/modules/logging/components/log-form.component.tsx
@@ -9,15 +9,18 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form'
-import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
+import type { PreferredUnits } from '~/api/generated'
+import { deriveDisplayPace } from '~/modules/logging/log-derivations.helpers'
 import type {
   WorkoutLogFormFields,
   WorkoutLogFormValues,
 } from '~/modules/logging/schemas/workout-log-form.schema'
 import { CompletionStatusField } from './completion-status-field.component'
+import { DateChip } from './date-chip.component'
 import { LogNumericField } from './log-numeric-field.component'
 import { MoreDetailsSection } from './more-details-section.component'
+import { PrescribedBanner } from './prescribed-banner.component'
 
 export interface LogFormProps {
   form: UseFormReturn<WorkoutLogFormFields, unknown, WorkoutLogFormValues>
@@ -26,6 +29,8 @@ export interface LogFormProps {
   formAlert: string | null
   /** The distance field label, unit-aware (e.g. `Distance (km)` / `Distance (mi)`). */
   distanceLabel: string
+  /** The runner's resolved display unit — drives the prescribed-workout banner and the derived-pace preview below the distance/duration cells. */
+  units: PreferredUnits
 }
 
 /**
@@ -33,9 +38,27 @@ export interface LogFormProps {
  * completion, notes) always visible, optional metrics behind "More details".
  * The container owns `useForm` + the create mutation + navigation; this renders
  * the field stack and gates submit on validity / in-flight state.
+ *
+ * The prescribed-workout banner and the derived-pace preview are both
+ * display-only reads off the live `watch()`ed form state — neither ever
+ * feeds back into what gets submitted (DEC-076: the prescription snapshot is
+ * resolved server-side, and the pace preview never gates submit).
  */
-export const LogForm = ({ form, onSubmit, isLoading, formAlert, distanceLabel }: LogFormProps) => {
+export const LogForm = ({
+  form,
+  onSubmit,
+  isLoading,
+  formAlert,
+  distanceLabel,
+  units,
+}: LogFormProps) => {
   const isSubmitDisabled = !form.formState.isValid || form.formState.isSubmitting || isLoading
+  const occurredOn = form.watch('occurredOn')
+  const derivedPace = deriveDisplayPace(
+    form.watch('distance'),
+    form.watch('durationMinutes'),
+    units,
+  )
 
   return (
     <Form {...form}>
@@ -49,7 +72,7 @@ export const LogForm = ({ form, onSubmit, isLoading, formAlert, distanceLabel }:
           <p
             role="alert"
             data-testid="log-form-alert"
-            className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 font-mono text-sm text-destructive"
           >
             {formAlert}
           </p>
@@ -60,17 +83,39 @@ export const LogForm = ({ form, onSubmit, isLoading, formAlert, distanceLabel }:
           name="occurredOn"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Date</FormLabel>
               <FormControl>
-                <Input type="date" {...field} />
+                <DateChip value={field.value} onChange={field.onChange} />
               </FormControl>
               <FormMessage />
             </FormItem>
           )}
         />
 
-        <LogNumericField control={form.control} name="distance" label={distanceLabel} autoFocus />
-        <LogNumericField control={form.control} name="durationMinutes" label="Duration (minutes)" />
+        <PrescribedBanner date={occurredOn} units={units} />
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="[&_input]:font-condensed [&_input]:text-lg [&_input]:font-bold">
+            <LogNumericField
+              control={form.control}
+              name="distance"
+              label={distanceLabel}
+              autoFocus
+            />
+          </div>
+          <div className="[&_input]:font-condensed [&_input]:text-lg [&_input]:font-bold">
+            <LogNumericField
+              control={form.control}
+              name="durationMinutes"
+              label="Duration (minutes)"
+            />
+          </div>
+        </div>
+
+        {derivedPace !== null ? (
+          <p data-testid="log-derived-pace" className="font-mono text-[11px] text-muted-foreground">
+            {derivedPace}
+          </p>
+        ) : null}
 
         <CompletionStatusField control={form.control} name="completionStatus" />
 
@@ -80,10 +125,14 @@ export const LogForm = ({ form, onSubmit, isLoading, formAlert, distanceLabel }:
           render={({ field }) => (
             <FormItem>
               <FormLabel>How did it go?</FormLabel>
+              <p className="font-mono text-[11px] text-muted-foreground">
+                What actually happened — especially where it differed from the plan. The coach
+                adapts to what you write here.
+              </p>
               <FormControl>
                 <Textarea
                   rows={3}
-                  placeholder="Anything worth remembering — how you felt, weather, terrain…"
+                  placeholder="Cut to 3 reps, moved to the treadmill, calf felt tight on the last k…"
                   {...field}
                 />
               </FormControl>
@@ -97,10 +146,10 @@ export const LogForm = ({ form, onSubmit, isLoading, formAlert, distanceLabel }:
         <Button
           type="submit"
           disabled={isSubmitDisabled}
-          className="w-full"
+          className="min-h-[54px] w-full"
           data-testid="log-form-submit"
         >
-          {isLoading ? 'Saving…' : 'Save workout'}
+          {isLoading ? 'SAVING…' : 'SAVE RUN'}
         </Button>
       </form>
     </Form>

--- a/frontend/src/app/modules/logging/components/log-form.component.tsx
+++ b/frontend/src/app/modules/logging/components/log-form.component.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -125,10 +126,10 @@ export const LogForm = ({
           render={({ field }) => (
             <FormItem>
               <FormLabel>How did it go?</FormLabel>
-              <p className="font-mono text-[11px] text-muted-foreground">
+              <FormDescription className="font-mono text-[11px] text-muted-foreground">
                 What actually happened — especially where it differed from the plan. The coach
                 adapts to what you write here.
-              </p>
+              </FormDescription>
               <FormControl>
                 <Textarea
                   rows={3}
@@ -149,7 +150,7 @@ export const LogForm = ({
           className="min-h-[54px] w-full"
           data-testid="log-form-submit"
         >
-          {isLoading ? 'SAVING…' : 'SAVE RUN'}
+          {isLoading ? 'Saving…' : 'Save run'}
         </Button>
       </form>
     </Form>

--- a/frontend/src/app/modules/logging/components/prescribed-banner.component.spec.tsx
+++ b/frontend/src/app/modules/logging/components/prescribed-banner.component.spec.tsx
@@ -36,50 +36,59 @@ describe('PrescribedBanner', () => {
   })
 
   it('threads the date through to the query hook', () => {
-    bannerMock.mockReturnValue({ data: null, isLoading: false, isError: false })
+    bannerMock.mockReturnValue({ currentData: null, isLoading: false, isError: false })
     renderBanner(PreferredUnits.Kilometers, '2026-07-20')
 
     expect(bannerMock).toHaveBeenCalledExactlyOnceWith('2026-07-20')
   })
 
-  it('renders the PRESCRIBED line for a present prescription (km)', () => {
-    bannerMock.mockReturnValue({ data: buildPrescribedWorkout(), isLoading: false, isError: false })
+  it('renders the Prescribed line for a present prescription (km)', () => {
+    bannerMock.mockReturnValue({
+      currentData: buildPrescribedWorkout(),
+      isLoading: false,
+      isError: false,
+    })
     renderBanner()
 
-    // The workoutType label and pace range are uppercased in JS
-    // (`.toUpperCase()`); the distance fragment relies solely on the span's
-    // CSS `uppercase` class for its visual case, so jsdom's raw textContent
-    // (which never applies CSS text-transform) still carries a lowercase
-    // "km" here even though the design reads all-caps on screen.
+    // Source copy stays sentence case (WORKOUT_TYPE_LABELS' "Threshold run",
+    // the lowercase-suffixed pace/distance formatters, and the static
+    // "Prescribed" literal) — the span's CSS `uppercase` class is solely
+    // responsible for the all-caps look on screen; jsdom's raw textContent
+    // never applies CSS text-transform, so it carries the sentence-case
+    // source string.
     expect(screen.getByTestId('prescribed-banner')).toHaveTextContent(
-      'PRESCRIBED — THRESHOLD RUN · 9.0 km · 04:00–04:30/KM',
+      'Prescribed — Threshold run · 9.0 km · 04:00–04:30/km',
     )
   })
 
   it('renders mile-based distance and pace when units is Miles', () => {
-    bannerMock.mockReturnValue({ data: buildPrescribedWorkout(), isLoading: false, isError: false })
+    bannerMock.mockReturnValue({
+      currentData: buildPrescribedWorkout(),
+      isLoading: false,
+      isError: false,
+    })
     renderBanner(PreferredUnits.Miles)
 
     expect(screen.getByTestId('prescribed-banner')).toHaveTextContent(
-      'PRESCRIBED — THRESHOLD RUN · 5.6 mi · 06:26–07:15/MI',
+      'Prescribed — Threshold run · 5.6 mi · 06:26–07:15/mi',
     )
   })
 
   it('falls back to the raw workoutType when it has no mapped label, without throwing', () => {
     bannerMock.mockReturnValue({
-      data: buildPrescribedWorkout({ workoutType: 'Fartlek' }),
+      currentData: buildPrescribedWorkout({ workoutType: 'Fartlek' }),
       isLoading: false,
       isError: false,
     })
 
     expect(() => renderBanner()).not.toThrow()
     expect(screen.getByTestId('prescribed-banner')).toHaveTextContent(
-      'PRESCRIBED — FARTLEK · 9.0 km · 04:00–04:30/KM',
+      'Prescribed — Fartlek · 9.0 km · 04:00–04:30/km',
     )
   })
 
-  it('renders nothing when the date has no prescription (data === null)', () => {
-    bannerMock.mockReturnValue({ data: null, isLoading: false, isError: false })
+  it('renders nothing when the date has no prescription (currentData === null)', () => {
+    bannerMock.mockReturnValue({ currentData: null, isLoading: false, isError: false })
     const { container } = renderBanner()
 
     expect(container).toBeEmptyDOMElement()
@@ -87,17 +96,42 @@ describe('PrescribedBanner', () => {
   })
 
   it('renders nothing while the query is loading (no skeleton)', () => {
-    bannerMock.mockReturnValue({ data: undefined, isLoading: true, isError: false })
+    bannerMock.mockReturnValue({ currentData: undefined, isLoading: true, isError: false })
     const { container } = renderBanner()
 
     expect(container).toBeEmptyDOMElement()
   })
 
   it('renders nothing when the query errors', () => {
-    bannerMock.mockReturnValue({ data: undefined, isLoading: false, isError: true })
+    bannerMock.mockReturnValue({ currentData: undefined, isLoading: false, isError: true })
     const { container } = renderBanner()
 
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('does not flash the previous date’s prescription while a new date is still resolving', () => {
+    // RTK Query keeps `data` pinned to the last successful result across an
+    // arg change; `currentData` is `undefined` for the duration of the new
+    // arg's in-flight request. Simulate that by keying the mock off the
+    // requested date: the first date resolves immediately, the second is
+    // still mid-flight when the component rerenders with it.
+    bannerMock.mockImplementation((requestedDate: string) =>
+      requestedDate === '2026-07-20'
+        ? { currentData: buildPrescribedWorkout(), isLoading: false, isError: false }
+        : { currentData: undefined, isLoading: false, isError: false },
+    )
+
+    const { rerender, container } = render(
+      <PrescribedBanner date="2026-07-20" units={PreferredUnits.Kilometers} />,
+    )
+    expect(screen.getByTestId('prescribed-banner')).toHaveTextContent(
+      'Prescribed — Threshold run · 9.0 km · 04:00–04:30/km',
+    )
+
+    rerender(<PrescribedBanner date="2026-07-21" units={PreferredUnits.Kilometers} />)
+
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByTestId('prescribed-banner')).not.toBeInTheDocument()
   })
 
   describe('dual-theme parity', () => {
@@ -106,7 +140,7 @@ describe('PrescribedBanner', () => {
     // eslint-disable-next-line sonarjs/assertions-in-tests
     it('renders identically in both themes with zero raw colour literals', () => {
       bannerMock.mockReturnValue({
-        data: buildPrescribedWorkout(),
+        currentData: buildPrescribedWorkout(),
         isLoading: false,
         isError: false,
       })

--- a/frontend/src/app/modules/logging/components/prescribed-banner.component.spec.tsx
+++ b/frontend/src/app/modules/logging/components/prescribed-banner.component.spec.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { PreferredUnits, type PrescribedWorkoutDto } from '~/api/generated'
+import {
+  expectDualThemeParity,
+  renderInBothThemes,
+} from '~/modules/common/test-utils/render-in-both-themes'
+
+const { bannerMock } = vi.hoisted(() => ({
+  bannerMock: vi.fn(),
+}))
+
+vi.mock('~/api/workout-log.api', () => ({
+  useGetPrescribedWorkoutQuery: (date: string) => bannerMock(date),
+}))
+
+import { PrescribedBanner } from './prescribed-banner.component'
+
+const buildPrescribedWorkout = (
+  overrides: Partial<PrescribedWorkoutDto> = {},
+): PrescribedWorkoutDto => ({
+  workoutType: 'Tempo',
+  distanceMeters: 9000,
+  durationSeconds: 2400,
+  paceFastSecPerKm: 240,
+  paceEasySecPerKm: 270,
+  ...overrides,
+})
+
+const renderBanner = (units: PreferredUnits = PreferredUnits.Kilometers, date = '2026-07-20') =>
+  render(<PrescribedBanner date={date} units={units} />)
+
+describe('PrescribedBanner', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('threads the date through to the query hook', () => {
+    bannerMock.mockReturnValue({ data: null, isLoading: false, isError: false })
+    renderBanner(PreferredUnits.Kilometers, '2026-07-20')
+
+    expect(bannerMock).toHaveBeenCalledExactlyOnceWith('2026-07-20')
+  })
+
+  it('renders the PRESCRIBED line for a present prescription (km)', () => {
+    bannerMock.mockReturnValue({ data: buildPrescribedWorkout(), isLoading: false, isError: false })
+    renderBanner()
+
+    // The workoutType label and pace range are uppercased in JS
+    // (`.toUpperCase()`); the distance fragment relies solely on the span's
+    // CSS `uppercase` class for its visual case, so jsdom's raw textContent
+    // (which never applies CSS text-transform) still carries a lowercase
+    // "km" here even though the design reads all-caps on screen.
+    expect(screen.getByTestId('prescribed-banner')).toHaveTextContent(
+      'PRESCRIBED — THRESHOLD RUN · 9.0 km · 04:00–04:30/KM',
+    )
+  })
+
+  it('renders mile-based distance and pace when units is Miles', () => {
+    bannerMock.mockReturnValue({ data: buildPrescribedWorkout(), isLoading: false, isError: false })
+    renderBanner(PreferredUnits.Miles)
+
+    expect(screen.getByTestId('prescribed-banner')).toHaveTextContent(
+      'PRESCRIBED — THRESHOLD RUN · 5.6 mi · 06:26–07:15/MI',
+    )
+  })
+
+  it('falls back to the raw workoutType when it has no mapped label, without throwing', () => {
+    bannerMock.mockReturnValue({
+      data: buildPrescribedWorkout({ workoutType: 'Fartlek' }),
+      isLoading: false,
+      isError: false,
+    })
+
+    expect(() => renderBanner()).not.toThrow()
+    expect(screen.getByTestId('prescribed-banner')).toHaveTextContent(
+      'PRESCRIBED — FARTLEK · 9.0 km · 04:00–04:30/KM',
+    )
+  })
+
+  it('renders nothing when the date has no prescription (data === null)', () => {
+    bannerMock.mockReturnValue({ data: null, isLoading: false, isError: false })
+    const { container } = renderBanner()
+
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByTestId('prescribed-banner')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing while the query is loading (no skeleton)', () => {
+    bannerMock.mockReturnValue({ data: undefined, isLoading: true, isError: false })
+    const { container } = renderBanner()
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when the query errors', () => {
+    bannerMock.mockReturnValue({ data: undefined, isLoading: false, isError: true })
+    const { container } = renderBanner()
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  describe('dual-theme parity', () => {
+    // The assertions live inside the shared expectDualThemeParity helper —
+    // sonarjs's static check can't see through the function call.
+    // eslint-disable-next-line sonarjs/assertions-in-tests
+    it('renders identically in both themes with zero raw colour literals', () => {
+      bannerMock.mockReturnValue({
+        data: buildPrescribedWorkout(),
+        isLoading: false,
+        isError: false,
+      })
+      const result = renderInBothThemes(
+        <PrescribedBanner date="2026-07-20" units={PreferredUnits.Kilometers} />,
+      )
+
+      expectDualThemeParity(result, 'prescribed-banner')
+    })
+  })
+})

--- a/frontend/src/app/modules/logging/components/prescribed-banner.component.tsx
+++ b/frontend/src/app/modules/logging/components/prescribed-banner.component.tsx
@@ -1,11 +1,10 @@
-// The /log form's "prescribed" banner (Slice 4 PR-B): a single-line
-// supplementary readout of the active plan's prescription for the log
-// form's target date, sourced from the server-authoritative
-// `getPrescribedWorkout` endpoint (PR-A). This is display-only — the log
-// form itself never reads or writes the prescription, it stays a free-typed
-// log. Per the root `CLAUDE.md` trademark rule, the rendered label comes from
-// `WORKOUT_TYPE_LABELS` (Daniels-Gilbert / pace-zone-index phrasing) — never
-// "VDOT".
+// The /log form's "prescribed" banner: a single-line supplementary readout
+// of the active plan's prescription for the log form's target date, sourced
+// from the server-authoritative `getPrescribedWorkout` endpoint. This is
+// display-only — the log form itself never reads or writes the
+// prescription, it stays a free-typed log. The rendered label comes from
+// `WORKOUT_TYPE_LABELS`, which carries the project's trademark-clean
+// Daniels-Gilbert / pace-zone-index phrasing.
 
 import type { ReactElement } from 'react'
 
@@ -25,39 +24,53 @@ export interface PrescribedBannerProps {
 }
 
 /**
+ * `workoutType` is a bare `string` on the wire (no validated union), so an
+ * unmapped value (a future enum member, or a stale/malformed snapshot) must
+ * be guarded before it can safely index `WORKOUT_TYPE_LABELS` — narrowing
+ * this way avoids an unchecked `as WorkoutType` assertion at the call site.
+ */
+const isKnownWorkoutType = (value: string): value is WorkoutType =>
+  Object.prototype.hasOwnProperty.call(WORKOUT_TYPE_LABELS, value)
+
+/**
  * Renders nothing while loading (this banner is supplementary — no skeleton
  * is worth the layout churn), on a fetch error, and when the resolved date
  * has no prescription (`data === null`: off-plan, rest day, no active plan,
  * or a malformed stored prescription — the endpoint folds all of these into
  * one `null` body per PR-A). Only a present prescription renders the single
- * `PRESCRIBED — {TYPE} · {DISTANCE} · {PACE RANGE}` line, with the dynamic
- * fragments uppercased via `.toUpperCase()` and the static copy/separators
- * uppercased via CSS — both derived-value paths agree on casing, so the
- * static "PRESCRIBED" reads consistently alongside them.
+ * `Prescribed — {Type} · {Distance} · {Pace range}` line — source copy stays
+ * sentence case; the span's CSS `uppercase` class is solely responsible for
+ * the all-caps presentation, so nothing here calls `.toUpperCase()`.
+ *
+ * Reads `currentData`, not `data`: RTK Query retains the last successful
+ * result across arg changes, so as `date` changes (e.g. the log form's date
+ * picker moves), `data` would keep showing the previous date's prescription
+ * until the new request resolves. `currentData` is `undefined` during that
+ * in-flight window, which the loading/error/null guard below already treats
+ * as "render nothing" — so the stale prescription never flashes.
  */
 export const PrescribedBanner = ({
   date,
   units,
   className,
 }: PrescribedBannerProps): ReactElement | null => {
-  const { data, isLoading, isError } = useGetPrescribedWorkoutQuery(date)
+  const { currentData, isLoading, isError } = useGetPrescribedWorkoutQuery(date)
 
-  if (isLoading || isError || data === null || data === undefined) {
+  if (isLoading || isError || currentData === null || currentData === undefined) {
     return null
   }
 
-  // `workoutType` is a bare `string` on the wire (no validated union), so an
-  // unmapped value (a future enum member, or a stale/malformed snapshot)
-  // falls back to the raw type string rather than crashing the lookup.
-  const workoutTypeLabel = WORKOUT_TYPE_LABELS[data.workoutType as WorkoutType] ?? data.workoutType
+  const workoutTypeLabel = isKnownWorkoutType(currentData.workoutType)
+    ? WORKOUT_TYPE_LABELS[currentData.workoutType]
+    : currentData.workoutType
 
   return (
     <div data-testid="prescribed-banner" className={cn('flex items-center gap-[10px]', className)}>
       <span aria-hidden className="size-2.5 rounded-xs bg-clay-marker" />
       <span className="font-mono text-[11px] font-medium tracking-[0.06em] text-muted-foreground uppercase">
-        PRESCRIBED — {workoutTypeLabel.toUpperCase()} ·{' '}
-        {formatDistanceKm(data.distanceMeters / 1000, units) ?? '—'} ·{' '}
-        {formatPaceRange(data.paceFastSecPerKm, data.paceEasySecPerKm, units).toUpperCase()}
+        Prescribed — {workoutTypeLabel} ·{' '}
+        {formatDistanceKm(currentData.distanceMeters / 1000, units) ?? '—'} ·{' '}
+        {formatPaceRange(currentData.paceFastSecPerKm, currentData.paceEasySecPerKm, units)}
       </span>
     </div>
   )

--- a/frontend/src/app/modules/logging/components/prescribed-banner.component.tsx
+++ b/frontend/src/app/modules/logging/components/prescribed-banner.component.tsx
@@ -1,0 +1,64 @@
+// The /log form's "prescribed" banner (Slice 4 PR-B): a single-line
+// supplementary readout of the active plan's prescription for the log
+// form's target date, sourced from the server-authoritative
+// `getPrescribedWorkout` endpoint (PR-A). This is display-only — the log
+// form itself never reads or writes the prescription, it stays a free-typed
+// log. Per the root `CLAUDE.md` trademark rule, the rendered label comes from
+// `WORKOUT_TYPE_LABELS` (Daniels-Gilbert / pace-zone-index phrasing) — never
+// "VDOT".
+
+import type { ReactElement } from 'react'
+
+import { cn } from '@/lib/utils'
+import type { PreferredUnits } from '~/api/generated'
+import { useGetPrescribedWorkoutQuery } from '~/api/workout-log.api'
+import { formatDistanceKm } from '~/modules/common/utils/unit-format.helpers'
+import { formatPaceRange } from '~/modules/logging/log-derivations.helpers'
+import { WORKOUT_TYPE_LABELS } from '~/modules/plan/components/plan-display.helpers'
+import type { WorkoutType } from '~/modules/plan/models/plan.model'
+
+export interface PrescribedBannerProps {
+  /** ISO `YYYY-MM-DD` date-only string — the log form's target date. */
+  date: string
+  units: PreferredUnits
+  className?: string
+}
+
+/**
+ * Renders nothing while loading (this banner is supplementary — no skeleton
+ * is worth the layout churn), on a fetch error, and when the resolved date
+ * has no prescription (`data === null`: off-plan, rest day, no active plan,
+ * or a malformed stored prescription — the endpoint folds all of these into
+ * one `null` body per PR-A). Only a present prescription renders the single
+ * `PRESCRIBED — {TYPE} · {DISTANCE} · {PACE RANGE}` line, with the dynamic
+ * fragments uppercased via `.toUpperCase()` and the static copy/separators
+ * uppercased via CSS — both derived-value paths agree on casing, so the
+ * static "PRESCRIBED" reads consistently alongside them.
+ */
+export const PrescribedBanner = ({
+  date,
+  units,
+  className,
+}: PrescribedBannerProps): ReactElement | null => {
+  const { data, isLoading, isError } = useGetPrescribedWorkoutQuery(date)
+
+  if (isLoading || isError || data === null || data === undefined) {
+    return null
+  }
+
+  // `workoutType` is a bare `string` on the wire (no validated union), so an
+  // unmapped value (a future enum member, or a stale/malformed snapshot)
+  // falls back to the raw type string rather than crashing the lookup.
+  const workoutTypeLabel = WORKOUT_TYPE_LABELS[data.workoutType as WorkoutType] ?? data.workoutType
+
+  return (
+    <div data-testid="prescribed-banner" className={cn('flex items-center gap-[10px]', className)}>
+      <span aria-hidden className="size-2.5 rounded-xs bg-clay-marker" />
+      <span className="font-mono text-[11px] font-medium tracking-[0.06em] text-muted-foreground uppercase">
+        PRESCRIBED — {workoutTypeLabel.toUpperCase()} ·{' '}
+        {formatDistanceKm(data.distanceMeters / 1000, units) ?? '—'} ·{' '}
+        {formatPaceRange(data.paceFastSecPerKm, data.paceEasySecPerKm, units).toUpperCase()}
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/app/modules/logging/log-derivations.helpers.spec.ts
+++ b/frontend/src/app/modules/logging/log-derivations.helpers.spec.ts
@@ -57,29 +57,31 @@ describe('deriveDisplayPace', () => {
 })
 
 describe('formatDateChipLabel', () => {
-  it('formats an ISO date-only string as an uppercase "WEEKDAY, MON DAY" label', () => {
+  it('formats an ISO date-only string as a title-case "Weekday, Mon Day" label', () => {
     // 2026-07-08 is a Wednesday.
-    expect(formatDateChipLabel('2026-07-08')).toBe('WED, JUL 8')
+    expect(formatDateChipLabel('2026-07-08')).toBe('Wed, Jul 8')
   })
 
   it('formats a single-digit day with no leading zero', () => {
     // 2026-06-01 is a Monday.
-    expect(formatDateChipLabel('2026-06-01')).toBe('MON, JUN 1')
+    expect(formatDateChipLabel('2026-06-01')).toBe('Mon, Jun 1')
   })
 
   it('formats a double-digit day', () => {
     // 2026-06-18 is a Thursday.
-    expect(formatDateChipLabel('2026-06-18')).toBe('THU, JUN 18')
+    expect(formatDateChipLabel('2026-06-18')).toBe('Thu, Jun 18')
   })
 
   it.each([
     { occurredOn: '', label: 'empty string' },
     { occurredOn: 'not-a-date', label: 'non-numeric garbage' },
     { occurredOn: '2026-13-40', label: 'out-of-range month/day' },
+    { occurredOn: '2026-07-08-09', label: 'an extra trailing segment' },
+    { occurredOn: '2026-7-8', label: 'non-padded month/day' },
   ])(
-    'returns the "SELECT DATE" placeholder for $label (never throws, never a garbage label)',
+    'returns the "Select date" placeholder for $label (never throws, never a garbage label)',
     ({ occurredOn }) => {
-      expect(formatDateChipLabel(occurredOn)).toBe('SELECT DATE')
+      expect(formatDateChipLabel(occurredOn)).toBe('Select date')
       expect(() => formatDateChipLabel(occurredOn)).not.toThrow()
     },
   )
@@ -105,14 +107,14 @@ describe('formatDateChipLabel', () => {
       // this date BACKWARD a day under a negative UTC offset — this function
       // must not do that; it parses the Y/M/D fields directly as local.
       process.env.TZ = 'America/Los_Angeles' // UTC-8 (winter) / UTC-7 (summer)
-      expect(formatDateChipLabel('2026-07-08')).toBe('WED, JUL 8')
+      expect(formatDateChipLabel('2026-07-08')).toBe('Wed, Jul 8')
     })
 
     it('reflects the LOCAL calendar day under a positive-offset process timezone', () => {
       // Same bug, opposite direction: a UTC-parse read back locally would
       // roll this date FORWARD a day under a positive UTC offset.
       process.env.TZ = 'Pacific/Kiritimati' // UTC+14
-      expect(formatDateChipLabel('2026-07-08')).toBe('WED, JUL 8')
+      expect(formatDateChipLabel('2026-07-08')).toBe('Wed, Jul 8')
     })
   })
 })

--- a/frontend/src/app/modules/logging/log-derivations.helpers.spec.ts
+++ b/frontend/src/app/modules/logging/log-derivations.helpers.spec.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { PreferredUnits } from '~/api/generated'
+
+import { deriveDisplayPace, formatDateChipLabel, formatPaceRange } from './log-derivations.helpers'
+
+const KM = PreferredUnits.Kilometers
+const MI = PreferredUnits.Miles
+
+describe('deriveDisplayPace', () => {
+  it('derives a display pace in km from raw distance/duration strings', () => {
+    // 5 km in 30 min -> 6:00/km.
+    expect(deriveDisplayPace('5', '30', KM)).toBe('06:00/km')
+  })
+
+  it('derives a display pace in miles from raw distance/duration strings', () => {
+    // 5 mi in 30 min -> 6:00/mi (the raw distance is interpreted in the
+    // preferred unit, so the same "5" reads as miles here).
+    expect(deriveDisplayPace('5', '30', MI)).toBe('06:00/mi')
+  })
+
+  it('trims surrounding whitespace before parsing either field', () => {
+    expect(deriveDisplayPace(' 5 ', ' 30 ', KM)).toBe('06:00/km')
+  })
+
+  it('flips the rendered unit suffix when the preferred unit flips', () => {
+    const km = deriveDisplayPace('5', '30', KM)
+    const mi = deriveDisplayPace('5', '30', MI)
+    expect(km).not.toBe(mi)
+    expect(km).toMatch(/\/km$/)
+    expect(mi).toMatch(/\/mi$/)
+  })
+
+  it.each([
+    { distanceRaw: '0', label: 'zero distance' },
+    { distanceRaw: '-5', label: 'negative distance' },
+    { distanceRaw: 'abc', label: 'garbage distance' },
+    { distanceRaw: '', label: 'empty distance' },
+    { distanceRaw: '   ', label: 'whitespace-only distance' },
+  ])('returns null for a $label (never NaN or 00:00)', ({ distanceRaw }) => {
+    expect(deriveDisplayPace(distanceRaw, '30', KM)).toBeNull()
+  })
+
+  it.each([
+    { durationRaw: '0', label: 'zero duration' },
+    { durationRaw: '-30', label: 'negative duration' },
+    { durationRaw: 'xyz', label: 'garbage duration' },
+    { durationRaw: '', label: 'empty duration' },
+    { durationRaw: '   ', label: 'whitespace-only duration' },
+  ])('returns null for a $label (never NaN or 00:00)', ({ durationRaw }) => {
+    expect(deriveDisplayPace('5', durationRaw, KM)).toBeNull()
+  })
+
+  it('never throws on non-numeric input', () => {
+    expect(() => deriveDisplayPace('not-a-number', 'also-not', KM)).not.toThrow()
+  })
+})
+
+describe('formatDateChipLabel', () => {
+  it('formats an ISO date-only string as an uppercase "WEEKDAY, MON DAY" label', () => {
+    // 2026-07-08 is a Wednesday.
+    expect(formatDateChipLabel('2026-07-08')).toBe('WED, JUL 8')
+  })
+
+  it('formats a single-digit day with no leading zero', () => {
+    // 2026-06-01 is a Monday.
+    expect(formatDateChipLabel('2026-06-01')).toBe('MON, JUN 1')
+  })
+
+  it('formats a double-digit day', () => {
+    // 2026-06-18 is a Thursday.
+    expect(formatDateChipLabel('2026-06-18')).toBe('THU, JUN 18')
+  })
+
+  it.each([
+    { occurredOn: '', label: 'empty string' },
+    { occurredOn: 'not-a-date', label: 'non-numeric garbage' },
+    { occurredOn: '2026-13-40', label: 'out-of-range month/day' },
+  ])(
+    'returns the "SELECT DATE" placeholder for $label (never throws, never a garbage label)',
+    ({ occurredOn }) => {
+      expect(formatDateChipLabel(occurredOn)).toBe('SELECT DATE')
+      expect(() => formatDateChipLabel(occurredOn)).not.toThrow()
+    },
+  )
+
+  describe('non-UTC timezone safety (DEC-076 local training dates)', () => {
+    const originalTz = process.env.TZ
+
+    afterEach(() => {
+      // `originalTz` is `undefined` when TZ was unset before this suite ran —
+      // assigning `undefined` back to `process.env.TZ` would coerce it to the
+      // literal string "undefined" (env vars are always strings), leaking a
+      // bogus TZ into later tests in the same worker. Delete the key instead
+      // to restore the true "unset" state.
+      if (originalTz === undefined) {
+        delete process.env.TZ
+      } else {
+        process.env.TZ = originalTz
+      }
+    })
+
+    it('reflects the LOCAL calendar day under a negative-offset process timezone', () => {
+      // A UTC-parse (`new Date(iso)`) read back with local getters would roll
+      // this date BACKWARD a day under a negative UTC offset — this function
+      // must not do that; it parses the Y/M/D fields directly as local.
+      process.env.TZ = 'America/Los_Angeles' // UTC-8 (winter) / UTC-7 (summer)
+      expect(formatDateChipLabel('2026-07-08')).toBe('WED, JUL 8')
+    })
+
+    it('reflects the LOCAL calendar day under a positive-offset process timezone', () => {
+      // Same bug, opposite direction: a UTC-parse read back locally would
+      // roll this date FORWARD a day under a positive UTC offset.
+      process.env.TZ = 'Pacific/Kiritimati' // UTC+14
+      expect(formatDateChipLabel('2026-07-08')).toBe('WED, JUL 8')
+    })
+  })
+})
+
+describe('formatPaceRange', () => {
+  it('renders the faster pace first, joined by an en dash, with a single unit suffix', () => {
+    const result = formatPaceRange(240, 270, KM)
+    expect(result).toBe('04:00–04:30/km')
+    // En dash (U+2013), never a plain hyphen, and no surrounding spaces.
+    expect(result).toContain('–')
+    expect(result).not.toContain(' ')
+    expect(result).not.toContain('-')
+    // The unit suffix appears exactly once.
+    expect(result.match(/\/km/g)).toHaveLength(1)
+  })
+
+  it('renders the miles path with the /mi suffix shown once', () => {
+    const result = formatPaceRange(240, 270, MI)
+    expect(result).toBe('06:26–07:15/mi')
+    expect(result.match(/\/mi/g)).toHaveLength(1)
+  })
+
+  it('orders the faster pace first regardless of argument order', () => {
+    expect(formatPaceRange(270, 240, KM)).toBe('04:00–04:30/km')
+  })
+
+  it('collapses to a single formatted pace when both bounds round to the same MM:SS', () => {
+    expect(formatPaceRange(300, 300, KM)).toBe('05:00/km')
+    expect(formatPaceRange(300.1, 299.9, KM)).toBe('05:00/km')
+  })
+
+  it('falls back to the valid side when the other bound is invalid', () => {
+    expect(formatPaceRange(Number.NaN, 270, KM)).toBe('04:30/km')
+    expect(formatPaceRange(240, Number.NaN, KM)).toBe('04:00/km')
+  })
+
+  it('falls back to an em-dash placeholder when both bounds are invalid', () => {
+    expect(formatPaceRange(Number.NaN, Number.NaN, KM)).toBe('—')
+  })
+})

--- a/frontend/src/app/modules/logging/log-derivations.helpers.ts
+++ b/frontend/src/app/modules/logging/log-derivations.helpers.ts
@@ -1,0 +1,151 @@
+// Pure display-derivation helpers for the /log form restyle (Slice 4 PR-B).
+//
+// These are display-only computations that sit in front of the log form's
+// React Hook Form state and the prescribed-workout banner — none of them
+// touch the wire. Pace formatting is intentionally NOT re-implemented here:
+// `deriveDisplayPace` reuses the history surface's `formatLogPace` so the
+// form's live pace preview and the history list's rendered pace agree
+// byte-for-byte, and `formatPaceRange` reuses `unit-format.helpers`'s
+// `formatPaceSecPerKm` for the same reason. Per the root `CLAUDE.md`
+// trademark rule, nothing here references zone names — only neutral
+// distance/duration/pace strings.
+
+import type { PreferredUnits } from '~/api/generated'
+import {
+  distanceUnitLabel,
+  formatPaceSecPerKm,
+  preferredDistanceToMeters,
+} from '~/modules/common/utils/unit-format.helpers'
+import { formatLogPace } from '~/modules/logging/history/history-format.helpers'
+
+const SECONDS_PER_MINUTE = 60
+
+/** Em dash placeholder for a pace range with no valid bound (both invalid). */
+const EMPTY_RANGE_PLACEHOLDER = '—'
+
+/** En dash (U+2013) joining a pace range's fast/easy bounds — never a plain hyphen. */
+const EN_DASH = '–'
+
+/**
+ * Placeholder rendered by {@link formatDateChipLabel} when `occurredOn`
+ * doesn't parse to a valid calendar date — e.g. the native date input was
+ * cleared via the browser's clear control, leaving RHF's field value `''`.
+ * Uppercase to match the module's other baked-caps abbreviations; the
+ * `DateChip` applies no CSS `uppercase` of its own.
+ */
+const DATE_CHIP_PLACEHOLDER = 'SELECT DATE'
+
+const WEEKDAY_ABBR = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'] as const
+
+const MONTH_ABBR = [
+  'JAN',
+  'FEB',
+  'MAR',
+  'APR',
+  'MAY',
+  'JUN',
+  'JUL',
+  'AUG',
+  'SEP',
+  'OCT',
+  'NOV',
+  'DEC',
+] as const
+
+/**
+ * Derives a display-only pace for the /log form's live preview from the raw
+ * React Hook Form `watch()` strings for distance and duration-in-minutes.
+ * Returns `null` for empty, non-numeric, zero, or negative input on either
+ * field — never throws, and never surfaces `NaN` or a degenerate `00:00`
+ * pace while the runner is still typing. The distance is interpreted in the
+ * runner's preferred unit (`preferredDistanceToMeters`) before handing off
+ * to the shared `formatLogPace` pace derivation, so this stays unit-aware.
+ */
+export const deriveDisplayPace = (
+  distanceRaw: string,
+  durationMinutesRaw: string,
+  units: PreferredUnits,
+): string | null => {
+  const distance = Number(distanceRaw.trim())
+  const durationMinutes = Number(durationMinutesRaw.trim())
+  if (!Number.isFinite(distance) || distance <= 0) {
+    return null
+  }
+  if (!Number.isFinite(durationMinutes) || durationMinutes <= 0) {
+    return null
+  }
+  const metres = preferredDistanceToMeters(distance, units)
+  return formatLogPace(metres, durationMinutes * SECONDS_PER_MINUTE, units)
+}
+
+/**
+ * Formats an ISO `YYYY-MM-DD` date-only string as an uppercase date-chip
+ * label (e.g. `"WED, JUL 8"`). Parsed as a LOCAL calendar date (DEC-076:
+ * training dates are local, never UTC) — this is a log-module-local
+ * formatter, distinct from `history-format.helpers`'s mixed-case
+ * `formatLogDate` (`"Sun, Jun 7"`), which this module deliberately does not
+ * reuse.
+ *
+ * Never throws and never surfaces a garbage label: if `occurredOn` doesn't
+ * split into three finite Y/M/D numbers, or the constructed `Date` doesn't
+ * round-trip back to those same Y/M/D values (`Date`'s constructor silently
+ * ROLLS OVER an out-of-range month/day — e.g. `2026-13-40` — rather than
+ * producing an `Invalid Date`, so a bare `Number.isNaN(date.getTime())`
+ * check alone would miss it), this returns {@link DATE_CHIP_PLACEHOLDER}.
+ */
+export const formatDateChipLabel = (occurredOn: string): string => {
+  const [year, month, day] = occurredOn.split('-').map(Number)
+  if (![year, month, day].every(Number.isFinite)) {
+    return DATE_CHIP_PLACEHOLDER
+  }
+
+  const date = new Date(year, month - 1, day)
+  const isValidCalendarDate =
+    date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day
+  if (!isValidCalendarDate) {
+    return DATE_CHIP_PLACEHOLDER
+  }
+
+  return `${WEEKDAY_ABBR[date.getDay()]}, ${MONTH_ABBR[date.getMonth()]} ${date.getDate()}`
+}
+
+/**
+ * Formats the prescribed-workout banner's pace range (e.g. `"4:00–4:30/km"`)
+ * from the fast/easy pace-zone-index bounds, joined with an EN DASH (never a
+ * hyphen) and no surrounding spaces — the unit suffix renders once, at the
+ * end. Reuses `formatPaceSecPerKm` so this agrees byte-for-byte with every
+ * other pace rendering in the app.
+ *
+ * Null-robust like the existing `formatPaceRangeSecPerKm`: an invalid bound
+ * falls back to the other side, both invalid fall back to an em-dash
+ * placeholder, and bounds that round to the same `MM:SS` collapse to a
+ * single formatted pace (no degenerate `"4:00–4:00/km"`). The faster pace
+ * (fewer sec/km) renders first, regardless of argument order. The caller
+ * applies `uppercase` via CSS for the banner — this returns the
+ * lowercase-suffixed form (e.g. `"4:00–4:30/km"`).
+ */
+export const formatPaceRange = (
+  fastSecPerKm: number,
+  easySecPerKm: number,
+  units: PreferredUnits,
+): string => {
+  const formattedFast = formatPaceSecPerKm(fastSecPerKm, units)
+  const formattedEasy = formatPaceSecPerKm(easySecPerKm, units)
+
+  if (formattedFast === null) {
+    return formattedEasy ?? EMPTY_RANGE_PLACEHOLDER
+  }
+  if (formattedEasy === null) {
+    return formattedFast
+  }
+
+  const [first, second] =
+    fastSecPerKm <= easySecPerKm ? [formattedFast, formattedEasy] : [formattedEasy, formattedFast]
+
+  if (first === second) {
+    return first
+  }
+
+  const suffix = `/${distanceUnitLabel(units)}`
+  return `${first.slice(0, -suffix.length)}${EN_DASH}${second}`
+}

--- a/frontend/src/app/modules/logging/log-derivations.helpers.ts
+++ b/frontend/src/app/modules/logging/log-derivations.helpers.ts
@@ -1,4 +1,4 @@
-// Pure display-derivation helpers for the /log form restyle (Slice 4 PR-B).
+// Pure display-derivation helpers for the /log form.
 //
 // These are display-only computations that sit in front of the log form's
 // React Hook Form state and the prescribed-workout banner — none of them
@@ -6,9 +6,9 @@
 // `deriveDisplayPace` reuses the history surface's `formatLogPace` so the
 // form's live pace preview and the history list's rendered pace agree
 // byte-for-byte, and `formatPaceRange` reuses `unit-format.helpers`'s
-// `formatPaceSecPerKm` for the same reason. Per the root `CLAUDE.md`
-// trademark rule, nothing here references zone names — only neutral
-// distance/duration/pace strings.
+// `formatPaceSecPerKm` for the same reason. Nothing here references zone
+// names — only neutral distance/duration/pace strings, keeping this module
+// clear of trademark-sensitive vocabulary.
 
 import type { PreferredUnits } from '~/api/generated'
 import {
@@ -30,26 +30,34 @@ const EN_DASH = '–'
  * Placeholder rendered by {@link formatDateChipLabel} when `occurredOn`
  * doesn't parse to a valid calendar date — e.g. the native date input was
  * cleared via the browser's clear control, leaving RHF's field value `''`.
- * Uppercase to match the module's other baked-caps abbreviations; the
- * `DateChip` applies no CSS `uppercase` of its own.
+ * Sentence case, matching the module's weekday/month source strings below —
+ * source copy stays sentence case; any visible uppercasing is a CSS
+ * presentation concern applied by the caller (e.g. `DateChip`'s label span),
+ * never baked into the stored string.
  */
-const DATE_CHIP_PLACEHOLDER = 'SELECT DATE'
+const DATE_CHIP_PLACEHOLDER = 'Select date'
 
-const WEEKDAY_ABBR = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'] as const
+/** Exact `YYYY-MM-DD` shape — four digits, a dash, two digits, a dash, two
+ * digits, and nothing else. Anchored so extra/missing segments (e.g.
+ * `"2026-07-08-09"`) or non-padded fields (e.g. `"2026-7-8"`) are rejected
+ * before ever reaching `Number`/`Date` parsing. */
+const ISO_DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+const WEEKDAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
 
 const MONTH_ABBR = [
-  'JAN',
-  'FEB',
-  'MAR',
-  'APR',
-  'MAY',
-  'JUN',
-  'JUL',
-  'AUG',
-  'SEP',
-  'OCT',
-  'NOV',
-  'DEC',
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
 ] as const
 
 /**
@@ -79,26 +87,29 @@ export const deriveDisplayPace = (
 }
 
 /**
- * Formats an ISO `YYYY-MM-DD` date-only string as an uppercase date-chip
- * label (e.g. `"WED, JUL 8"`). Parsed as a LOCAL calendar date (DEC-076:
- * training dates are local, never UTC) — this is a log-module-local
- * formatter, distinct from `history-format.helpers`'s mixed-case
+ * Formats an ISO `YYYY-MM-DD` date-only string as a title-case date-chip
+ * label (e.g. `"Wed, Jul 8"`) — sentence-case source copy; a caller that
+ * wants it to render uppercase applies that via CSS. Parsed as a LOCAL
+ * calendar date (DEC-076: training dates are local, never UTC) — this is a
+ * log-module-local formatter, distinct from `history-format.helpers`'s
  * `formatLogDate` (`"Sun, Jun 7"`), which this module deliberately does not
  * reuse.
  *
- * Never throws and never surfaces a garbage label: if `occurredOn` doesn't
- * split into three finite Y/M/D numbers, or the constructed `Date` doesn't
- * round-trip back to those same Y/M/D values (`Date`'s constructor silently
- * ROLLS OVER an out-of-range month/day — e.g. `2026-13-40` — rather than
- * producing an `Invalid Date`, so a bare `Number.isNaN(date.getTime())`
- * check alone would miss it), this returns {@link DATE_CHIP_PLACEHOLDER}.
+ * Never throws and never surfaces a garbage label: `occurredOn` must match
+ * {@link ISO_DATE_ONLY_PATTERN} exactly (rejecting extra/missing segments
+ * like `"2026-07-08-09"` or non-padded fields like `"2026-7-8"`) before it's
+ * split into Y/M/D numbers, and the constructed `Date` must round-trip back
+ * to those same Y/M/D values (`Date`'s constructor silently ROLLS OVER an
+ * out-of-range month/day — e.g. `2026-13-40` — rather than producing an
+ * `Invalid Date`, so a bare `Number.isNaN(date.getTime())` check alone would
+ * miss it). Either failure returns {@link DATE_CHIP_PLACEHOLDER}.
  */
 export const formatDateChipLabel = (occurredOn: string): string => {
-  const [year, month, day] = occurredOn.split('-').map(Number)
-  if (![year, month, day].every(Number.isFinite)) {
+  if (!ISO_DATE_ONLY_PATTERN.test(occurredOn)) {
     return DATE_CHIP_PLACEHOLDER
   }
 
+  const [year, month, day] = occurredOn.split('-').map(Number)
   const date = new Date(year, month - 1, day)
   const isValidCalendarDate =
     date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day

--- a/frontend/src/app/modules/logging/pages/log.page.spec.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.spec.tsx
@@ -140,7 +140,9 @@ describe('LogPage', () => {
   it('pins the /log chrome copy verbatim: header, sub-copy, notes helper, placeholder, submit label (DU-7)', () => {
     renderPage()
 
-    expect(screen.getByRole('heading', { level: 1, name: 'LOG RUN' })).toBeInTheDocument()
+    // Accessible name is the sentence-case textContent — `.t-screen-title`
+    // applies the visual caps via CSS, which doesn't change the DOM text.
+    expect(screen.getByRole('heading', { level: 1, name: 'Log run' })).toBeInTheDocument()
     // EM DASH (U+2014).
     expect(
       screen.getByText(
@@ -159,7 +161,8 @@ describe('LogPage', () => {
         'Cut to 3 reps, moved to the treadmill, calf felt tight on the last k…',
       ),
     ).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'SAVE RUN' })).toBeInTheDocument()
+    // The Button primitive CSS-uppercases its label; source stays sentence case.
+    expect(screen.getByRole('button', { name: 'Save run' })).toBeInTheDocument()
   })
 
   it('shows the live pace preview once distance and duration are filled (5 km / 30 min -> 06:00/km)', async () => {
@@ -207,8 +210,10 @@ describe('LogPage', () => {
       completionStatus: 0,
     })
     // Exact glyph-pinned copy (DU-7): EM DASH (U+2014) + "5.0 km" under the
-    // default km preference and a 5000m submit.
-    expect(await screen.findByText('RUN LOGGED — 5.0 km')).toBeInTheDocument()
+    // default km preference and a 5000m submit. Source is sentence case; the
+    // toast's `className: 'uppercase'` renders it capitalized via CSS, which
+    // does not change the DOM text this query matches against.
+    expect(await screen.findByText('Run logged — 5.0 km')).toBeInTheDocument()
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/', { replace: true }))
   })
 

--- a/frontend/src/app/modules/logging/pages/log.page.spec.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.spec.tsx
@@ -51,6 +51,10 @@ const unitsResolution = (
 
 vi.mock('~/api/workout-log.api', () => ({
   useCreateWorkoutLogMutation: () => [createWorkoutLogTrigger, mutationStateRef],
+  // The form now mounts `PrescribedBanner` (via `LogForm`), which calls this
+  // hook directly. `data: null` keeps the banner hidden across these tests —
+  // its own behavior is covered by `prescribed-banner.component.spec.tsx`.
+  useGetPrescribedWorkoutQuery: () => ({ data: null, isLoading: false, isError: false }),
 }))
 
 vi.mock('~/error-boundary/report-client-error', () => ({
@@ -133,6 +137,52 @@ describe('LogPage', () => {
     expect(dateInput.value).toBe(toIsoDateOnly(new Date()))
   })
 
+  it('pins the /log chrome copy verbatim: header, sub-copy, notes helper, placeholder, submit label (DU-7)', () => {
+    renderPage()
+
+    expect(screen.getByRole('heading', { level: 1, name: 'LOG RUN' })).toBeInTheDocument()
+    // EM DASH (U+2014).
+    expect(
+      screen.getByText(
+        'Record what you actually ran — the plan adapts to the truth, not the intention.',
+      ),
+    ).toBeInTheDocument()
+    // EM DASH (U+2014).
+    expect(
+      screen.getByText(
+        'What actually happened — especially where it differed from the plan. The coach adapts to what you write here.',
+      ),
+    ).toBeInTheDocument()
+    // Ellipsis (U+2026), not three periods.
+    expect(
+      screen.getByPlaceholderText(
+        'Cut to 3 reps, moved to the treadmill, calf felt tight on the last k…',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'SAVE RUN' })).toBeInTheDocument()
+  })
+
+  it('shows the live pace preview once distance and duration are filled (5 km / 30 min -> 06:00/km)', async () => {
+    const { user } = renderPage()
+    await fillCoreFields(user)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('log-derived-pace')).toHaveTextContent('06:00/km'),
+    )
+  })
+
+  it('hides the pace preview for blank distance, both before typing and after clearing (never NaN/00:00)', async () => {
+    const { user } = renderPage()
+    // Distance/duration are both blank on mount — no preview yet.
+    expect(screen.queryByTestId('log-derived-pace')).toBeNull()
+
+    await fillCoreFields(user)
+    await waitFor(() => expect(screen.getByTestId('log-derived-pace')).toBeInTheDocument())
+
+    await user.clear(screen.getByLabelText('Distance (km)'))
+    await waitFor(() => expect(screen.queryByTestId('log-derived-pace')).toBeNull())
+  })
+
   it('shows an inline role=alert error for a missing distance and does not submit', async () => {
     renderPage()
     const form = document.querySelector('form') as HTMLFormElement
@@ -156,7 +206,9 @@ describe('LogPage', () => {
       durationSeconds: 1800,
       completionStatus: 0,
     })
-    expect(await screen.findByText('Workout logged')).toBeInTheDocument()
+    // Exact glyph-pinned copy (DU-7): EM DASH (U+2014) + "5.0 km" under the
+    // default km preference and a 5000m submit.
+    expect(await screen.findByText('RUN LOGGED — 5.0 km')).toBeInTheDocument()
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/', { replace: true }))
   })
 
@@ -193,7 +245,10 @@ describe('LogPage', () => {
     await fillCoreFields(user)
     await clickSave(user)
 
-    expect(await screen.findByTestId('log-form-alert')).toHaveTextContent(/could not save/i)
+    // Exact glyph-pinned copy (DU-7): curly apostrophe (U+2019).
+    expect(await screen.findByTestId('log-form-alert')).toHaveTextContent(
+      'Couldn’t save. Nothing lost.',
+    )
     expect(navigateMock).not.toHaveBeenCalled()
     // The handled rejection is invisible to the global reporter + error boundary,
     // so the submit handler forwards it explicitly (keeps backend failures observable).

--- a/frontend/src/app/modules/logging/pages/log.page.spec.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.spec.tsx
@@ -5,7 +5,11 @@ import { toast } from 'sonner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { Toaster } from '@/components/ui/sonner'
-import type { CreateWorkoutLogRequest, StructuredLogDraft } from '~/api/generated'
+import type {
+  CreateWorkoutLogRequest,
+  PrescribedWorkoutDto,
+  StructuredLogDraft,
+} from '~/api/generated'
 import { PreferredUnits } from '~/api/generated'
 import { METERS_PER_MILE } from '~/modules/common/utils/unit-format.helpers'
 import type { UsePreferredUnitsResolutionReturn } from '~/modules/settings/hooks/use-preferred-units.hooks'
@@ -20,6 +24,7 @@ const {
   reportClientErrorMock,
   preferredUnitsResolutionMock,
   refetchUnitsMock,
+  useGetPrescribedWorkoutQueryMock,
 } = vi.hoisted(() => {
   const createWorkoutLogUnwrap = vi.fn()
   return {
@@ -34,6 +39,9 @@ const {
     reportClientErrorMock: vi.fn(),
     preferredUnitsResolutionMock: vi.fn<() => UsePreferredUnitsResolutionReturn>(),
     refetchUnitsMock: vi.fn(),
+    // Mockable per-test so we can verify LogForm's wiring of the banner (date/units
+    // threading) in addition to the default hidden-banner case most tests want.
+    useGetPrescribedWorkoutQueryMock: vi.fn(),
   }
 })
 
@@ -52,9 +60,11 @@ const unitsResolution = (
 vi.mock('~/api/workout-log.api', () => ({
   useCreateWorkoutLogMutation: () => [createWorkoutLogTrigger, mutationStateRef],
   // The form now mounts `PrescribedBanner` (via `LogForm`), which calls this
-  // hook directly. `data: null` keeps the banner hidden across these tests —
-  // its own behavior is covered by `prescribed-banner.component.spec.tsx`.
-  useGetPrescribedWorkoutQuery: () => ({ data: null, isLoading: false, isError: false }),
+  // hook directly. Defaults to a hidden banner (see beforeEach) — most tests
+  // don't care about it; its own rendering behavior is covered by
+  // `prescribed-banner.component.spec.tsx`. The wiring itself (that `LogForm`
+  // threads the watched date/units into it) is covered below.
+  useGetPrescribedWorkoutQuery: (date: string) => useGetPrescribedWorkoutQueryMock(date),
 }))
 
 vi.mock('~/error-boundary/report-client-error', () => ({
@@ -112,6 +122,13 @@ describe('LogPage', () => {
     // Default: preference resolved to Kilometers (the common case). Individual
     // tests override for Miles / still-loading / errored.
     preferredUnitsResolutionMock.mockReturnValue(unitsResolution())
+    // Default: no prescription for the target date, keeping the banner hidden
+    // across tests that don't exercise it. Overridden below for the banner-wiring test.
+    useGetPrescribedWorkoutQueryMock.mockReturnValue({
+      currentData: null,
+      isLoading: false,
+      isError: false,
+    })
     vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-0000-0000-00000000abcd')
   })
 
@@ -184,6 +201,32 @@ describe('LogPage', () => {
 
     await user.clear(screen.getByLabelText('Distance (km)'))
     await waitFor(() => expect(screen.queryByTestId('log-derived-pace')).toBeNull())
+  })
+
+  it('renders PrescribedBanner inside the real form wired to the watched date/units, and re-queries on date change', async () => {
+    const prescribed: PrescribedWorkoutDto = {
+      workoutType: 'Tempo',
+      distanceMeters: 9000,
+      durationSeconds: 2400,
+      paceFastSecPerKm: 240,
+      paceEasySecPerKm: 270,
+    }
+    useGetPrescribedWorkoutQueryMock.mockReturnValue({
+      currentData: prescribed,
+      isLoading: false,
+      isError: false,
+    })
+    renderPage()
+
+    const today = toIsoDateOnly(new Date())
+    expect(useGetPrescribedWorkoutQueryMock).toHaveBeenCalledWith(today)
+    expect(screen.getByTestId('prescribed-banner')).toHaveTextContent(
+      'Prescribed — Threshold run · 9.0 km · 04:00–04:30/km',
+    )
+
+    fireEvent.change(screen.getByLabelText('Date'), { target: { value: '2026-06-20' } })
+
+    await waitFor(() => expect(useGetPrescribedWorkoutQueryMock).toHaveBeenCalledWith('2026-06-20'))
   })
 
   it('shows an inline role=alert error for a missing distance and does not submit', async () => {

--- a/frontend/src/app/modules/logging/pages/log.page.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.tsx
@@ -85,7 +85,13 @@ const WorkoutLogFormView = ({ units, editDraft }: WorkoutLogFormViewProps) => {
     const request = toCreateWorkoutLogRequest(values, idempotencyKey, units)
     try {
       await createWorkoutLog(request).unwrap()
-      toast.success(`RUN LOGGED — ${formatDistanceMeters(request.distanceMeters, units) ?? '…'}`)
+      // Source copy stays sentence case; `className: 'uppercase'` sets the
+      // toast's outer classname (sonner applies it to the wrapping <li>), which
+      // cascades `text-transform: uppercase` onto the title text — the toast
+      // renders capitalized without baking that casing into the stored string.
+      toast.success(`Run logged — ${formatDistanceMeters(request.distanceMeters, units) ?? '…'}`, {
+        className: 'uppercase',
+      })
       navigate('/', { replace: true })
     } catch (error) {
       // The awaited `.unwrap()` rejection is a *handled* rejection, so neither
@@ -199,7 +205,7 @@ const LogPage = () => {
       data-testid="log-page"
     >
       <header className="flex flex-col gap-1">
-        <h1 className="t-screen-title text-foreground">LOG RUN</h1>
+        <h1 className="t-screen-title text-foreground">Log run</h1>
         <p className="text-sm text-muted-foreground">
           Record what you actually ran — the plan adapts to the truth, not the intention.
         </p>

--- a/frontend/src/app/modules/logging/pages/log.page.tsx
+++ b/frontend/src/app/modules/logging/pages/log.page.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button'
 import { PreferredUnits, type StructuredLogDraft } from '~/api/generated'
 import { useCreateWorkoutLogMutation } from '~/api/workout-log.api'
 import { reportClientError } from '~/error-boundary/report-client-error'
-import { distanceUnitLabel } from '~/modules/common/utils/unit-format.helpers'
+import { distanceUnitLabel, formatDistanceMeters } from '~/modules/common/utils/unit-format.helpers'
 import { LogForm } from '~/modules/logging/components/log-form.component'
 import { draftToWorkoutLogFormFields } from '~/modules/logging/draft-to-form.helpers'
 import {
@@ -79,9 +79,13 @@ const WorkoutLogFormView = ({ units, editDraft }: WorkoutLogFormViewProps) => {
 
   const onSubmit = async (values: WorkoutLogFormValues): Promise<void> => {
     setFormAlert(null)
+    // Built once so the success toast's distance readout is derived from the
+    // EXACT payload that shipped (not re-derived from form state, which could
+    // in principle drift from the sent request).
+    const request = toCreateWorkoutLogRequest(values, idempotencyKey, units)
     try {
-      await createWorkoutLog(toCreateWorkoutLogRequest(values, idempotencyKey, units)).unwrap()
-      toast.success('Workout logged')
+      await createWorkoutLog(request).unwrap()
+      toast.success(`RUN LOGGED — ${formatDistanceMeters(request.distanceMeters, units) ?? '…'}`)
       navigate('/', { replace: true })
     } catch (error) {
       // The awaited `.unwrap()` rejection is a *handled* rejection, so neither
@@ -93,7 +97,7 @@ const WorkoutLogFormView = ({ units, editDraft }: WorkoutLogFormViewProps) => {
         kind: 'unhandled-rejection',
         error: error instanceof Error ? error : new Error(String(error)),
       })
-      setFormAlert('We could not save your workout. Please try again in a moment.')
+      setFormAlert('Couldn’t save. Nothing lost.')
     }
   }
 
@@ -104,6 +108,7 @@ const WorkoutLogFormView = ({ units, editDraft }: WorkoutLogFormViewProps) => {
       isLoading={isLoading}
       formAlert={formAlert}
       distanceLabel={`Distance (${distanceUnitLabel(units)})`}
+      units={units}
     />
   )
 }
@@ -194,8 +199,10 @@ const LogPage = () => {
       data-testid="log-page"
     >
       <header className="flex flex-col gap-1">
-        <h1 className="text-2xl font-semibold text-foreground">Log a workout</h1>
-        <p className="text-sm text-muted-foreground">Record what you actually ran.</p>
+        <h1 className="t-screen-title text-foreground">LOG RUN</h1>
+        <p className="text-sm text-muted-foreground">
+          Record what you actually ran — the plan adapts to the truth, not the intention.
+        </p>
       </header>
       <LogPageContent
         units={units}


### PR DESCRIPTION
## Slice 4 PR-B — `/log` Alpine restyle + prescribed banner + derived pace

Second PR of the Slice 4 (Log & Log Book) train (**A → B → C → D**). Recomposes the `/log` screen onto the Alpine design and consumes **PR-A's** already-merged backend wire (`GET /api/v1/workouts/logs/prescribed`), over a **byte-identical create contract**. Spec: `docs/specs/slice-4-log-logbook/spec.md` §3 PR-B + §4 (DEC-089 D5).

### What's in it (DU-3 … DU-7)
- **`PrescribedBanner`** — supplementary single-line readout (`PRESCRIBED — {TYPE} · {DIST} · {FAST–EASY/UNIT}`) of the active plan's prescription for the selected date via `useGetPrescribedWorkoutQuery`; hidden on loading/error/absent (the endpoint's `200 + null`). Title via `WORKOUT_TYPE_LABELS`.
- **`DateChip`** — presentational chip (`WED, JUL 8` + calendar/chevron) over the **same** native `<input type="date">`; back-dating preserved.
- **Derived PACE row** — display-only `deriveDisplayPace(distance, duration, units)` off live `watch()`; hidden for blank/garbage input, never gates submit.
- **Completion `SegmentedControl`** — the Alpine primitive's first app consumer; same field name, same `0|1|2` wire values, same default.
- **Restyle** — `LOG RUN` header + sub-copy, condensed distance/time cells, `HOW DID IT GO?` deviation helper, `MORE DETAILS`, `SAVE RUN`, moss `RUN LOGGED — {dist}` toast, danger inline `Couldn't save. Nothing lost.` alert.

### Wire + a11y frozen (the "restyle only" bar)
`toCreateWorkoutLogRequest` payload, `idempotencyKey` reuse on retry (DEC-077), the 3-state unit gate (DEC-086), pessimistic create → toast → navigate, and the inline `formAlert` failure path are all unchanged — pinned by `log.page.spec.tsx`'s `toHaveBeenCalledWith` + `/saving/i` + unit-gate assertions. Accessible names (`Distance (km)` / `Duration (minutes)` / `Date` / `How did it go?`) are preserved, so the page + E2E label selectors are untouched. **Backend / generated / api slices untouched** (PR-A shipped the wire).

### Quality
- Full frontend suite **992 vitest pass** (+10 new), `npm run build` clean, `check-contrast` **44/44**, ESLint clean on all touched files.
- Ran a multi-lens adversarial review (correctness / spec-compliance / a11y-tokens / test-quality) with per-finding blind-challenge; the confirmed findings were fixed in this branch:
  - Banner label lookup now **degrades** (falls back to the raw type string) instead of throwing `undefined.toUpperCase()` if the backend enum ever widens.
  - `DateChip` `forwardRef`s so `FormControl`'s `id`/`aria-describedby`/`aria-invalid` reach the real input (validation-error wiring restored), renders a `SELECT DATE` placeholder for a cleared date instead of a garbage label, and meets the ≥44px hit-target rule.
  - Added coverage for the verbatim DU-7 copy (glyph-exact), the derived-pace wiring, and the exact toast/failure strings.

### Non-negotiables
Form ARIA preserved; trademark-clean (`WORKOUT_TYPE_LABELS`, zero rendered `VDOT`); semantic tokens only (no raw hex); every animation pairs `motion-reduce:`; dual-theme parity tests on new components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKe9ogLzTZqLjNG2t2ZnGM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a date-picker chip for selecting workout dates.
  * Added a prescribed-workout banner showing type, distance, and pace for the selected date.
  * Added live pace previews based on entered distance and duration.
  * Replaced completion radio buttons with a segmented control.
  * Updated logging form copy, notes guidance, and save actions.
* **Bug Fixes**
  * Prevented stale prescription details from showing while switching dates.
  * Improved handling of invalid/missing date and pace inputs.
  * Refined save success and failure messages for clearer feedback.
* **Tests**
  * Added/expanded UI and helper coverage across supported themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->