### PR TITLE
fix(ci): restabilize pipeline after stale-month advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
         update-types:
           - minor
           - patch
+    # WolverineFx is deliberately pinned (6.18.0+ silently drops Marten session
+    # commits on synchronous InvokeForTenantAsync); bumps are taken manually
+    # only after that regression is re-validated against the new release.
+    ignore:
+      - dependency-name: "WolverineFx*"
 
   - package-ecosystem: npm
     directory: /frontend
@@ -38,6 +43,14 @@ updates:
       interval: weekly
     commit-message:
       prefix: "ci(deps):"
+    # Group actions bumps so multi-action repos (github/codeql-action init +
+    # analyze) move in one PR — split bumps fail CodeQL's version-consistency
+    # check between init and analyze.
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: docker
     directory: /backend

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -62,6 +62,6 @@ jobs:
       # ── End C# manual build ──
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         with:
           category: "/language:${{ matrix.language }}"

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ docs/specs/
 
 # Brainstorming visual companion (superpowers)
 .superpowers/
+/.code-gauntlet/

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -89,6 +89,13 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" Version="2.2.2" />
     <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="Respawn" Version="7.0.0" />
+    <!-- Transitive-only pin (applied via CentralPackageTransitivePinningEnabled):
+         Testcontainers.PostgreSql pulls SSH.NET 2025.1.0, which carries the
+         high-severity advisory GHSA-q939-rpr3-3284 that NuGetAudit escalates
+         to a restore-fatal NU1903 under TreatWarningsAsErrors. 2026.0.0 is the
+         first patched release. Drop this pin once Testcontainers ships against
+         a patched SSH.NET. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
     <!-- xunit.v3 meta-package brings xunit.v3.core.mtp-v1 (built against
          MTP 1.x). Use the mtp-v2 core package directly so the MicrosoftTestingPlatform

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6064,9 +6064,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -7314,9 +7314,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -8354,9 +8354,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -8376,12 +8376,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -621,9 +621,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Why

After a month of inactivity, CI is red repo-wide from two security advisories published mid-August, deadlocking every open PR:

- **GHSA-q939-rpr3-3284** (SSH.NET ≤ 2025.1.0, high, published 2026-08-12) — transitive via `Testcontainers.PostgreSql 4.13.0`. NuGetAudit emits NU1903 at restore, and `TreatWarningsAsErrors` makes it restore-fatal → `Backend (build + test)`, `Backend analysis`, `Analyze (csharp)`, `submit-nuget`, and the `OpenAPI codegen drift gate` all fail on **every** PR that restores .NET (the CodeQL csharp leg restores even on frontend-only PRs).
- **GHSA-qwww-vcr4-c8h2** (react-router 7.18.1, high) + **CVE-2026-67213** (nanoid 3.3.16, high) in the committed frontend lockfile → `Security (Trivy)` fails on every PR.

Neither class is fixable by any single open Dependabot PR (each PR fails on the *other* side's advisory), so this PR fixes both at once.

## What

- **`backend/Directory.Packages.props`** — transitive-only pin `SSH.NET 2026.0.0` (first patched release; applied via `CentralPackageTransitivePinningEnabled`). Same fix as Dependabot security PR #332, which this supersedes; resolved version verified in `project.assets.json`.
- **`frontend/package-lock.json`** — lockfile-only, range-internal bumps: `react-router`/`react-router-dom` → 7.18.2, `nanoid` → 3.3.18, `fast-uri` → 3.1.5 (covers GHSA-4c8g-83qw-93j6 / GHSA-v2hh-gcrm-f6hx / GHSA-7p8r-x3mc-p8w7, which surface in #336's dependency diff). `package.json` untouched.
- **root `package-lock.json`** — `fast-uri` → 3.1.5 (supersedes #320, which only reached 3.1.4 and left one GHSA unpatched).
- **`.github/workflows/codeql.yml`** — `codeql-action/init` + `analyze` bumped **together** to v4.37.6 (`5595ccaf`, tag SHA verified against upstream). Supersedes #333/#334, which each bumped only one half and fail CodeQL's init/analyze version-consistency check.
- **`.github/dependabot.yml`** — (1) github-actions bumps now grouped (`minor-and-patch`) so codeql-action halves can't split again; (2) `WolverineFx*` ignored for nuget — the 6.17.0 pin is deliberate (6.18.0+ silently drops Marten session commits on synchronous `InvokeForTenantAsync`) and Dependabot keeps re-proposing it (#337).
- **`.gitignore`** — ignore the `.code-gauntlet/` working directory.

## Verification

- `dotnet build` clean (0 warnings, TreatWarningsAsErrors on); SSH.NET resolves 2026.0.0.
- Full backend suite vs Colima Docker: **2006/2006 passed** (Replay mode).
- `npm run build` clean; vitest **1022/1022 passed**.

## Follow-up merge train (after this lands)

Rebase + merge #336 (with orval 8.24 codegen regen), #319, #325, #335; recreate #337 (ignore now excludes WolverineFx); #330/#331/#332/#320/#333/#334 are superseded and will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011piN7GCKJK4iUYoN59K3i1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated code analysis tooling to improve security scanning reliability.
  * Added safeguards to support remediation of a known security advisory.

* **Chores**
  * Improved automated update management by grouping compatible updates.
  * Excluded Code Gauntlet artifacts from source control tracking.
  * Added maintenance guidance for future security-related updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->