### PR TITLE
ci: exempt sonaranalyzer.csharp from the license allowlist

### DIFF
--- a/.github/workflows/license-review.yml
+++ b/.github/workflows/license-review.yml
@@ -45,13 +45,16 @@ jobs:
             Unlicense, CC0-1.0, CC-BY-4.0, OFL-1.1, Zlib, BSL-1.0,
             Python-2.0, PSF-2.0, Artistic-2.0, MPL-2.0, WTFPL,
             PostgreSQL
-          # LGPL-3.0 CI tools (SonarQube scan action, SonarAnalyzer.CSharp,
+          # Sonar CI tools (SonarQube scan action, SonarAnalyzer.CSharp,
           # eslint-plugin-sonarjs) are build-time only — never shipped in the
-          # binary. runcoach-frontend is the monorepo's own private root
-          # package with no published license. Exempt by purl so the allowlist
-          # stays strict.
+          # binary. SonarAnalyzer.CSharp moved from LGPL-3.0 to the Sonar
+          # Source-Available License (SAL-1.0) in 10.33; it still only runs
+          # as a Roslyn analyzer at build time. runcoach-frontend is the
+          # monorepo's own private root package with no published license.
+          # Exempt by purl so the allowlist stays strict.
           allow-dependencies-licenses: >-
             pkg:githubactions/SonarSource/sonarqube-scan-action,
+            pkg:nuget/SonarAnalyzer.CSharp,
             pkg:npm/runcoach-frontend
           comment-summary-in-pr: always
           retry-on-snapshot-warnings: true


### PR DESCRIPTION
## Summary
- SonarAnalyzer.CSharp 10.33 changed its license from LGPL-3.0 to the Sonar Source-Available License (`LicenseRef-scancode-sonar-sal-1.0`), which `dependency-review-action` rejects against the allowlist.
- The analyzer is build-time only (Roslyn analyzer, never shipped). The workflow comment already stated it was meant to be exempt, but the `allow-dependencies-licenses` purl list only covered the scan action. Adds `pkg:nuget/SonarAnalyzer.CSharp`.
- Unblocks #356 (Dependabot NuGet minor-and-patch group).

## Test plan
- [ ] License & dependency review passes on this PR
- [ ] #356 passes after rebase onto main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U24u2K42TvNq2giUSeDkbP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency license review rules to account for the current licensing of a build-time code analysis tool.
  - Preserved strict license validation while allowing the approved package to pass automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->